### PR TITLE
Try fixing scala-native things on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
       os: linux
       jdk: oraclejdk8
       sudo: required
+      group: deprecated-2017Q3
       before_install:
       - curl https://raw.githubusercontent.com/scala-native/scala-native/v0.3.1/bin/travis_setup.sh | bash -x
       services:


### PR DESCRIPTION
Now getting [the following error](https://travis-ci.org/coursier/coursier/jobs/273854270#L1470) during linking:
```
/usr/bin/ld: warning: libunwind.so.8, needed by /usr/bin/../lib/gcc/x86_64-linux-gnu/4.8/../../../x86_64-linux-gnu/libunwind-x86_64.so, may conflict with libunwind.so.1
/usr/bin/ld: /home/travis/build/coursier/coursier/native-target/lib/unwind.c.o: undefined reference to symbol '_Ux86_64_getcontext'
//usr/lib/x86_64-linux-gnu/libunwind.so.8: error adding symbols: DSO missing from command line
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Maybe related to https://blog.travis-ci.com/2017-08-29-trusty-image-updates.