### PR TITLE
Introduce support for OS-specific standard cache directories

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "tests/metadata"]
 	path = tests/metadata
 	url = https://github.com/coursier/test-metadata.git
+[submodule "directories"]
+	path = directories
+	url = https://github.com/soc/directories.git

--- a/build.sbt
+++ b/build.sbt
@@ -86,7 +86,7 @@ lazy val paths = project
   .settings(
     pureJava,
     dontPublish,
-    libs += Deps.directories
+    addDirectoriesSources
   )
 
 lazy val cache = project
@@ -97,8 +97,7 @@ lazy val cache = project
     coursierPrefix,
     libs += Deps.scalazConcurrent,
     Mima.cacheFilters,
-    addPathsSources,
-    libs += Deps.directories
+    addPathsSources
   )
 
 lazy val bootstrap = project
@@ -106,7 +105,6 @@ lazy val bootstrap = project
     pureJava,
     dontPublish,
     addPathsSources,
-    libs += Deps.directories,
     // seems not to be automatically found with sbt 0.13.16-M1 :-/
     mainClass := Some("coursier.Bootstrap"),
     renameMainJar("bootstrap.jar")
@@ -470,6 +468,14 @@ lazy val sharedTestResources = {
   unmanagedResourceDirectories.in(Test) += baseDirectory.in(LocalRootProject).value / "tests" / "shared" / "src" / "test" / "resources"
 }
 
-lazy val addPathsSources = {
-  unmanagedSourceDirectories.in(Compile) ++= unmanagedSourceDirectories.in(Compile).in(paths).value
+// Using directly the sources of directories, rather than depending on it.
+// This is required to use it from the bootstrap module, whose jar is launched as is (so shouldn't require dependencies).
+// This is done for the other use of it too, from the cache module, not to have to manage two ways of depending on it.
+lazy val addDirectoriesSources = {
+  unmanagedSourceDirectories.in(Compile) += baseDirectory.in(LocalRootProject).value / "directories" / "src" / "main" / "java"
 }
+
+lazy val addPathsSources = Seq(
+  addDirectoriesSources,
+  unmanagedSourceDirectories.in(Compile) ++= unmanagedSourceDirectories.in(Compile).in(paths).value
+)

--- a/build.sbt
+++ b/build.sbt
@@ -85,7 +85,8 @@ lazy val `proxy-tests` = project
 lazy val paths = project
   .settings(
     pureJava,
-    dontPublish
+    dontPublish,
+    libs += Deps.directories
   )
 
 lazy val cache = project
@@ -96,7 +97,8 @@ lazy val cache = project
     coursierPrefix,
     libs += Deps.scalazConcurrent,
     Mima.cacheFilters,
-    addPathsSources
+    addPathsSources,
+    libs += Deps.directories
   )
 
 lazy val bootstrap = project
@@ -104,6 +106,7 @@ lazy val bootstrap = project
     pureJava,
     dontPublish,
     addPathsSources,
+    libs += Deps.directories,
     // seems not to be automatically found with sbt 0.13.16-M1 :-/
     mainClass := Some("coursier.Bootstrap"),
     renameMainJar("bootstrap.jar")

--- a/paths/src/main/java/coursier/CachePath.java
+++ b/paths/src/main/java/coursier/CachePath.java
@@ -85,7 +85,7 @@ public class CachePath {
     }
 
     public static File defaultCacheDirectory() {
-        return new File(CoursierPaths.cacheDirectory(), "v1");
+        return CoursierPaths.cacheDirectory();
     }
 
     private static ConcurrentHashMap<File, Object> processStructureLocks = new ConcurrentHashMap<File, Object>();

--- a/paths/src/main/java/coursier/CachePath.java
+++ b/paths/src/main/java/coursier/CachePath.java
@@ -85,18 +85,7 @@ public class CachePath {
     }
 
     public static File defaultCacheDirectory() {
-
-        // cache this method result so that it's only ever computed once?
-
-        String path = System.getenv("COURSIER_CACHE");
-
-        if (path == null)
-          path = System.getProperty("coursier.cache");
-
-        if (path == null)
-            path = System.getProperty("user.home") + "/.coursier/cache/v1"; // shouldn't have put a "v1" component here...
-
-        return new File(path).getAbsoluteFile();
+        return new File(CoursierPaths.cacheDirectory(), "v1");
     }
 
     private static ConcurrentHashMap<File, Object> processStructureLocks = new ConcurrentHashMap<File, Object>();

