### PR TITLE
Bump asm version (for shading)

### DIFF
--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -40,8 +40,8 @@ object Deps {
 
   def jarjarTransitiveDeps = Seq(
     "com.google.code.findbugs" % "jsr305" % "2.0.2",
-    "org.ow2.asm" % "asm-commons" % "5.0.3",
-    "org.ow2.asm" % "asm-util" % "5.0.3",
+    "org.ow2.asm" % "asm-commons" % SharedVersions.asm,
+    "org.ow2.asm" % "asm-util" % SharedVersions.asm,
     "org.slf4j" % "slf4j-api" % "1.7.25"
   )
 

--- a/project/SharedVersions.scala
+++ b/project/SharedVersions.scala
@@ -1,6 +1,7 @@
 
 object SharedVersions {
 
+  def asm = "5.2"
   def fastParse = "1.0.0"
   def http4s = "0.15.16a"
   def proguard = "5.3.3"


### PR DESCRIPTION
Seems to fix `java.lang.IncompatibleClassChangeError` errors when using shaded code with Java 9. Release of coursier using the next one for shading should be fine with Java 9 thanks to that.