### PR TITLE
Fix cli print out completeness and cyclic handling issue

### DIFF
--- a/core/shared/src/main/scala/coursier/util/Tree.scala
+++ b/core/shared/src/main/scala/coursier/util/Tree.scala
@@ -15,11 +15,9 @@ object Tree {
       * @param acc       accumulation method on a string
       */
     def recursivePrint(elems: Seq[T], ancestors: Set[T], prefix: String, acc: String => Unit): Unit = {
-      for (elem <- elems) {
-        if (ancestors.contains(elem)) {
-          return
-        }
-        val isLast = elems.indexOf(elem) == elems.length - 1
+      val unseenElems: Seq[T] = elems.filterNot(ancestors.contains)
+      for (elem <- unseenElems) {
+        val isLast = unseenElems.indexOf(elem) == unseenElems.length - 1
         val tee = if (isLast) "└─ " else "├─ "
         acc(prefix + tee + show(elem))
 

--- a/core/shared/src/main/scala/coursier/util/Tree.scala
+++ b/core/shared/src/main/scala/coursier/util/Tree.scala
@@ -6,13 +6,20 @@ object Tree {
 
   def apply[T](roots: IndexedSeq[T])(children: T => Seq[T], show: T => String): String = {
 
-
-    def recursivePrint(roots: Seq[T], ancestors: Set[T], prefix: String, acc: String => Unit): Unit = {
-      for (root <- roots) {
+    /**
+      * Recursively go down the resolution for the elems to construct the tree for print out.
+      *
+      * @param elems     Seq of Elems that have been resolved
+      * @param ancestors a set of Elems to keep track for cycle detection
+      * @param prefix    prefix for the print out
+      * @param acc       accumulation method on a string
+      */
+    def recursivePrint(elems: Seq[T], ancestors: Set[T], prefix: String, acc: String => Unit): Unit = {
+      for (root <- elems) {
         if (ancestors.contains(root)) {
           return
         }
-        val isLast = roots.indexOf(root) == roots.length - 1
+        val isLast = elems.indexOf(root) == elems.length - 1
         val tee = if (isLast) "└─ " else "├─ "
         acc(prefix + tee + show(root))
 

--- a/core/shared/src/main/scala/coursier/util/Tree.scala
+++ b/core/shared/src/main/scala/coursier/util/Tree.scala
@@ -23,7 +23,7 @@ object Tree {
         val tee = if (isLast) "└─ " else "├─ "
         acc(prefix + tee + show(elem))
 
-        val extraPrefix = if (isLast) "   " else "|  "
+        val extraPrefix = if (isLast) "   " else "│  "
         recursivePrint(children(elem), ancestors + elem, prefix + extraPrefix, acc)
       }
     }

--- a/core/shared/src/main/scala/coursier/util/Tree.scala
+++ b/core/shared/src/main/scala/coursier/util/Tree.scala
@@ -16,8 +16,9 @@ object Tree {
       */
     def recursivePrint(elems: Seq[T], ancestors: Set[T], prefix: String, acc: String => Unit): Unit = {
       val unseenElems: Seq[T] = elems.filterNot(ancestors.contains)
-      for (elem <- unseenElems) {
-        val isLast = unseenElems.indexOf(elem) == unseenElems.length - 1
+      val unseenElemsLen = unseenElems.length
+      for ((elem, idx) <- unseenElems.iterator.zipWithIndex) {
+        val isLast = idx == unseenElemsLen - 1
         val tee = if (isLast) "└─ " else "├─ "
         acc(prefix + tee + show(elem))
 

--- a/core/shared/src/main/scala/coursier/util/Tree.scala
+++ b/core/shared/src/main/scala/coursier/util/Tree.scala
@@ -1,73 +1,29 @@
 package coursier.util
 
-import scala.annotation.tailrec
+import scala.collection.mutable.ArrayBuffer
 
 object Tree {
 
   def apply[T](roots: IndexedSeq[T])(children: T => Seq[T], show: T => String): String = {
 
-    val buffer = new StringBuilder
-    val printLine: (String) => Unit = { line =>
-      buffer.append(line).append('\n')
-    }
 
-    def last[E, O](seq: Seq[E])(f: E => O) =
-      seq.takeRight(1).map(f)
-    def init[E, O](seq: Seq[E])(f: E => O) =
-      seq.dropRight(1).map(f)
+    def recursivePrint(roots: Seq[T], ancestors: Set[T], prefix: String, acc: String => Unit): Unit = {
+      for (root <- roots) {
+        if (ancestors.contains(root)) {
+          return
+        }
+        val isLast = roots.indexOf(root) == roots.length - 1
+        val tee = if (isLast) "└─ " else "├─ "
+        acc(prefix + tee + show(root))
 
-    /*
-     * Add elements to the stack
-     * @param elems elements to add
-     * @param isLast a list that contains whether an element is the last in its siblings or not.
-     */
-    def childrenWithLast(elems: Seq[T],
-                         isLast: Seq[Boolean]): Seq[(T, Seq[Boolean])] = {
-
-      val isNotLast = isLast :+ false
-
-      init(elems)(_ -> isNotLast) ++
-        last(elems)(_ -> (isLast :+ true))
-    }
-
-    /**
-      * Has to end with a "─"
-      */
-    def showLine(isLast: Seq[Boolean]): String = {
-      val initPrefix = init(isLast) {
-        case true => "   "
-        case false => "│  "
-      }.mkString
-
-      val lastPrefix = last(isLast) {
-        case true => "└─ "
-        case false => "├─ "
-      }.mkString
-
-      initPrefix + lastPrefix
-    }
-
-    // Depth-first traverse
-    @tailrec
-    def helper(stack: Seq[(T, Seq[Boolean])], seen: Set[T]): Unit = {
-      stack match {
-        case (elem, isLast) +: next =>
-          printLine(showLine(isLast) + show(elem))
-
-          if (!seen(elem))
-            helper(childrenWithLast(children(elem), isLast) ++ next,
-                   seen + elem)
-          else
-            helper(next, seen)
-        case Seq() =>
+        val extraPrefix = if (isLast) "   " else "|  "
+        recursivePrint(children(root), ancestors + root, prefix + extraPrefix, acc)
       }
     }
 
-    helper(childrenWithLast(roots, Vector[Boolean]()), Set.empty)
-
-    buffer
-      .dropRight(1) // drop last appended '\n'
-      .toString
+    val b = new ArrayBuffer[String]
+    recursivePrint(roots, Set(), "", b += _)
+    b.mkString("\n")
   }
 
 }

--- a/core/shared/src/main/scala/coursier/util/Tree.scala
+++ b/core/shared/src/main/scala/coursier/util/Tree.scala
@@ -15,16 +15,16 @@ object Tree {
       * @param acc       accumulation method on a string
       */
     def recursivePrint(elems: Seq[T], ancestors: Set[T], prefix: String, acc: String => Unit): Unit = {
-      for (root <- elems) {
-        if (ancestors.contains(root)) {
+      for (elem <- elems) {
+        if (ancestors.contains(elem)) {
           return
         }
-        val isLast = elems.indexOf(root) == elems.length - 1
+        val isLast = elems.indexOf(elem) == elems.length - 1
         val tee = if (isLast) "└─ " else "├─ "
-        acc(prefix + tee + show(root))
+        acc(prefix + tee + show(elem))
 
         val extraPrefix = if (isLast) "   " else "|  "
-        recursivePrint(children(root), ancestors + root, prefix + extraPrefix, acc)
+        recursivePrint(children(elem), ancestors + elem, prefix + extraPrefix, acc)
       }
     }
 

--- a/tests/shared/src/test/scala/coursier/util/TreeTests.scala
+++ b/tests/shared/src/test/scala/coursier/util/TreeTests.scala
@@ -2,49 +2,105 @@ package coursier.util
 
 import utest._
 
+import scala.collection.mutable.ArrayBuffer
+
 object TreeTests extends TestSuite {
 
-  case class Node(label: String, children: Node*)
+  case class Node(label: String, children: ArrayBuffer[Node]) {
+    def addChild(x: Node): Unit = {
+      children.append(x)
+    }
+
+    // The default behavior of hashcode will calculate things recursively,
+    // which will be infinite because we want to test cycles, so hardcoding
+    // the hashcode to 0 to get around the issue.
+    // TODO: make the hashcode to return something more interesting to
+    // improve performance.
+    override def hashCode(): Int = 0
+  }
 
   val roots = Array(
-    Node("p1",
-      Node("c1"),
-      Node("c2")),
-    Node("p2",
-      Node("c3"),
-      Node("c4"))
+    Node("p1", ArrayBuffer(
+      Node("c1", ArrayBuffer.empty),
+      Node("c2", ArrayBuffer.empty))),
+    Node("p2", ArrayBuffer(
+      Node("c3", ArrayBuffer.empty),
+      Node("c4", ArrayBuffer.empty)))
   )
 
   val moreNestedRoots = Array(
-    Node("p1",
-      Node("c1",
-        Node("p2"))),
-    Node("p2",
-      Node("c1"))
-  )
+    Node("p1", ArrayBuffer(
+      Node("c1", ArrayBuffer(
+        Node("p2", ArrayBuffer.empty))))),
+    Node("p3", ArrayBuffer(
+      Node("d1", ArrayBuffer.empty))
+    ))
+
+
+  // Constructing cyclic graph:
+  // a -> b -> c -> a
+  //             -> e -> f
+
+  val a = Node("a", ArrayBuffer.empty)
+  val b = Node("b", ArrayBuffer.empty)
+  val c = Node("c", ArrayBuffer.empty)
+  val e = Node("e", ArrayBuffer.empty)
+  val f = Node("f", ArrayBuffer.empty)
+
+  a.addChild(b)
+  b.addChild(c)
+  c.addChild(a)
+  c.addChild(e)
+  e.addChild(f)
 
 
   val tests = TestSuite {
-    'apply {
+    'basic {
       val str = Tree[Node](roots)(_.children, _.label)
       assert(str ==
         """├─ p1
-        #│  ├─ c1
-        #│  └─ c2
-        #└─ p2
-        #   ├─ c3
-        #   └─ c4""".stripMargin('#'))
+          #│  ├─ c1
+          #│  └─ c2
+          #└─ p2
+          #   ├─ c3
+          #   └─ c4""".stripMargin('#'))
     }
 
-    'apply {
+    'moreNested {
       val str = Tree[Node](moreNestedRoots)(_.children, _.label)
-      println(str)
       assert(str ==
         """├─ p1
-        #│  └─ c1
-        #│     └─ p2
-        #└─ p2
-        #   └─ c1""".stripMargin('#'))
+          #│  └─ c1
+          #│     └─ p2
+          #└─ p3
+          #   └─ d1""".stripMargin('#'))
+    }
+
+    'cyclic1 {
+      val str: String = Tree[Node](Array(a, e))(_.children, _.label)
+      assert(str ==
+        """├─ a
+          #│  └─ b
+          #│     └─ c
+          #│        └─ e
+          #│           └─ f
+          #└─ e
+          #   └─ f""".stripMargin('#'))
+    }
+
+    'cyclic2 {
+      val str: String = Tree[Node](Array(a, c))(_.children, _.label)
+      assert(str ==
+        """├─ a
+          #│  └─ b
+          #│     └─ c
+          #│        └─ e
+          #│           └─ f
+          #└─ c
+          #   ├─ a
+          #   │  └─ b
+          #   └─ e
+          #      └─ f""".stripMargin('#'))
     }
   }
 }

--- a/tests/shared/src/test/scala/coursier/util/TreeTests.scala
+++ b/tests/shared/src/test/scala/coursier/util/TreeTests.scala
@@ -3,6 +3,7 @@ package coursier.util
 import utest._
 
 object TreeTests extends TestSuite {
+
   case class Node(label: String, children: Node*)
 
   val roots = Array(
@@ -14,15 +15,36 @@ object TreeTests extends TestSuite {
       Node("c4"))
   )
 
+  val moreNestedRoots = Array(
+    Node("p1",
+      Node("c1",
+        Node("p2"))),
+    Node("p2",
+      Node("c1"))
+  )
+
+
   val tests = TestSuite {
     'apply {
       val str = Tree[Node](roots)(_.children, _.label)
-      assert(str == """├─ p1
+      assert(str ==
+        """├─ p1
         #│  ├─ c1
         #│  └─ c2
         #└─ p2
         #   ├─ c3
         #   └─ c4""".stripMargin('#'))
+    }
+
+    'apply {
+      val str = Tree[Node](moreNestedRoots)(_.children, _.label)
+      println(str)
+      assert(str ==
+        """├─ p1
+        #│  └─ c1
+        #│     └─ p2
+        #└─ p2
+        #   └─ c1""".stripMargin('#'))
     }
   }
 }


### PR DESCRIPTION
## Problem
Before resolve/fetch does not output the complete graph. E.g.
```
./coursier resolve -t org.apache.avro:avro:1.7.4 org.apache.commons:commons-compress:1.4.1
 Result:
├─ org.apache.avro:avro:1.7.4
│  ├─ com.thoughtworks.paranamer:paranamer:2.3
│  ├─ org.apache.commons:commons-compress:1.4.1
│  │  └─ org.tukaani:xz:1.0
│  ├─ org.codehaus.jackson:jackson-core-asl:1.8.8
│  ├─ org.codehaus.jackson:jackson-mapper-asl:1.8.8
│  │  └─ org.codehaus.jackson:jackson-core-asl:1.8.8
│  ├─ org.slf4j:slf4j-api:1.6.4
│  └─ org.xerial.snappy:snappy-java:1.0.4.1
└─ org.apache.commons:commons-compress:1.4.1
          // why is there nothing over here?
```

## Solution
Do not avoid jars have been printed out before. E.g.
```
]$ cli/target/pack/bin/coursier resolve  -t org.apache.avro:avro:1.7.4   org.apache.commons:commons-compress:1.4.1 
  Result:
├─ org.apache.avro:avro:1.7.4
│  ├─ com.thoughtworks.paranamer:paranamer:2.3
│  ├─ org.apache.commons:commons-compress:1.4.1
│  │  └─ org.tukaani:xz:1.0
│  ├─ org.codehaus.jackson:jackson-core-asl:1.8.8
│  ├─ org.codehaus.jackson:jackson-mapper-asl:1.8.8
│  │  └─ org.codehaus.jackson:jackson-core-asl:1.8.8
│  ├─ org.slf4j:slf4j-api:1.6.4
│  └─ org.xerial.snappy:snappy-java:1.0.4.1
└─ org.apache.commons:commons-compress:1.4.1
   └─ org.tukaani:xz:1.0
```