### PR TITLE
Create Resolution#errors from its errorCache

### DIFF
--- a/cli/src/main/scala-2.11/coursier/cli/Helper.scala
+++ b/cli/src/main/scala-2.11/coursier/cli/Helper.scala
@@ -467,13 +467,13 @@ class Helper(
     errPrintln("\nMaximum number of iterations reached!")
   }
 
-  if (res.errors.nonEmpty) {
+  if (res.metadataErrors.nonEmpty) {
     anyError = true
     errPrintln(
-      s"\nError:\n" +
-      res.errors.map {
-        case (dep, errs) =>
-          s"  ${dep.module}:${dep.version}:\n${errs.map("    " + _.replace("\n", "    \n")).mkString("\n")}"
+      "\nError:\n" +
+      res.metadataErrors.map {
+        case ((module, version), errors) =>
+          s"  $module:$version\n${errors.map("    " + _.replace("\n", "    \n")).mkString("\n")}"
       }.mkString("\n")
     )
   }

--- a/core/shared/src/main/scala/coursier/core/Resolution.scala
+++ b/core/shared/src/main/scala/coursier/core/Resolution.scala
@@ -1039,6 +1039,17 @@ final case class Resolution(
   def dependencyClassifiersArtifacts(classifiers: Seq[String]): Seq[(Dependency, Artifact)] =
     dependencyArtifacts0(Some(classifiers))
 
+  /**
+    * Returns errors on dependencies
+    * @return errors
+    */
+  def metadataErrors: Seq[(ModuleVersion, Seq[String])] = errorCache.toSeq
+
+  /**
+    * Returns errors on dependencies, but that don't have POM-related errors
+    * @return errors
+    */
+  @deprecated("use metadataErrors instead")
   def errors: Seq[(Dependency, Seq[String])] =
     for {
       dep <- dependencies.toSeq

--- a/tests/shared/src/test/scala/coursier/test/ResolutionTests.scala
+++ b/tests/shared/src/test/scala/coursier/test/ResolutionTests.scala
@@ -50,6 +50,10 @@ object ResolutionTests extends TestSuite {
         "" -> Dependency(Module("acme", "play"), "2.4.1",
           exclusions = Set(("*", "config"))))),
 
+    Project(Module("acme", "module-with-missing-pom"), "1.0.0",
+      dependencyManagement = Seq(
+        "import" -> Dependency(Module("acme", "missing-pom"), "1.0.0"))),
+
     Project(Module("hudsucker", "mail"), "10.0",
       Seq(
         "test" -> Dependency(Module("${project.groupId}", "test-util"), "${project.version}"))),
@@ -226,6 +230,20 @@ object ResolutionTests extends TestSuite {
         )
 
         assert(res == expected)
+      }
+    }
+    'missingPom{
+      async {
+        val dep = Dependency(Module("acme", "module-with-missing-pom"), "1.0.0")
+        val res = await(resolve0(
+          Set(dep)
+        ))
+
+        // A missing POM dependency is not reported correctly. That's why the method is deprecated.
+        assert(res.errors == Seq.empty)
+
+        // metadataErrors have that
+        assert(res.metadataErrors == Seq((Module("acme", "missing-pom"), "1.0.0") -> List("Not found")))
       }
     }
     'single{


### PR DESCRIPTION
Apparently using Resolution#dependencies hides some errors (e.g. #157).

----

Is this because dependencies are direct dependencies and errorCache contains transitive dependencies?
