### PR TITLE
Tree: Fix the pipe symbol to match the other UTF-8 symbols used

### DIFF
--- a/core/shared/src/main/scala/coursier/util/Tree.scala
+++ b/core/shared/src/main/scala/coursier/util/Tree.scala
@@ -36,7 +36,7 @@ object Tree {
     def showLine(isLast: Seq[Boolean]): String = {
       val initPrefix = init(isLast) {
         case true => "   "
-        case false => "|  "
+        case false => "│  "
       }.mkString
 
       val lastPrefix = last(isLast) {

--- a/tests/shared/src/test/scala/coursier/util/TreeTests.scala
+++ b/tests/shared/src/test/scala/coursier/util/TreeTests.scala
@@ -18,11 +18,11 @@ object TreeTests extends TestSuite {
     'apply {
       val str = Tree[Node](roots)(_.children, _.label)
       assert(str == """├─ p1
-        ││  ├─ c1
-        ││  └─ c2
-        │└─ p2
-        │   ├─ c3
-        │   └─ c4""".stripMargin)
+        #│  ├─ c1
+        #│  └─ c2
+        #└─ p2
+        #   ├─ c3
+        #   └─ c4""".stripMargin('#'))
     }
   }
 }

--- a/tests/shared/src/test/scala/coursier/util/TreeTests.scala
+++ b/tests/shared/src/test/scala/coursier/util/TreeTests.scala
@@ -18,11 +18,11 @@ object TreeTests extends TestSuite {
     'apply {
       val str = Tree[Node](roots)(_.children, _.label)
       assert(str == """├─ p1
-        ||  ├─ c1
-        ||  └─ c2
-        |└─ p2
-        |   ├─ c3
-        |   └─ c4""".stripMargin)
+        ││  ├─ c1
+        ││  └─ c2
+        │└─ p2
+        │   ├─ c3
+        │   └─ c4""".stripMargin)
     }
   }
 }


### PR DESCRIPTION
The "branching" symbols used to print the tree are UTF-8 characters.
Make the pipe symbol be the matching UTF-8 character to close the tiny gap
between symbols visible in the tree before.