### PR TITLE
Support --repository bintray-ivy:org/repo/ in cli.

### DIFF
--- a/cli/src/main/scala-2.11/coursier/cli/Options.scala
+++ b/cli/src/main/scala-2.11/coursier/cli/Options.scala
@@ -29,6 +29,7 @@ final case class CommonOptions(
   @Short("N")
     maxIterations: Int = 100,
   @Help("Repository - for multiple repositories, separate with comma and/or add this option multiple times (e.g. -r central,ivy2local -r sonatype-snapshots, or equivalently -r central,ivy2local,sonatype-snapshots)")
+  @Value("maven|sonatype:repo|ivy2local|bintray:org/repo|bintray-ivy:org/repo|typesafe-ivy:releases|ivy:pattern")
   @Short("r")
     repository: List[String] = Nil,
   @Help("Source repository - for multiple repositories, separate with comma and/or add this option multiple times")

--- a/core/shared/src/main/scala/coursier/util/Parse.scala
+++ b/core/shared/src/main/scala/coursier/util/Parse.scala
@@ -188,6 +188,11 @@ object Parse {
       MavenRepository(s"https://oss.sonatype.org/content/repositories/${s.stripPrefix("sonatype:")}").right
     else if (s.startsWith("bintray:"))
       MavenRepository(s"https://dl.bintray.com/${s.stripPrefix("bintray:")}").right
+    else if (s.startsWith("bintray-ivy:"))
+      IvyRepository.fromPattern(
+        s"https://dl.bintray.com/${s.stripPrefix("bintray-ivy:").stripSuffix("/")}" +: "/" +:
+          coursier.ivy.Pattern.default
+      ).right
     else if (s.startsWith("typesafe:ivy-"))
       IvyRepository.fromPattern(
         (s"https://repo.typesafe.com/typesafe/ivy-" + s.stripPrefix("typesafe:ivy-") + "/") +:

--- a/tests/shared/src/test/scala/coursier/test/ParseTests.scala
+++ b/tests/shared/src/test/scala/coursier/test/ParseTests.scala
@@ -1,0 +1,21 @@
+package coursier.test
+
+import scalaz.\/-
+
+import coursier.MavenRepository
+import coursier.ivy.IvyRepository
+import coursier.util.Parse
+import utest._
+
+object ParseTests extends TestSuite {
+  val tests = TestSuite {
+    "bintray-ivy:" - {
+      val obtained = Parse.repository("bintray-ivy:scalameta/maven")
+      assert(obtained.exists(_.isInstanceOf[IvyRepository]))
+    }
+    "bintray:" - {
+      val obtained = Parse.repository("bintray:scalameta/maven")
+      assert(obtained.exists(_.isInstanceOf[MavenRepository]))
+    }
+  }
+}


### PR DESCRIPTION
This commit adds support for a `bintray-ivy:` prefix to the `--repository`
flag in the cli. This option is equivalent to the `Resolver.bintrayIvyRepo` helper in sbt.
With this new helper, it's possible to write `-r bintray-ivy:scalameta/maven/` instead of

```
-r ivy:https://dl.bintray.com/scalameta/maven/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
```