### PR TITLE
Prevent tags to be split in generated Ivy XML

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -219,7 +219,10 @@ lazy val doc = project
 
 lazy val `sbt-coursier` = project
   .dependsOn(coreJvm, cache, extra)
-  .settings(plugin)
+  .settings(
+    plugin,
+    utest
+  )
 
 lazy val `sbt-pgp-coursier` = project
   .dependsOn(`sbt-coursier`)

--- a/sbt-coursier/src/test/scala/coursier/IvyXmlTests.scala
+++ b/sbt-coursier/src/test/scala/coursier/IvyXmlTests.scala
@@ -1,0 +1,35 @@
+package coursier
+
+import utest._
+
+object IvyXmlTests extends TestSuite {
+
+  val tests = TestSuite {
+    "no truncation" - {
+
+      val project = Project(
+        Module("org", "name"),
+        "ver",
+        Nil,
+        Map(
+          "foo" -> (1 to 80).map("bar" + _) // long list of configurations -> no truncation any way
+        ),
+        None,
+        Nil,
+        Nil,
+        Nil,
+        None,
+        None,
+        None,
+        None,
+        Nil,
+        Info.empty
+      )
+
+      val content = IvyXml.rawContent(project, None)
+
+      assert(!content.contains("</conf>"))
+    }
+  }
+
+}


### PR DESCRIPTION
See https://github.com/sbt/sbt/issues/3412.