### PR TITLE
Fix spark-submit command in spark 1.x

### DIFF
--- a/cli/src/main/scala-2.11/coursier/cli/SparkSubmit.scala
+++ b/cli/src/main/scala-2.11/coursier/cli/SparkSubmit.scala
@@ -120,7 +120,8 @@ final case class SparkSubmit(
         sparkVersion,
         options.yarnVersion,
         options.defaultAssemblyDependencies.getOrElse(true),
-        options.assemblyDependencies.flatMap(_.split(",")).filter(_.nonEmpty),
+        options.assemblyDependencies.flatMap(_.split(",")).filter(_.nonEmpty) ++
+          options.sparkAssemblyDependencies.flatMap(_.split(",")).filter(_.nonEmpty).map(_ + s":$sparkVersion"),
         options.common,
         options.artifactOptions.artifactTypes(sources = false, javadoc = false)
       )


### PR DESCRIPTION
(This command badly needs a few integration tests... which would themselves need a CI with more memory.)