--- a/paths/src/main/java/coursier/CachePath.java
+++ b/paths/src/main/java/coursier/CachePath.java
@@ -85,7 +85,7 @@ public class CachePath {
     }
 
     public static File defaultCacheDirectory() {
-        return CoursierPaths.cacheDirectory();
+        return new File(CoursierPaths.cacheDirectory(), "v1");
     }
 
     private static ConcurrentHashMap<File, Object> processStructureLocks = new ConcurrentHashMap<File, Object>();

--- a/paths/src/main/java/coursier/CoursierPaths.java
+++ b/paths/src/main/java/coursier/CoursierPaths.java
@@ -27,7 +27,7 @@ public final class CoursierPaths {
         if (path == null) {
         	File coursierDotFile = new File(System.getProperty("user.home") + "/.coursier");
         	if (coursierDotFile.isDirectory())
-                path = System.getProperty("user.home") + "/.coursier/cache/v1/";
+        		path = System.getProperty("user.home") + "/.coursier/cache/";
         }
 
         if (path == null) {
@@ -35,6 +35,11 @@ public final class CoursierPaths {
         	 path = coursierDirectories.projectCacheDir;
         }
 
-        return new File(path).getAbsoluteFile();
+        File coursierCacheDirectory = new File(path).getAbsoluteFile();
+
+        if (coursierCacheDirectory.getName().equals("v1"))
+        	coursierCacheDirectory = coursierCacheDirectory.getParentFile();
+        
+        return coursierCacheDirectory.getAbsoluteFile();
 	}
 }

--- a/paths/src/main/java/coursier/CoursierPaths.java
+++ b/paths/src/main/java/coursier/CoursierPaths.java
@@ -7,39 +7,66 @@ import io.github.soc.directories.ProjectDirectories;
 /**
  * Computes Coursier's directories according to the standard
  * defined by operating system Coursier is running on.
- * 
+ *
  * @implNote If more paths e. g. for configuration or application data is required,
- *           use {@link #coursierDirectories} and do not roll your own logic.
+ * use {@link #coursierDirectories} and do not roll your own logic.
  */
 public final class CoursierPaths {
-	private CoursierPaths() {
-		throw new Error();
-	}
-	
-	private static ProjectDirectories coursierDirectories;
-	
-	public static File cacheDirectory() {
+    private CoursierPaths() {
+        throw new Error();
+    }
+
+    private static ProjectDirectories coursierDirectories;
+
+    private static volatile File cacheDirectory0 = null;
+
+    private static final Object lock = new Object();
+
+    // TODO After switching to nio, that logic can be unit tested with mock filesystems.
+
+    private static File computeCacheDirectory() {
         String path = System.getenv("COURSIER_CACHE");
 
         if (path == null)
-          path = System.getProperty("coursier.cache");
+            path = System.getProperty("coursier.cache");
+
+        String xdgPath = coursierDirectories.projectCacheDir;
+        File xdgDir = new File(xdgPath);
 
         if (path == null) {
-        	File coursierDotFile = new File(System.getProperty("user.home") + "/.coursier");
-        	if (coursierDotFile.isDirectory())
-        		path = System.getProperty("user.home") + "/.coursier/cache/";
+            if (xdgDir.isDirectory())
+              path = xdgPath;
         }
 
         if (path == null) {
-        	 coursierDirectories = ProjectDirectories.fromProjectName("Coursier");
-        	 path = coursierDirectories.projectCacheDir;
+            File coursierDotFile = new File(System.getProperty("user.home") + "/.coursier");
+            if (coursierDotFile.isDirectory())
+                path = System.getProperty("user.home") + "/.coursier/cache/";
+        }
+
+        if (path == null) {
+            path = xdgPath;
+            xdgDir.mkdirs();
         }
 
         File coursierCacheDirectory = new File(path).getAbsoluteFile();
 
         if (coursierCacheDirectory.getName().equals("v1"))
-        	coursierCacheDirectory = coursierCacheDirectory.getParentFile();
-        
-        return coursierCacheDirectory.getAbsoluteFile();
-	}
+            coursierCacheDirectory = coursierCacheDirectory.getParentFile();
+
+        return coursierCacheDirectory;
+    }
+
+    public static File cacheDirectory() {
+
+        if (cacheDirectory0 == null)
+            synchronized (lock) {
+                if (cacheDirectory0 == null) {
+                    coursierDirectories = ProjectDirectories.fromProjectName("Coursier");
+                    cacheDirectory0 = computeCacheDirectory();
+                }
+            }
+
+        return cacheDirectory0;
+    }
 }

