### PR TITLE
added acceptense for more possible forms of checksum patterns

### DIFF
--- a/cache/src/main/scala/coursier/Cache.scala
+++ b/cache/src/main/scala/coursier/Cache.scala
@@ -884,7 +884,12 @@ object Cache {
     findChecksum(lines.map(_.toLowerCase.replaceAll("\\s", "")))
 
   private def parseChecksumAlternative(lines: Seq[String]): Option[BigInteger] =
-    findChecksum(lines.flatMap(_.toLowerCase.split("\\s+")))
+    findChecksum(lines.flatMap(_.toLowerCase.split("\\s+"))) orElse {
+      findChecksum(lines.map(_.toLowerCase
+        .split("\\s+")
+        .filter(_.matches("[0-9a-f]+"))
+        .mkString))
+    }
 
   def validateChecksum(
     artifact: Artifact,

--- a/tests/jvm/src/test/scala/coursier/test/ChecksumTests.scala
+++ b/tests/jvm/src/test/scala/coursier/test/ChecksumTests.scala
@@ -46,6 +46,17 @@ object ChecksumTests extends TestSuite {
         sha1ParseTest(cleanSha1, dirtySha1)
       }
 
+      'singleLineEndingWithChunkedSha1 - {
+        // http://www-eu.apache.org/dist/kafka/0.10.1.0/kafka_2.11-0.10.1.0.tgz.sha1
+        // as of 2017-08-17
+        val dirtySha1 =
+          "kafka_2.11-0.10.1.0.tgz: 710F 31E7 0AB7 54BF D533  3278 E226 82C9 8DD0 56CA\n"
+
+        val cleanSha1 = "710f31e70ab754bfd5333278e22682c98dd056ca"
+
+        sha1ParseTest(cleanSha1, dirtySha1)
+      }
+
       'binarySha1 - {
         val content = Platform.readFullySync(getClass.getResource("/empty.sha1").openStream())
         val res = Cache.parseRawChecksum(content)


### PR DESCRIPTION
Following the [message posted on gitter](https://gitter.im/coursier/coursier?at=5992bfe9a7b406262d8d3962), I modified `parseChecksumAlternative` to also accept patterns such as:

```none
kafka_2.10-0.10.1.0.tgz: 46A7 8910 F316 32C5 09F8 D540 0ED4 93F1 2479 637B
```

which can be found on apache's dist repo, e.g:
http://www-eu.apache.org/dist/kafka/0.10.1.0/kafka_2.11-0.10.1.0.tgz.sha1
