### PR TITLE
Fix for: Coursier not resilient to changing local ivy cache directory #665 

### DIFF
--- a/cache/src/main/scala/coursier/Cache.scala
+++ b/cache/src/main/scala/coursier/Cache.scala
@@ -1075,7 +1075,7 @@ object Cache {
   private lazy val ivy2HomeUri = {
 
     val path =
-      sys.props("coursier.ivy.home")
+      sys.props.get("coursier.ivy.home")
         .orElse(sys.props.get("ivy.home"))
         .getOrElse(sys.props("user.home") + "/.ivy2/")
 

--- a/cache/src/main/scala/coursier/Cache.scala
+++ b/cache/src/main/scala/coursier/Cache.scala
@@ -1073,15 +1073,14 @@ object Cache {
   }
 
   private lazy val ivy2HomeUri = {
+
+    val path =
+      sys.props("coursier.ivy.home")
+        .orElse(sys.props.get("ivy.home"))
+        .getOrElse(sys.props("user.home") + "/.ivy2/")
+
     // a bit touchy on Windows... - don't try to manually write down the URI with s"file://..."
-    val home =
-      if (sys.props("ivy.home") != null)
-        sys.props("ivy.home")
-      else if (sys.props("coursier.ivy.home") != null)
-        sys.props("coursier.ivy.home")
-      else
-        sys.props("user.home") +  "/.ivy2/"
-    val str = new File(home).toURI.toString
+    val str = new File(path).toURI.toString
     if (str.endsWith("/"))
       str
     else

--- a/cache/src/main/scala/coursier/Cache.scala
+++ b/cache/src/main/scala/coursier/Cache.scala
@@ -1077,12 +1077,11 @@ object Cache {
     val home =
       if (sys.props("ivy.home") != null)
         sys.props("ivy.home")
-      else if (sys.props("sbt.ivy.home") != null)
-        sys.props("sbt.ivy.home")
+      else if (sys.props("coursier.ivy.home") != null)
+        sys.props("coursier.ivy.home")
       else
-        sys.props("user.home")
-    println(s"home is $home")
-    val str = new File(home + "/.ivy2/").toURI.toString
+        sys.props("user.home") +  "/.ivy2/"
+    val str = new File(home).toURI.toString
     if (str.endsWith("/"))
       str
     else

--- a/cache/src/main/scala/coursier/Cache.scala
+++ b/cache/src/main/scala/coursier/Cache.scala
@@ -1075,7 +1075,9 @@ object Cache {
   private lazy val ivy2HomeUri = {
     // a bit touchy on Windows... - don't try to manually write down the URI with s"file://..."
     val home =
-      if (sys.props("sbt.ivy.home") != null)
+      if (sys.props("ivy.home") != null)
+        sys.props("ivy.home")
+      else if (sys.props("sbt.ivy.home") != null)
         sys.props("sbt.ivy.home")
       else
         sys.props("user.home")

--- a/cache/src/main/scala/coursier/Cache.scala
+++ b/cache/src/main/scala/coursier/Cache.scala
@@ -1074,7 +1074,13 @@ object Cache {
 
   private lazy val ivy2HomeUri = {
     // a bit touchy on Windows... - don't try to manually write down the URI with s"file://..."
-    val str = new File(sys.props("user.home") + "/.ivy2/").toURI.toString
+    val home =
+      if (sys.props("sbt.ivy.home") != null)
+        sys.props("sbt.ivy.home")
+      else
+        sys.props("user.home")
+    println(s"home is $home")
+    val str = new File(home + "/.ivy2/").toURI.toString
     if (str.endsWith("/"))
       str
     else


### PR DESCRIPTION
Made to address issue: https://github.com/coursier/coursier/issues/665
New priority for ivy home location is:
1. ivy.home property
2. sbt.ivy.home property
3. user.home property

One primary question with this fix: Will this address instances where coursier is used from CLI/API/Jar file?
