### PR TITLE
Performance improvements for cli json report and minor refactoring

### DIFF
--- a/cli/src/main/scala-2.11/coursier/cli/Helper.scala
+++ b/cli/src/main/scala-2.11/coursier/cli/Helper.scala
@@ -716,12 +716,12 @@ class Helper(
           a.isOptional && notFound
       }
 
-    val artifactToFile: collection.mutable.Map[String, File] = collection.mutable.Map()
-    val files0 = results.collect {
+    val artifactToFile = results.collect {
       case (artifact: Artifact, \/-(f)) =>
-        artifactToFile.put(artifact.url, f)
-        f
-    }
+        (artifact.url, f)
+    }.toMap
+
+    val files0 = artifactToFile.values.toSeq
 
     logger.foreach(_.stop())
 
@@ -769,9 +769,9 @@ class Helper(
 
       val artifacts: Seq[(Dependency, Artifact)] = res.dependencyArtifacts
 
-      val jsonReq = JsonPrintRequirement(artifactToFile, depToArtifacts, conflictResolutionForRoots)
+      val jsonReq = JsonPrintRequirement(artifactToFile, depToArtifacts)
       val roots = deps.toVector.map(JsonElem(_, artifacts, Option(jsonReq), res, printExclusions = verbosityLevel >= 1, excluded = false, colors = false))
-      val jsonStr = JsonReport(roots, jsonReq.conflictResolutionForRoots)(_.children, _.reconciledVersionStr, _.requestedVersionStr, _.downloadedFiles)
+      val jsonStr = JsonReport(roots, conflictResolutionForRoots)(_.children, _.reconciledVersionStr, _.requestedVersionStr, _.downloadedFiles)
 
       val pw = new PrintWriter(new File(jsonOutputFile))
       pw.write(jsonStr)


### PR DESCRIPTION
Major change:
* Identified hotspot in `JsonElem.hashCode` because it hashes children recursively. Hence simplified hashing scheme, reducing CPU time on `JsonReport.apply()` from 64.7 sec to 2.5 sec

Before:
![screen shot 2017-12-28 at 1 26 20 pm](https://user-images.githubusercontent.com/596358/34423713-e5419d02-ebd2-11e7-9052-8a01b05ca5e6.png)

After:
![screen shot 2017-12-28 at 1 26 27 pm](https://user-images.githubusercontent.com/596358/34423709-df2faddc-ebd2-11e7-9581-9a3634741e3f.png)


Other minor changes:
* Make `JsonRequirement` use immutable classes
* Simplify `JsonRequirement` composition
