### PR TITLE
Test resolution for distinct configurations is run separately.

### DIFF
--- a/sbt-coursier/src/sbt-test/sbt-coursier/config-deps-resolution/build.sbt
+++ b/sbt-coursier/src/sbt-test/sbt-coursier/config-deps-resolution/build.sbt
@@ -1,0 +1,5 @@
+name := "config-deps-resolution"
+libraryDependencies ++= Seq(
+  "org.slf4j" % "slf4j-api" % "1.7.2",
+  "ch.qos.logback" % "logback-classic" % "1.1.1"
+)

--- a/sbt-coursier/src/sbt-test/sbt-coursier/config-deps-resolution/project/plugins.sbt
+++ b/sbt-coursier/src/sbt-test/sbt-coursier/config-deps-resolution/project/plugins.sbt
@@ -1,0 +1,11 @@
+{
+  val pluginVersion = sys.props.getOrElse(
+    "plugin.version",
+    throw new RuntimeException(
+      """|The system property 'plugin.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin
+    )
+  )
+
+  addSbtPlugin("io.get-coursier" % "sbt-coursier" % pluginVersion)
+}

--- a/sbt-coursier/src/sbt-test/sbt-coursier/config-deps-resolution/project/src/main/scala/sbt/MyPlugin.scala
+++ b/sbt-coursier/src/sbt-test/sbt-coursier/config-deps-resolution/project/src/main/scala/sbt/MyPlugin.scala
@@ -1,0 +1,19 @@
+package sbt
+
+import sbt._
+import Keys._
+
+object MyPlugin extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+
+  val FooConfig = config("foo")
+
+  override def projectSettings = Seq(
+    libraryDependencies ++= Seq(
+      "org.slf4j" % "slf4j-api" % "1.7.0",
+      "ch.qos.logback" % "logback-classic" % "1.1.7"
+    ).map(_ % FooConfig),
+    ivyConfigurations += FooConfig
+  )
+}

--- a/sbt-coursier/src/sbt-test/sbt-coursier/config-deps-resolution/src/main/scala/App.scala
+++ b/sbt-coursier/src/sbt-test/sbt-coursier/config-deps-resolution/src/main/scala/App.scala
@@ -1,0 +1,6 @@
+import ch.qos.logback.classic.BasicConfigurator
+import ch.qos.logback.classic.LoggerContext
+
+object GcMetricsApp extends App {
+  BasicConfigurator.configure(new LoggerContext())
+}

--- a/sbt-coursier/src/sbt-test/sbt-coursier/config-deps-resolution/test
+++ b/sbt-coursier/src/sbt-test/sbt-coursier/config-deps-resolution/test
@@ -1,0 +1,2 @@
+> compile
+


### PR DESCRIPTION
The original issue was likely resolved in 8002910a433fa21e40faa072408ad2448b440383