### PR TITLE
Support latest subrevision

### DIFF
--- a/core/shared/src/main/scala/coursier/core/Parse.scala
+++ b/core/shared/src/main/scala/coursier/core/Parse.scala
@@ -11,23 +11,28 @@ object Parse {
     else Some(Version(trimmed))
   }
 
+  // matches revisions with a '+' appended, e.g. "1.2.+", "1.2+" or "1.2.3-+"
+  private val latestSubRevision = "(.*[^.-])[.-]?[+]".r
+
   def ivyLatestSubRevisionInterval(s: String): Option[VersionInterval] =
-    if (s.endsWith(".+")) {
-      for {
-        from <- version(s.stripSuffix(".+"))
-        if from.rawItems.nonEmpty
-        last <- Some(from.rawItems.last).collect { case n: Version.Numeric => n }
-        // a bit loose, but should do the job
-        if from.repr.endsWith(last.repr)
-        // appending -a1 to the next version, so has not to include things like
-        // nextVersion-RC1 in the interval - nothing like nextVersion* should be included
-        to <- version(from.repr.stripSuffix(last.repr) + last.next.repr + "-a1")
-        // the contrary would mean something went wrong in the loose substitution above
-        if from.rawItems.init == to.rawItems.dropRight(2).init
-        if to.rawItems.takeRight(2) == Seq(Version.Literal("a"), Version.Number(1))
-      } yield VersionInterval(Some(from), Some(to), fromIncluded = true, toIncluded = false)
-    } else
-      None
+    s match {
+      case latestSubRevision(prefix) =>
+        for {
+          from <- version(prefix)
+          if from.rawItems.nonEmpty
+          last <- Some(from.rawItems.last).collect { case n: Version.Numeric => n }
+          // a bit loose, but should do the job
+          if from.repr.endsWith(last.repr)
+          // appending -a1 to the next version, so has not to include things like
+          // nextVersion-RC1 in the interval - nothing like nextVersion* should be included
+          to <- version(from.repr.stripSuffix(last.repr) + last.next.repr + "-a1")
+          // the contrary would mean something went wrong in the loose substitution above
+          if from.rawItems.init == to.rawItems.dropRight(2).init
+          if to.rawItems.takeRight(2) == Seq(Version.Literal("a"), Version.Number(1))
+        } yield VersionInterval(Some(from), Some(to), fromIncluded = true, toIncluded = false)
+      case _ =>
+        None
+    }
 
   def versionInterval(s: String): Option[VersionInterval] = {
 

--- a/tests/shared/src/test/scala/coursier/test/VersionConstraintTests.scala
+++ b/tests/shared/src/test/scala/coursier/test/VersionConstraintTests.scala
@@ -20,6 +20,10 @@ object VersionConstraintTests extends TestSuite {
         val c0 = Parse.versionConstraint("(,1.2]")
         assert(c0 == Some(VersionConstraint.interval(VersionInterval(None, Some(Version("1.2")), false, true))))
       }
+      'latestSubRevision{
+        val c0 = Parse.versionConstraint("1.2.3-+")
+        assert(c0 == Some(VersionConstraint.interval(VersionInterval(Some(Version("1.2.3")), Some(Version("1.2.4-a1")), true, false))))
+      }
     }
 
     'repr{


### PR DESCRIPTION
Hi.

Here's my initial try at fixing #424, kindly requesting some thoughts. 

As you can see, the test is still failing.

Why is the `-a1` appended to the upper version bound? Should the revision `1.2.3-+` not be equivalent to `[1.2.3,1.2.4[`?

Note, I will squash the commits when the open questions are resolved.