--- a/paths/src/main/java/coursier/CoursierPaths.java
+++ b/paths/src/main/java/coursier/CoursierPaths.java
@@ -1,0 +1,45 @@
+package coursier;
+
+import java.io.File;
+
+import io.github.soc.directories.ProjectDirectories;
+
+/**
+ * Computes Coursier's directories according to the standard
+ * defined by operating system Coursier is running on.
+ * 
+ * @implNote If more paths e. g. for configuration or application data is required,
+ *           use {@link #coursierDirectories} and do not roll your own logic.
+ */
+public final class CoursierPaths {
+	private CoursierPaths() {
+		throw new Error();
+	}
+	
+	private static ProjectDirectories coursierDirectories;
+	
+	public static File cacheDirectory() {
+        String path = System.getenv("COURSIER_CACHE");
+
+        if (path == null)
+          path = System.getProperty("coursier.cache");
+
+        if (path == null) {
+        	File coursierDotFile = new File(System.getProperty("user.home") + "/.coursier");
+        	if (coursierDotFile.isDirectory())
+        		path = System.getProperty("user.home") + "/.coursier/cache/";
+        }
+
+        if (path == null) {
+        	 coursierDirectories = ProjectDirectories.fromProjectName("Coursier");
+        	 path = coursierDirectories.projectCacheDir;
+        }
+
+        File coursierCacheDirectory = new File(path).getAbsoluteFile();
+
+        if (coursierCacheDirectory.getName().equals("v1"))
+        	coursierCacheDirectory = coursierCacheDirectory.getParentFile();
+        
+        return coursierCacheDirectory.getAbsoluteFile();
+	}
+}

--- a/paths/src/main/java/coursier/CoursierPaths.java
+++ b/paths/src/main/java/coursier/CoursierPaths.java
@@ -27,7 +27,7 @@ public final class CoursierPaths {
         if (path == null) {
         	File coursierDotFile = new File(System.getProperty("user.home") + "/.coursier");
         	if (coursierDotFile.isDirectory())
-        		path = System.getProperty("user.home") + "/.coursier/cache/";
+                path = System.getProperty("user.home") + "/.coursier/cache/v1/";
         }
 
         if (path == null) {
@@ -35,11 +35,6 @@ public final class CoursierPaths {
         	 path = coursierDirectories.projectCacheDir;
         }
 
-        File coursierCacheDirectory = new File(path).getAbsoluteFile();
-
-        if (coursierCacheDirectory.getName().equals("v1"))
-        	coursierCacheDirectory = coursierCacheDirectory.getParentFile();
-        
-        return coursierCacheDirectory.getAbsoluteFile();
+        return new File(path).getAbsoluteFile();
 	}
 }

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -19,6 +19,7 @@ object Deps {
   def sbtLauncherInterface = "org.scala-sbt" % "launcher-interface" % "1.0.0"
   def typesafeConfig = "com.typesafe" % "config" % "1.3.1"
   def argonautShapeless = "com.github.alexarchambault" %% "argonaut-shapeless_6.2" % "1.2.0-M5"
+  def directories = "io.github.soc" % "directories" % "5"
 
   def sbtPgp = Def.setting {
     val sbtv = CrossVersion.binarySbtVersion(sbtVersion.value)

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -19,7 +19,6 @@ object Deps {
   def sbtLauncherInterface = "org.scala-sbt" % "launcher-interface" % "1.0.0"
   def typesafeConfig = "com.typesafe" % "config" % "1.3.1"
   def argonautShapeless = "com.github.alexarchambault" %% "argonaut-shapeless_6.2" % "1.2.0-M5"
-  def directories = "io.github.soc" % "directories" % "5"
 
   def sbtPgp = Def.setting {
     val sbtv = CrossVersion.binarySbtVersion(sbtVersion.value)


### PR DESCRIPTION
This cleans up the home directories of users and helps making sure that
Coursier's cache is not accidentically backed up by applications or OS
functionality.

The precedence is as follows:

- existing $COURSIER_CACHE environment variable
- existing coursier.cache Java property
- existing ~/.coursier/
- existing operating system specific standards:
  - Linux:   $XDG_CACHE_HOME/coursier, with fallback to ~/.cache/coursier
  - Windows: {SpecialFolder.LocalApplicationData}/cache/Coursier
  - macOS:   $HOME/Library/Caches/Coursier