### PR TITLE
Fix Java 6 test

### DIFF
--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -165,6 +165,7 @@ testSbtCoursierJava6() {
 
   git clone https://github.com/alexarchambault/scalacheck-shapeless.git
   cd scalacheck-shapeless
+  git checkout e11ec8b2b069ee598b20ae3f3ad6e00f5edfd7ac
   cd project
   clean_plugin_sbt
   cd project


### PR DESCRIPTION
The test was checking out the master of scalacheck-shapeless (which switched to sbt 1.0.4, so can't get built with java 6 anymore…)