### PR TITLE
Update homebrew installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ $ curl -L -o coursier https://git.io/vgvpD && chmod +x coursier && ./coursier --
 
 Alternatively on OS X, install it via homebrew,
 ```
-$ brew install coursier/formulas/coursier
+$ brew install --HEAD coursier/formulas/coursier
 ```
 
 Run an application distributed via artifacts with

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ It downloads the artifacts required to launch coursier on the first run.
 
 Alternatively on OS X, install it via homebrew, that puts the `coursier` launcher directly in your PATH,
 ```
-$ brew install coursier/formulas/coursier
+$ brew install --HEAD coursier/formulas/coursier
 ```
 
 ```

--- a/doc/README.md
+++ b/doc/README.md
@@ -88,7 +88,7 @@ $ curl -L -o coursier https://git.io/vgvpD && chmod +x coursier && ./coursier --
 
 Alternatively on OS X, install it via homebrew,
 ```
-$ brew install coursier/formulas/coursier
+$ brew install --HEAD coursier/formulas/coursier
 ```
 
 Run an application distributed via artifacts with
@@ -268,7 +268,7 @@ It downloads the artifacts required to launch coursier on the first run.
 
 Alternatively on OS X, install it via homebrew, that puts the `coursier` launcher directly in your PATH,
 ```
-$ brew install coursier/formulas/coursier
+$ brew install --HEAD coursier/formulas/coursier
 ```
 
 ```


### PR DESCRIPTION
The command to install via homebrew didn't work for me. Presumably this changed in a recent version of homebrew.

This is the error I received:
```
$ brew install coursier/formulas/coursier

Error: coursier/formulas/coursier is a head-only formula
Install with `brew install --HEAD coursier/formulas/coursier`
```

So this change just incorporates the fix it suggests, which works for me.