### PR TITLE
Specify classifier on module level on CLI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: java
 sudo: required
-dist: trusty
 install:
   - npm install
+os:
+  - osx
 script:
   - scripts/travis.sh
 # Uncomment once https://github.com/scoverage/sbt-scoverage/issues/111 is fixed

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: java
 sudo: required
+dist: trusty
 install:
   - npm install
-os:
-  - osx
 script:
   - scripts/travis.sh
 # Uncomment once https://github.com/scoverage/sbt-scoverage/issues/111 is fixed

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ matrix:
       jdk: oraclejdk8
       script:
         # Sanity check for Pants build path.
-        - ./pants test cli::
+        - ./pants test "cli/::"
 env:
   global:
   - secure: miHFMwVRD/yjOLy794nOwc2lJTMyL5O0MXABT9ksg5ejQy1FrFVc2YH86Agp80W02/lGLGl0qWCiK1TBcs9q4Apt01nkD1a/0/iuTRm//bdhnu8BbRxFITf+2cyYJVytKPsF585aHldMv1rwZs3TDaTzEEecAEki5r50yyTVo7ycG0lVj9aVWXerKRMIT54Wb8M6nqbyRB1jGWT0ETNU13vOvQznPTUXQG5hsiKnGYRf8T3umOMdOHpV0rvdwYqAIMsikaAFcYCS5P/pLXMtmRHICH9KUG8TV/ST07p1BXtbBg9y1Q+lpnXotXh4ZNoWOp8B6v7fxJ/WlLYTDROWCiHJ4s2V4Di00db/nW4OWrEEBlrh7vJ/npZqyt9V9YeNv6alxi+DCESwusgvD4Cx5c3zh+2X6RB6BYwWHlFnd80rmsLe4R4fFUcc8E/ZR9vUFjP1CsQKqfJ5yfKR6V+n8jK8FjLpoaU9PHPo2H4V3FZM/fCLcxhE37vfaYI7/O7MqE/cdGpZIuz7g3c4toWCgNZJDn8iJCPmrgcbW5zbfDxvWU2K816ycgnUwSQ5dufrJpAbLNrjR1O8EPRkMDDp9bB7/4RVQvfDfP9GGoiHPHHgxGzY0Lf5bm+Bj1mRfB5/SXHd3IjhUCD9q7eD1/ANifEYALC5BJ4TB8RhQUPU8uM=

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ matrix:
       jdk: oraclejdk8
       script:
         # Sanity check for Pants build path.
-        - ./pants run cli/src/main/scala-2.11:coursier-cli -- fetch --help
+        - ./pants test cli::
 env:
   global:
   - secure: miHFMwVRD/yjOLy794nOwc2lJTMyL5O0MXABT9ksg5ejQy1FrFVc2YH86Agp80W02/lGLGl0qWCiK1TBcs9q4Apt01nkD1a/0/iuTRm//bdhnu8BbRxFITf+2cyYJVytKPsF585aHldMv1rwZs3TDaTzEEecAEki5r50yyTVo7ycG0lVj9aVWXerKRMIT54Wb8M6nqbyRB1jGWT0ETNU13vOvQznPTUXQG5hsiKnGYRf8T3umOMdOHpV0rvdwYqAIMsikaAFcYCS5P/pLXMtmRHICH9KUG8TV/ST07p1BXtbBg9y1Q+lpnXotXh4ZNoWOp8B6v7fxJ/WlLYTDROWCiHJ4s2V4Di00db/nW4OWrEEBlrh7vJ/npZqyt9V9YeNv6alxi+DCESwusgvD4Cx5c3zh+2X6RB6BYwWHlFnd80rmsLe4R4fFUcc8E/ZR9vUFjP1CsQKqfJ5yfKR6V+n8jK8FjLpoaU9PHPo2H4V3FZM/fCLcxhE37vfaYI7/O7MqE/cdGpZIuz7g3c4toWCgNZJDn8iJCPmrgcbW5zbfDxvWU2K816ycgnUwSQ5dufrJpAbLNrjR1O8EPRkMDDp9bB7/4RVQvfDfP9GGoiHPHHgxGzY0Lf5bm+Bj1mRfB5/SXHd3IjhUCD9q7eD1/ANifEYALC5BJ4TB8RhQUPU8uM=

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ matrix:
       jdk: oraclejdk8
       script:
         # Sanity check for Pants build path.
-        - ./pants test "cli/::"
+        - ./pants run cli/src/main/scala-2.11:coursier-cli -- fetch --help
 env:
   global:
   - secure: miHFMwVRD/yjOLy794nOwc2lJTMyL5O0MXABT9ksg5ejQy1FrFVc2YH86Agp80W02/lGLGl0qWCiK1TBcs9q4Apt01nkD1a/0/iuTRm//bdhnu8BbRxFITf+2cyYJVytKPsF585aHldMv1rwZs3TDaTzEEecAEki5r50yyTVo7ycG0lVj9aVWXerKRMIT54Wb8M6nqbyRB1jGWT0ETNU13vOvQznPTUXQG5hsiKnGYRf8T3umOMdOHpV0rvdwYqAIMsikaAFcYCS5P/pLXMtmRHICH9KUG8TV/ST07p1BXtbBg9y1Q+lpnXotXh4ZNoWOp8B6v7fxJ/WlLYTDROWCiHJ4s2V4Di00db/nW4OWrEEBlrh7vJ/npZqyt9V9YeNv6alxi+DCESwusgvD4Cx5c3zh+2X6RB6BYwWHlFnd80rmsLe4R4fFUcc8E/ZR9vUFjP1CsQKqfJ5yfKR6V+n8jK8FjLpoaU9PHPo2H4V3FZM/fCLcxhE37vfaYI7/O7MqE/cdGpZIuz7g3c4toWCgNZJDn8iJCPmrgcbW5zbfDxvWU2K816ycgnUwSQ5dufrJpAbLNrjR1O8EPRkMDDp9bB7/4RVQvfDfP9GGoiHPHHgxGzY0Lf5bm+Bj1mRfB5/SXHd3IjhUCD9q7eD1/ANifEYALC5BJ4TB8RhQUPU8uM=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+sudo: required
 install:
   - npm install
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: java
-sudo: required
 install:
   - npm install
 os:

--- a/cli/src/main/scala-2.11/BUILD
+++ b/cli/src/main/scala-2.11/BUILD
@@ -7,8 +7,23 @@ scala_library(
         "core:core",
         "extra/src/main/scala/coursier/extra:extra",
         "extra/src/main/scala-2.11/coursier/extra:native",
+        ":util",
     ],
-    sources = rglobs("*.scala"),
+    sources = globs(
+        "coursier/cli/scaladex/*.scala",
+        "coursier/cli/spark/*.scala",
+        "coursier/cli/*.scala",
+    ),
+)
+
+scala_library(
+    name = "util",
+    dependencies = [
+        "3rdparty/jvm:argonaut-shapeless",
+        "cache/src/main/scala:cache",
+        "core:core",
+    ],
+    sources = globs("coursier/cli/util/*.scala"),
 )
 
 jvm_binary(

--- a/cli/src/main/scala-2.11/coursier/cli/Helper.scala
+++ b/cli/src/main/scala-2.11/coursier/cli/Helper.scala
@@ -344,8 +344,6 @@ class Helper(
   private def createDependency(parsedModule: ParsedModule, transitive: Boolean) = {
     val attributes = parsedModule.attrs.get("classifier") match {
       case Some(c) => Attributes("", c)
-      // TODO(wisechengyi): Cannot use Attributes() because it will be confused for with
-      // `java.util.jar.Attributes` for scalajs https://github.com/coursier/coursier/issues/741
       case None => Attributes("", "")
     }
 

--- a/cli/src/main/scala-2.11/coursier/cli/Helper.scala
+++ b/cli/src/main/scala-2.11/coursier/cli/Helper.scala
@@ -10,7 +10,7 @@ import coursier.cli.scaladex.Scaladex
 import coursier.cli.util.{JsonElem, JsonPrintRequirement, JsonReport}
 import coursier.extra.Typelevel
 import coursier.ivy.IvyRepository
-import coursier.util.Parse.AdditionalRequirements
+import coursier.util.Parse.ModuleRequirements
 import coursier.util.{Parse, Print}
 
 import scala.annotation.tailrec
@@ -320,13 +320,13 @@ class Helper(
       }).groupBy(_._1).mapValues(_.map(_._2).toSet).toMap
     }
 
-  val additionalRequirements = AdditionalRequirements(globalExcludes, localExcludeMap, defaultConfiguration)
+  val moduleReq = ModuleRequirements(globalExcludes, localExcludeMap, defaultConfiguration)
 
   val (modVerCfgErrors: Seq[String], normalDeps: Seq[Dependency]) =
-    Parse.moduleVersionConfigs(otherRawDependencies, globalExcludes, localExcludeMap, transitive=true, scalaVersion)
+    Parse.moduleVersionConfigs(otherRawDependencies, moduleReq, transitive=true, scalaVersion)
 
   val (intransitiveModVerCfgErrors: Seq[String], intransitiveDeps: Seq[Dependency]) =
-    Parse.moduleVersionConfigs(intransitive, globalExcludes, localExcludeMap, transitive=false, scalaVersion)
+    Parse.moduleVersionConfigs(intransitive, moduleReq, transitive=false, scalaVersion)
 
   prematureExitIf(modVerCfgErrors.nonEmpty) {
     s"Cannot parse dependencies:\n" + modVerCfgErrors.map("  "+_).mkString("\n")

--- a/cli/src/main/scala-2.11/coursier/cli/Helper.scala
+++ b/cli/src/main/scala-2.11/coursier/cli/Helper.scala
@@ -286,16 +286,16 @@ class Helper(
 
   val (excludesNoAttr, excludesWithAttr) = excludes0.partition(_.attributes.isEmpty)
 
-  val globalExcludes: Set[(String, String)] = excludesNoAttr.map { mod =>
-    (mod.organization, mod.name)
-  }.toSet
-
   prematureExitIf(excludesWithAttr.nonEmpty) {
     s"Excluded modules with attributes not supported:\n" +
       excludesWithAttr
         .map("  " + _)
         .mkString("\n")
   }
+
+  val globalExcludes: Set[(String, String)] = excludesNoAttr.map { mod =>
+    (mod.organization, mod.name)
+  }.toSet
 
   val localExcludeMap: Map[String, Set[(String, String)]] =
     if (localExcludeFile.isEmpty) {

--- a/cli/src/main/scala-2.11/coursier/cli/Helper.scala
+++ b/cli/src/main/scala-2.11/coursier/cli/Helper.scala
@@ -344,7 +344,7 @@ class Helper(
   private def createDependency(parsedModule: ParsedModule, transitive: Boolean) = {
     val attributes = parsedModule.attrs.get("classifier") match {
       case Some(c) => Attributes("", c)
-      case None => Attributes("", "")
+      case None => Attributes()
     }
 
     Dependency(

--- a/cli/src/main/scala-2.11/coursier/cli/Helper.scala
+++ b/cli/src/main/scala-2.11/coursier/cli/Helper.scala
@@ -237,7 +237,7 @@ class Helper(
   val (intransitiveModVerCfgErrors: Seq[String], intransitiveModuleVersionConfigs: Seq[ParsedModule]) =
     Parse.moduleVersionConfigs(intransitive, scalaVersion)
 
-  def allModuleVersionConfigs: Seq[ParsedModule] =
+  val allModuleVersionConfigs: Seq[ParsedModule] =
     // FIXME Order of the dependencies is not respected here (scaladex ones go first)
     scaladexModuleVersionConfigs ++ moduleVersionConfigs
 

--- a/cli/src/main/scala-2.11/coursier/cli/Helper.scala
+++ b/cli/src/main/scala-2.11/coursier/cli/Helper.scala
@@ -344,7 +344,7 @@ class Helper(
   private def createDependency(parsedModule: ParsedModule, transitive: Boolean) = {
     val attributes = parsedModule.attrs.get("classifier") match {
       case Some(c) => Attributes("", c)
-      case None => Attributes()
+      case None => Attributes("", "")
     }
 
     Dependency(

--- a/cli/src/main/scala-2.11/coursier/cli/Helper.scala
+++ b/cli/src/main/scala-2.11/coursier/cli/Helper.scala
@@ -232,9 +232,9 @@ class Helper(
     }
 
 
-  val (modVerCfgErrors, moduleVersionConfigs: Seq[ParsedModule]) =
+  val (modVerCfgErrors: Seq[String], moduleVersionConfigs: Seq[ParsedModule]) =
     Parse.moduleVersionConfigs(otherRawDependencies, scalaVersion)
-  val (intransitiveModVerCfgErrors: Seq[String], intransitiveModuleVersionConfigs) =
+  val (intransitiveModVerCfgErrors: Seq[String], intransitiveModuleVersionConfigs: Seq[ParsedModule]) =
     Parse.moduleVersionConfigs(intransitive, scalaVersion)
 
   def allModuleVersionConfigs: Seq[ParsedModule] =

--- a/cli/src/main/scala-2.11/coursier/cli/Helper.scala
+++ b/cli/src/main/scala-2.11/coursier/cli/Helper.scala
@@ -344,6 +344,8 @@ class Helper(
   private def createDependency(parsedModule: ParsedModule, transitive: Boolean) = {
     val attributes = parsedModule.attrs.get("classifier") match {
       case Some(c) => Attributes("", c)
+      // TODO(wisechengyi): Cannot use Attributes() because it will be confused for with
+      // `java.util.jar.Attributes` for scalajs https://github.com/coursier/coursier/issues/741
       case None => Attributes("", "")
     }
 

--- a/cli/src/main/scala-2.11/coursier/cli/Helper.scala
+++ b/cli/src/main/scala-2.11/coursier/cli/Helper.scala
@@ -320,9 +320,10 @@ class Helper(
     }
 
   val (modVerCfgErrors: Seq[String], normalDeps: Seq[Dependency]) =
-    Parse.moduleVersionConfigs(otherRawDependencies, globalExcludes, localExcludeMap, scalaVersion)
+    Parse.moduleVersionConfigs(otherRawDependencies, globalExcludes, localExcludeMap, transitive=true, scalaVersion)
+
   val (intransitiveModVerCfgErrors: Seq[String], intransitiveDeps: Seq[Dependency]) =
-    Parse.moduleVersionConfigs(intransitive, globalExcludes, localExcludeMap, scalaVersion)
+    Parse.moduleVersionConfigs(intransitive, globalExcludes, localExcludeMap, transitive=false, scalaVersion)
 
   prematureExitIf(modVerCfgErrors.nonEmpty) {
     s"Cannot parse dependencies:\n" + modVerCfgErrors.map("  "+_).mkString("\n")

--- a/cli/src/main/scala-2.11/coursier/cli/Helper.scala
+++ b/cli/src/main/scala-2.11/coursier/cli/Helper.scala
@@ -10,6 +10,7 @@ import coursier.cli.scaladex.Scaladex
 import coursier.cli.util.{JsonElem, JsonPrintRequirement, JsonReport}
 import coursier.extra.Typelevel
 import coursier.ivy.IvyRepository
+import coursier.util.Parse.AdditionalRequirements
 import coursier.util.{Parse, Print}
 
 import scala.annotation.tailrec
@@ -318,6 +319,8 @@ class Helper(
         (parent_and_child(0), (child_org_name(0), child_org_name(1)))
       }).groupBy(_._1).mapValues(_.map(_._2).toSet).toMap
     }
+
+  val additionalRequirements = AdditionalRequirements(globalExcludes, localExcludeMap, defaultConfiguration)
 
   val (modVerCfgErrors: Seq[String], normalDeps: Seq[Dependency]) =
     Parse.moduleVersionConfigs(otherRawDependencies, globalExcludes, localExcludeMap, transitive=true, scalaVersion)

--- a/cli/src/test/scala-2.11/coursier/cli/CliIntegrationTest.scala
+++ b/cli/src/test/scala-2.11/coursier/cli/CliIntegrationTest.scala
@@ -2,8 +2,8 @@ package coursier.cli
 
 import java.io.{File, FileWriter}
 
-import coursier.cli.util.ReportNode
-import argonaut._, Argonaut._
+import argonaut.Argonaut._
+import coursier.cli.util.{DepNode, ReportNode}
 import org.junit.runner.RunWith
 import org.scalatest.FlatSpec
 import org.scalatest.junit.JUnitRunner
@@ -222,7 +222,7 @@ class CliIntegrationTest extends FlatSpec {
     * |└─ org.apache.commons:commons-compress:1.5
     * |   └─ org.tukaani:xz:1.2
     */
-  "classifier" should "be fetched" in withFile() {
+  "classifier tests" should "have tests.jar" in withFile() {
     (excludeFile, _) =>
       withFile() {
         (jsonFile, _) => {
@@ -240,6 +240,43 @@ class CliIntegrationTest extends FlatSpec {
           assert(compressNode.get.files.head._1 == "tests")
           assert(compressNode.get.files.head._2.contains("commons-compress-1.5-tests.jar"))
           assert(compressNode.get.dependencies.contains("org.tukaani:xz:1.2"))
+        }
+      }
+  }
+
+  /**
+    * Result:
+    * |├─ org.apache.commons:commons-compress:1.5
+    * |│  └─ org.tukaani:xz:1.2
+    * |└─ org.apache.commons:commons-compress:1.5
+    * |   └─ org.tukaani:xz:1.2
+    */
+  "mixed vanilla and classifier " should "have tests.jar and .jar" in withFile() {
+    (excludeFile, _) =>
+      withFile() {
+        (jsonFile, _) => {
+          val commonOpt = CommonOptions(jsonOutputFile = jsonFile.getPath)
+          val fetchOpt = FetchOptions(common = commonOpt)
+
+          val fetch = new Fetch(fetchOpt) with TestOnlyExtraArgsApp
+          fetch.setRemainingArgs(
+            Seq("org.apache.commons:commons-compress:1.5,classifier=tests",
+              "org.apache.commons:commons-compress:1.5"),
+            Seq())
+          fetch.apply()
+
+          val node: ReportNode = getReportFromJson(jsonFile)
+
+          val compressNodes: Seq[DepNode] = node.dependencies
+            .filter(_.coord == "org.apache.commons:commons-compress:1.5")
+            .sortBy(_.files.head._1.length) // sort by first classifier length
+          println(compressNodes)
+          assert(compressNodes.length == 2)
+          assert(compressNodes.head.files.head._1 == "")
+          assert(compressNodes.head.files.head._2.contains("commons-compress-1.5.jar"))
+
+          assert(compressNodes.last.files.head._1 == "tests")
+          assert(compressNodes.last.files.head._2.contains("commons-compress-1.5-tests.jar"))
         }
       }
   }

--- a/cli/src/test/scala-2.11/coursier/cli/CliIntegrationTest.scala
+++ b/cli/src/test/scala-2.11/coursier/cli/CliIntegrationTest.scala
@@ -270,7 +270,6 @@ class CliIntegrationTest extends FlatSpec {
           val compressNodes: Seq[DepNode] = node.dependencies
             .filter(_.coord == "org.apache.commons:commons-compress:1.5")
             .sortBy(_.files.head._1.length) // sort by first classifier length
-          println(compressNodes)
           assert(compressNodes.length == 2)
           assert(compressNodes.head.files.head._1 == "")
           assert(compressNodes.head.files.head._2.contains("commons-compress-1.5.jar"))
@@ -290,15 +289,13 @@ class CliIntegrationTest extends FlatSpec {
     (_, _) =>
       withFile() {
         (jsonFile, _) => {
-          val commonOpt = CommonOptions(jsonOutputFile = jsonFile.getPath)
+          val commonOpt = CommonOptions(jsonOutputFile = jsonFile.getPath, intransitive = List("org.apache.commons:commons-compress:1.5"))
           val fetchOpt = FetchOptions(common = commonOpt)
 
           val fetch = new Fetch(fetchOpt) with TestOnlyExtraArgsApp
-          fetch.setRemainingArgs(Seq("--intransitive", "org.apache.commons:commons-compress:1.5"), Seq())
           fetch.apply()
 
           val node: ReportNode = getReportFromJson(jsonFile)
-
           val compressNode = node.dependencies.find(_.coord == "org.apache.commons:commons-compress:1.5")
           assert(compressNode.isDefined)
           assert(compressNode.get.files.head._1 == "")
@@ -318,11 +315,11 @@ class CliIntegrationTest extends FlatSpec {
     (excludeFile, _) =>
       withFile() {
         (jsonFile, _) => {
-          val commonOpt = CommonOptions(jsonOutputFile = jsonFile.getPath)
+          val commonOpt = CommonOptions(jsonOutputFile = jsonFile.getPath, intransitive = List("org.apache.commons:commons-compress:1.5,classifier=tests"))
           val fetchOpt = FetchOptions(common = commonOpt)
 
           val fetch = new Fetch(fetchOpt) with TestOnlyExtraArgsApp
-          fetch.setRemainingArgs(Seq("--intransitive", "org.apache.commons:commons-compress:1.5,classifier=tests"), Seq())
+          fetch.setRemainingArgs(Seq(), Seq())
           fetch.apply()
 
           val node: ReportNode = getReportFromJson(jsonFile)
@@ -346,14 +343,11 @@ class CliIntegrationTest extends FlatSpec {
     (excludeFile, _) =>
       withFile() {
         (jsonFile, _) => {
-          val commonOpt = CommonOptions(jsonOutputFile = jsonFile.getPath)
+          val commonOpt = CommonOptions(jsonOutputFile = jsonFile.getPath, forceVersion = List("org.apache.commons:commons-compress:1.4.1"))
           val fetchOpt = FetchOptions(common = commonOpt)
 
           val fetch = new Fetch(fetchOpt) with TestOnlyExtraArgsApp
-          fetch.setRemainingArgs(
-            Seq("org.apache.commons:commons-compress:1.5,classifier=tests",
-              "-V", "org.apache.commons:commons-compress:1.4.1"),
-            Seq())
+          fetch.setRemainingArgs(Seq("org.apache.commons:commons-compress:1.5,classifier=tests"), Seq())
           fetch.apply()
 
           val node: ReportNode = getReportFromJson(jsonFile)
@@ -380,14 +374,13 @@ class CliIntegrationTest extends FlatSpec {
     (excludeFile, _) =>
       withFile() {
         (jsonFile, _) => {
-          val commonOpt = CommonOptions(jsonOutputFile = jsonFile.getPath)
+          val commonOpt = CommonOptions(jsonOutputFile = jsonFile.getPath,
+            intransitive = List("org.apache.commons:commons-compress:1.5,classifier=tests"),
+            forceVersion = List("org.apache.commons:commons-compress:1.4.1"))
           val fetchOpt = FetchOptions(common = commonOpt)
 
           val fetch = new Fetch(fetchOpt) with TestOnlyExtraArgsApp
-          fetch.setRemainingArgs(
-            Seq("org.apache.commons:commons-compress:1.5,classifier=tests",
-              "-V", "org.apache.commons:commons-compress:1.4.1"),
-            Seq())
+          fetch.setRemainingArgs(Seq(), Seq())
           fetch.apply()
 
           val node: ReportNode = getReportFromJson(jsonFile)

--- a/core/shared/src/main/scala/coursier/core/Resolution.scala
+++ b/core/shared/src/main/scala/coursier/core/Resolution.scala
@@ -1058,7 +1058,7 @@ final case class Resolution(
         .get(dep.moduleVersion)
         .toSeq
       artifact <- source
-        .artifacts(dep, proj, overrideClassifiers)
+        .artifacts(dep, proj, Option(overrideClassifiers.getOrElse(Seq()) ++ Seq(dep.attributes.classifier)))
       if optional || !artifact.isOptional
     } yield dep -> artifact
 

--- a/core/shared/src/main/scala/coursier/core/Resolution.scala
+++ b/core/shared/src/main/scala/coursier/core/Resolution.scala
@@ -1057,8 +1057,23 @@ final case class Resolution(
       (source, proj) <- projectCache
         .get(dep.moduleVersion)
         .toSeq
+
+      classifiers = {
+        if (!dep.attributes.classifier.isEmpty) {
+          val stringSeq: Seq[String] = overrideClassifiers.getOrElse(Seq()) ++ Seq(dep.attributes.classifier)
+          if (stringSeq.isEmpty) {
+            Option.empty
+          }
+          else {
+            Some(stringSeq)
+          }
+        } else {
+          overrideClassifiers
+        }
+      }
+
       artifact <- source
-        .artifacts(dep, proj, Option(overrideClassifiers.getOrElse(Seq()) ++ Seq(dep.attributes.classifier)))
+        .artifacts(dep, proj, classifiers)
       if optional || !artifact.isOptional
     } yield dep -> artifact
 

--- a/core/shared/src/main/scala/coursier/util/Parse.scala
+++ b/core/shared/src/main/scala/coursier/util/Parse.scala
@@ -119,11 +119,11 @@ object Parse {
 
   @deprecated("use the variant accepting a default scala version", "1.0.0-M13")
   def moduleVersionConfig(s: String, scalaVersion: String): Either[String, Dependency] =
-    moduleVersionConfig(s, Set.empty, Map.empty, scalaVersion)
+    moduleVersionConfig(s, Set.empty, Map.empty, transitive=true, scalaVersion)
 
   @deprecated("use the variant accepting a default scala version", "1.0.0-M13")
   def moduleVersionConfig(s: String): Either[String, Dependency] =
-    moduleVersionConfig(s, Set.empty, Map.empty, defaultScalaVersion)
+    moduleVersionConfig(s, Set.empty, Map.empty, transitive=true, defaultScalaVersion)
 
   /**
     * Parses coordinates like
@@ -140,6 +140,7 @@ object Parse {
   def moduleVersionConfig(s: String,
                           globalExcludes: Set[(String, String)],
                           localExcludes: Map[String, Set[(String, String)]],
+                          transitive: Boolean,
                           defaultScalaVersion: String): Either[String, Dependency] = {
 
     // Assume org:name:version,attr1=val1,attr2=val2
@@ -176,28 +177,50 @@ object Parse {
         module(s"$org::$rawName", defaultScalaVersion)
           .right
           .map(mod => {
-            Dependency(mod, version, config, attributes, exclusions = localExcludes.getOrElse(mod.orgName, Set()) | globalExcludes)
+            Dependency(
+              mod,
+              version,
+              config,
+              attributes,
+              transitive = transitive,
+              exclusions = localExcludes.getOrElse(mod.orgName, Set()) | globalExcludes)
           })
 
       case Array(org, "", rawName, version) =>
         module(s"$org::$rawName", defaultScalaVersion)
           .right
-          .map( mod => {
-            Dependency(mod, version, attributes=attributes, exclusions = localExcludes.getOrElse(mod.orgName, Set()) | globalExcludes)
+          .map(mod => {
+            Dependency(
+              mod,
+              version,
+              attributes = attributes,
+              transitive = transitive,
+              exclusions = localExcludes.getOrElse(mod.orgName, Set()) | globalExcludes)
           })
 
       case Array(org, rawName, version, config) =>
         module(s"$org:$rawName", defaultScalaVersion)
           .right
           .map(mod => {
-            Dependency(mod, version, config, attributes, exclusions = localExcludes.getOrElse(mod.orgName, Set()) | globalExcludes)
+            Dependency(
+              mod,
+              version,
+              config,
+              attributes,
+              transitive = transitive,
+              exclusions = localExcludes.getOrElse(mod.orgName, Set()) | globalExcludes)
           })
 
       case Array(org, rawName, version) =>
         module(s"$org:$rawName", defaultScalaVersion)
           .right
           .map(mod => {
-            Dependency(mod, version, attributes=attributes, exclusions = localExcludes.getOrElse(mod.orgName, Set()) | globalExcludes)
+            Dependency(
+              mod,
+              version,
+              attributes = attributes,
+              transitive = transitive,
+              exclusions = localExcludes.getOrElse(mod.orgName, Set()) | globalExcludes)
           })
 
       case _ =>
@@ -219,11 +242,11 @@ object Parse {
 
   @deprecated("use the variant accepting a default scala version", "1.0.0-M13")
   def moduleVersionConfigs(l: Seq[String]): (Seq[String], Seq[Dependency]) =
-    moduleVersionConfigs(l, Set.empty, Map.empty, defaultScalaVersion)
+    moduleVersionConfigs(l, Set.empty, Map.empty, transitive = true, defaultScalaVersion)
 
   @deprecated("use the variant accepting a default scala version", "1.0.0-M13")
   def moduleVersionConfigs(l: Seq[String], scalaVersion: String): (Seq[String], Seq[Dependency]) =
-    moduleVersionConfigs(l, Set.empty, Map.empty, scalaVersion)
+    moduleVersionConfigs(l, Set.empty, Map.empty, transitive = true, scalaVersion)
 
   /**
     * Parses a sequence of coordinates having an optional configuration.
@@ -233,8 +256,9 @@ object Parse {
   def moduleVersionConfigs(l: Seq[String],
                            globalExcludes: Set[(String, String)],
                            localExcludes: Map[String, Set[(String, String)]],
+                           transitive: Boolean,
                            defaultScalaVersion: String): (Seq[String], Seq[Dependency]) =
-    valuesAndErrors(moduleVersionConfig(_, globalExcludes, localExcludes, defaultScalaVersion), l)
+    valuesAndErrors(moduleVersionConfig(_, globalExcludes, localExcludes, transitive, defaultScalaVersion), l)
 
   def repository(s: String): String \/ Repository =
     if (s == "central")

--- a/core/shared/src/main/scala/coursier/util/Parse.scala
+++ b/core/shared/src/main/scala/coursier/util/Parse.scala
@@ -114,7 +114,7 @@ object Parse {
   }
 
   @deprecated("use the variant accepting a default scala version", "1.0.0-M13")
-  def moduleVersionConfig(s: String): Either[String, (Module, String, Option[String], Map[String, String])] =
+  def moduleVersionConfig(s: String): Either[String, ParsedModule] =
     moduleVersionConfig(s, defaultScalaVersion)
 
   case class ModuleParseError(private val message: String = "",
@@ -136,7 +136,7 @@ object Parse {
     *  or
     *   org:name:version:config;attr1=val1;attr2=val2
     */
-  def moduleVersionConfig(s: String, defaultScalaVersion: String): Either[String, (Module, String, Option[String], Map[String, String])] = {
+  def moduleVersionConfig(s: String, defaultScalaVersion: String): Either[String, ParsedModule] = {
 
     // Assume org:name:version;attr1=val1;attr2=val2
     // That is ';' has to go after ':'.
@@ -165,22 +165,22 @@ object Parse {
       case Array(org, "", rawName, version, config) =>
         module(s"$org::$rawName", defaultScalaVersion)
           .right
-          .map((_, version, Some(config), attrs))
+          .map(ParsedModule(_, version, Some(config), attrs))
 
       case Array(org, "", rawName, version) =>
         module(s"$org::$rawName", defaultScalaVersion)
           .right
-          .map((_, version, None, attrs))
+          .map(ParsedModule(_, version, None, attrs))
 
       case Array(org, rawName, version, config) =>
         module(s"$org:$rawName", defaultScalaVersion)
           .right
-          .map((_, version, Some(config), attrs))
+          .map(ParsedModule(_, version, Some(config), attrs))
 
       case Array(org, rawName, version) =>
         module(s"$org:$rawName", defaultScalaVersion)
           .right
-          .map((_, version, None, attrs))
+          .map(ParsedModule(_, version, None, attrs))
 
       case _ =>
         Left(s"Malformed dependency: $s")
@@ -200,7 +200,7 @@ object Parse {
     valuesAndErrors(moduleVersion(_, defaultScalaVersion), l)
 
   @deprecated("use the variant accepting a default scala version", "1.0.0-M13")
-  def moduleVersionConfigs(l: Seq[String]): (Seq[String], Seq[(Module, String, Option[String], Map[String, String])]) =
+  def moduleVersionConfigs(l: Seq[String]): (Seq[String], Seq[ParsedModule]) =
     moduleVersionConfigs(l, defaultScalaVersion)
 
   /**
@@ -208,7 +208,7 @@ object Parse {
     *
     * @return Sequence of errors, and sequence of modules / versions / optional configurations
     */
-  def moduleVersionConfigs(l: Seq[String], defaultScalaVersion: String): (Seq[String], Seq[(Module, String, Option[String], Map[String, String])]) =
+  def moduleVersionConfigs(l: Seq[String], defaultScalaVersion: String): (Seq[String], Seq[ParsedModule]) =
     valuesAndErrors(moduleVersionConfig(_, defaultScalaVersion), l)
 
   def repository(s: String): String \/ Repository =

--- a/core/shared/src/main/scala/coursier/util/Parse.scala
+++ b/core/shared/src/main/scala/coursier/util/Parse.scala
@@ -113,12 +113,6 @@ object Parse {
     }
   }
 
-//  // NB: Do not use this in tests. js tests will fail to find `java.util.jar.Attributes`
-//  // https://github.com/coursier/coursier/issues/741
-//  @deprecated("use the variant accepting a default scala version", "1.0.0-M13")
-//  def moduleVersionConfig(s: String): Either[String, Dependency] =
-//    moduleVersionConfig(s, defaultScalaVersion)
-
   case class ModuleParseError(private val message: String = "",
                               private val cause: Throwable = None.orNull)
     extends Exception(message, cause)

--- a/core/shared/src/main/scala/coursier/util/Parse.scala
+++ b/core/shared/src/main/scala/coursier/util/Parse.scala
@@ -117,6 +117,14 @@ object Parse {
                               private val cause: Throwable = None.orNull)
     extends Exception(message, cause)
 
+  @deprecated("use the variant accepting a default scala version", "1.0.0-M13")
+  def moduleVersionConfig(s: String, scalaVersion: String): Either[String, Dependency] =
+    moduleVersionConfig(s, Set.empty, Map.empty, scalaVersion)
+
+  @deprecated("use the variant accepting a default scala version", "1.0.0-M13")
+  def moduleVersionConfig(s: String): Either[String, Dependency] =
+    moduleVersionConfig(s, Set.empty, Map.empty, defaultScalaVersion)
+
   /**
     * Parses coordinates like
     *   org:name:version
@@ -206,6 +214,14 @@ object Parse {
     */
   def moduleVersions(l: Seq[String], defaultScalaVersion: String): (Seq[String], Seq[(Module, String)]) =
     valuesAndErrors(moduleVersion(_, defaultScalaVersion), l)
+
+  @deprecated("use the variant accepting a default scala version", "1.0.0-M13")
+  def moduleVersionConfigs(l: Seq[String]): (Seq[String], Seq[Dependency]) =
+    moduleVersionConfigs(l, Set.empty, Map.empty, defaultScalaVersion)
+
+  @deprecated("use the variant accepting a default scala version", "1.0.0-M13")
+  def moduleVersionConfigs(l: Seq[String], scalaVersion: String): (Seq[String], Seq[Dependency]) =
+    moduleVersionConfigs(l, Set.empty, Map.empty, scalaVersion)
 
   /**
     * Parses a sequence of coordinates having an optional configuration.

--- a/core/shared/src/main/scala/coursier/util/Parse.scala
+++ b/core/shared/src/main/scala/coursier/util/Parse.scala
@@ -149,7 +149,7 @@ object Parse {
 
     val attrs = strings.drop(1).map({ x => {
       if (x.mkString.contains(argSeparator)) {
-        throw ModuleParseError(s"'${argSeparator}' is not allowed in attribute '$x' in '$s'. Please follow the format " +
+        throw ModuleParseError(s"'$argSeparator' is not allowed in attribute '$x' in '$s'. Please follow the format " +
           s"'org${argSeparator}name[${argSeparator}version][${argSeparator}config]${attrSeparator}attr1=val1${attrSeparator}attr2=val2'")
       }
       val y = x.split("=")

--- a/core/shared/src/main/scala/coursier/util/Parse.scala
+++ b/core/shared/src/main/scala/coursier/util/Parse.scala
@@ -128,21 +128,23 @@ object Parse {
   /**
     * Parses coordinates like
     *   org:name:version
-    *  possibly with attributes, like
-    *   org:name;attr1=val1;attr2=val2:version
+    *  with attributes, like
+    *   org:name:version,attr1=val1,attr2=val2
     *  and a configuration, like
     *   org:name:version:config
     *  or
-    *   org:name:version:config;attr1=val1;attr2=val2
+    *   org:name:version:config,attr1=val1,attr2=val2
+    *
+    *  Currently only "classifier" attribute is used, and others are ignored.
     */
   def moduleVersionConfig(s: String,
                           globalExcludes: Set[(String, String)],
                           localExcludes: Map[String, Set[(String, String)]],
                           defaultScalaVersion: String): Either[String, Dependency] = {
 
-    // Assume org:name:version::attr1=val1::attr2=val2
-    // That is ';' has to go after ':'.
-    // E.g. "org:name::attr1=val1::attr2=val2:version:config" is illegal.
+    // Assume org:name:version,attr1=val1,attr2=val2
+    // That is ',' has to go after ':'.
+    // E.g. "org:name,attr1=val1,attr2=val2:version:config" is illegal.
     val attrSeparator = ","
     val argSeparator = ":"
 

--- a/core/shared/src/main/scala/coursier/util/Parse.scala
+++ b/core/shared/src/main/scala/coursier/util/Parse.scala
@@ -138,22 +138,23 @@ object Parse {
     */
   def moduleVersionConfig(s: String, defaultScalaVersion: String): Either[String, ParsedModule] = {
 
-    // Assume org:name:version;attr1=val1;attr2=val2
+    // Assume org:name:version::attr1=val1::attr2=val2
     // That is ';' has to go after ':'.
-    // E.g. "org:name;attr1=val1;attr2=val2:version:config" is illegal.
-    val attrSeparator = "#"
+    // E.g. "org:name::attr1=val1::attr2=val2:version:config" is illegal.
+    val attrSeparator = "::"
+    val argSeparator = ":"
 
     val strings = s.split(attrSeparator)
     val coords = strings.head
 
     val attrs = strings.drop(1).map({ x => {
-      if (x.mkString.contains(":")) {
-        throw ModuleParseError(s"':' is not allowed in attribute $x in $s. " +
-          s"Please follow the format org:name[:version][:config];attr1=val1;attr2=val2")
+      if (x.mkString.contains(argSeparator)) {
+        throw ModuleParseError(s"'${argSeparator}' is not allowed in attribute '$x' in '$s'. Please follow the format " +
+          s"'org${argSeparator}name[${argSeparator}version][${argSeparator}config]${attrSeparator}attr1=val1${attrSeparator}attr2=val2'")
       }
       val y = x.split("=")
       if (y.length != 2) {
-        throw ModuleParseError(s"Failed to parse attr $x in $s")
+        throw ModuleParseError(s"Failed to parse attribute '$x' in '$s'. Keyword argument expected such as 'classifier=tests'")
       }
       (y(0), y(1))
     }

--- a/core/shared/src/main/scala/coursier/util/Parse.scala
+++ b/core/shared/src/main/scala/coursier/util/Parse.scala
@@ -141,7 +141,7 @@ object Parse {
     // Assume org:name:version::attr1=val1::attr2=val2
     // That is ';' has to go after ':'.
     // E.g. "org:name::attr1=val1::attr2=val2:version:config" is illegal.
-    val attrSeparator = ":::"
+    val attrSeparator = ","
     val argSeparator = ":"
 
     val strings = s.split(attrSeparator)

--- a/core/shared/src/main/scala/coursier/util/Parse.scala
+++ b/core/shared/src/main/scala/coursier/util/Parse.scala
@@ -141,7 +141,7 @@ object Parse {
     // Assume org:name:version::attr1=val1::attr2=val2
     // That is ';' has to go after ':'.
     // E.g. "org:name::attr1=val1::attr2=val2:version:config" is illegal.
-    val attrSeparator = "::"
+    val attrSeparator = ":::"
     val argSeparator = ":"
 
     val strings = s.split(attrSeparator)

--- a/core/shared/src/main/scala/coursier/util/Parse.scala
+++ b/core/shared/src/main/scala/coursier/util/Parse.scala
@@ -113,6 +113,8 @@ object Parse {
     }
   }
 
+  // NB: Do not use this in tests. js tests will fail to find `java.util.jar.Attributes`
+  // https://github.com/coursier/coursier/issues/741
   @deprecated("use the variant accepting a default scala version", "1.0.0-M13")
   def moduleVersionConfig(s: String): Either[String, ParsedModule] =
     moduleVersionConfig(s, defaultScalaVersion)

--- a/core/shared/src/main/scala/coursier/util/Parse.scala
+++ b/core/shared/src/main/scala/coursier/util/Parse.scala
@@ -141,25 +141,23 @@ object Parse {
     // Assume org:name:version;attr1=val1;attr2=val2
     // That is ';' has to go after ':'.
     // E.g. "org:name;attr1=val1;attr2=val2:version:config" is illegal.
-    val attrSeparator = ","
+    val attrSeparator = "#"
 
     val strings = s.split(attrSeparator)
     val coords = strings.head
 
-    if (coords.contains(attrSeparator)){
-      throw ModuleParseError(s"'$attrSeparator' must go after ':")
-    }
-
     val attrs = strings.drop(1).map({ x => {
       if (x.mkString.contains(":")) {
-        throw ModuleParseError(s"':' is not allowed in attribute $x")
+        throw ModuleParseError(s"':' is not allowed in attribute $x in $s. " +
+          s"Please follow the format org:name[:version][:config];attr1=val1;attr2=val2")
       }
       val y = x.split("=")
       if (y.length != 2) {
-        throw ModuleParseError(s"Failed to parse attr $x")
+        throw ModuleParseError(s"Failed to parse attr $x in $s")
       }
       (y(0), y(1))
-    }}).toMap
+    }
+    }).toMap
 
     val parts = coords.split(":", 5)
 

--- a/core/shared/src/main/scala/coursier/util/Parse.scala
+++ b/core/shared/src/main/scala/coursier/util/Parse.scala
@@ -265,6 +265,15 @@ object Parse {
   }
 
   /**
+    *
+    *
+    * @param globalExcludes global excludes that need to be applied to all modules
+    * @param localExcludes excludes to be applied to specific modules
+    * @param defaultConfiguration default config
+    */
+  case class AdditionalRequirements(globalExcludes: Set[(String, String)], localExcludes: Map[String, Set[(String, String)]], defaultConfiguration: String)
+
+  /**
     * Parses a sequence of coordinates having an optional configuration.
     *
     * @return Sequence of errors, and sequence of modules / versions / optional configurations

--- a/core/shared/src/main/scala/coursier/util/Parse.scala
+++ b/core/shared/src/main/scala/coursier/util/Parse.scala
@@ -124,11 +124,6 @@ object Parse {
     extends Exception(message, cause)
 
   /**
-    * This class encapsulate the module info passed in as a string, such as org:name:version:config;classifier=tests
-    */
-  final case class ParsedModule(module: Module, version: String, config: Option[String], attrs: Map[String, String])
-
-  /**
     * Parses coordinates like
     *   org:name:version
     *  possibly with attributes, like

--- a/pants.ini
+++ b/pants.ini
@@ -33,3 +33,6 @@ jvm_options: [
     # TODO: Remove after https://github.com/pantsbuild/pants/issues/4477 is pulled in.
     '-Dzinc.analysis.cache.limit=5000',
   ]
+
+[test.junit]
+jvm_options = ['-Xmx2048m']

--- a/pants.ini
+++ b/pants.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-local_artifact_cache: %(pants_bootstrapdir)s/artifact_cache
+local_artifact_cache: %(buildroot)s/.artifact_cache
 
 [GLOBAL]
 pants_version: 1.2.1

--- a/pants.ini
+++ b/pants.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-local_artifact_cache: %(buildroot)s/.artifact_cache
+local_artifact_cache: %(pants_bootstrapdir)s/artifact_cache
 
 [GLOBAL]
 pants_version: 1.2.1

--- a/tests/shared/src/test/scala/coursier/test/CentralTests.scala
+++ b/tests/shared/src/test/scala/coursier/test/CentralTests.scala
@@ -45,9 +45,6 @@ abstract class CentralTests extends TestSuite {
       .run(fetch0)
       .map { res =>
 
-        if (!res.metadataErrors.isEmpty) {
-          println(s"meta error: ${res.metadataErrors}")
-        }
         assert(res.metadataErrors.isEmpty)
         assert(res.conflicts.isEmpty)
         assert(res.isDone)

--- a/tests/shared/src/test/scala/coursier/test/CentralTests.scala
+++ b/tests/shared/src/test/scala/coursier/test/CentralTests.scala
@@ -2,8 +2,9 @@ package coursier
 package test
 
 import utest._
-import scala.async.Async.{ async, await }
+import scala.async.Async.{async, await}
 
+import coursier.MavenRepository
 import coursier.Platform.fetch
 import coursier.test.compatibility._
 
@@ -507,6 +508,10 @@ abstract class CentralTests extends TestSuite {
     }
 
     'classifier - {
+
+      // Adding extra repo so it's agnostic from nexus which only has the poms
+      val extraRepo = MavenRepository("https://repo1.maven.org/maven2")
+
       'vanilla - {
         async {
           val deps = Set(
@@ -514,7 +519,7 @@ abstract class CentralTests extends TestSuite {
               Module("org.apache.avro", "avro"), "1.8.1"
             )
           )
-          val res = await(resolve(deps))
+          val res = await(resolve(deps, extraRepos = Seq(extraRepo)))
           val filenames: Set[String] = res.artifacts.map(_.url.split("/").last).toSet
           assert(filenames.contains("avro-1.8.1.jar"))
           assert(!filenames.contains("avro-1.8.1-tests.jar"))
@@ -528,7 +533,7 @@ abstract class CentralTests extends TestSuite {
               Module("org.apache.avro", "avro"), "1.8.1", attributes = Attributes("", "tests")
             )
           )
-          val res = await(resolve(deps))
+          val res = await(resolve(deps, extraRepos = Seq(extraRepo)))
           val filenames: Set[String] = res.artifacts.map(_.url.split("/").last).toSet
           assert(!filenames.contains("avro-1.8.1.jar"))
           assert(filenames.contains("avro-1.8.1-tests.jar"))
@@ -545,7 +550,7 @@ abstract class CentralTests extends TestSuite {
               Module("org.apache.avro", "avro"), "1.8.1", attributes = Attributes("", "tests")
             )
           )
-          val res = await(resolve(deps))
+          val res = await(resolve(deps, extraRepos = Seq(extraRepo)))
           val filenames: Set[String] = res.artifacts.map(_.url.split("/").last).toSet
           assert(filenames.contains("avro-1.8.1.jar"))
           assert(filenames.contains("avro-1.8.1-tests.jar"))

--- a/tests/shared/src/test/scala/coursier/test/CentralTests.scala
+++ b/tests/shared/src/test/scala/coursier/test/CentralTests.scala
@@ -44,6 +44,9 @@ abstract class CentralTests extends TestSuite {
       .run(fetch0)
       .map { res =>
 
+        if (!res.metadataErrors.isEmpty) {
+          println(s"meta error: ${res.metadataErrors}")
+        }
         assert(res.metadataErrors.isEmpty)
         assert(res.conflicts.isEmpty)
         assert(res.isDone)
@@ -500,6 +503,43 @@ abstract class CentralTests extends TestSuite {
           "maven-plugin",
           "jar"
         )
+      }
+    }
+
+    'classifier - {
+
+      'vanilla - {
+        async {
+          val deps = Set(
+            Dependency(
+              Module("org.apache.avro", "avro"), "1.8.1", attributes=Attributes("","tests")
+            )
+          )
+
+          val res = await(resolve(deps))
+          println(res.dependencyArtifacts)
+          assert(true)
+          //
+                    assert(res.metadataErrors.isEmpty)
+                    assert(res.conflicts.isEmpty)
+                    assert(res.isDone)
+
+                    val artifacts = res.artifacts
+
+                    val map = artifacts.groupBy(a => a)
+
+                    val nonUnique = map.filter {
+                      case (_, l) => l.length > 1
+                    }
+
+                    if (nonUnique.nonEmpty)
+                      println(
+                        "Found non unique artifacts:\n" +
+                          nonUnique.keys.toVector.map("  " + _).mkString("\n")
+                      )
+
+                    assert(nonUnique.isEmpty)
+        }
       }
     }
 

--- a/tests/shared/src/test/scala/coursier/test/CentralTests.scala
+++ b/tests/shared/src/test/scala/coursier/test/CentralTests.scala
@@ -512,35 +512,54 @@ abstract class CentralTests extends TestSuite {
         async {
           val deps = Set(
             Dependency(
-              Module("org.apache.avro", "avro"), "1.8.1", attributes=Attributes("","tests")
+              Module("org.apache.avro", "avro"), "1.8.1"
             )
           )
 
           val res = await(resolve(deps))
-          println(res.dependencyArtifacts)
-          assert(true)
-          //
-                    assert(res.metadataErrors.isEmpty)
-                    assert(res.conflicts.isEmpty)
-                    assert(res.isDone)
+          val dependencyArtifacts = res.dependencyArtifacts
+          val artifacts = res.artifacts
+          for (art <- dependencyArtifacts.map(_._1)) {
+            println(art)
+          }
+//          println(artifacts.map(_.url).mkString("\n"))
 
-                    val artifacts = res.artifacts
-
-                    val map = artifacts.groupBy(a => a)
-
-                    val nonUnique = map.filter {
-                      case (_, l) => l.length > 1
-                    }
-
-                    if (nonUnique.nonEmpty)
-                      println(
-                        "Found non unique artifacts:\n" +
-                          nonUnique.keys.toVector.map("  " + _).mkString("\n")
-                      )
-
-                    assert(nonUnique.isEmpty)
         }
       }
+
+//      'vanilla - {
+//        async {
+//          val deps = Set(
+//            Dependency(
+//              Module("org.apache.avro", "avro"), "1.8.1", attributes=Attributes("","tests")
+//            )
+//          )
+//
+//          val res = await(resolve(deps))
+//          println(res.dependencyArtifacts)
+//          assert(true)
+//          //
+//                    assert(res.metadataErrors.isEmpty)
+//                    assert(res.conflicts.isEmpty)
+//                    assert(res.isDone)
+//
+//                    val artifacts = res.artifacts
+//
+//                    val map = artifacts.groupBy(a => a)
+//
+//                    val nonUnique = map.filter {
+//                      case (_, l) => l.length > 1
+//                    }
+//
+//                    if (nonUnique.nonEmpty)
+//                      println(
+//                        "Found non unique artifacts:\n" +
+//                          nonUnique.keys.toVector.map("  " + _).mkString("\n")
+//                      )
+//
+//                    assert(nonUnique.isEmpty)
+//        }
+//      }
     }
 
     'artifacts - {

--- a/tests/shared/src/test/scala/coursier/test/CentralTests.scala
+++ b/tests/shared/src/test/scala/coursier/test/CentralTests.scala
@@ -507,7 +507,6 @@ abstract class CentralTests extends TestSuite {
     }
 
     'classifier - {
-
       'vanilla - {
         async {
           val deps = Set(
@@ -515,51 +514,43 @@ abstract class CentralTests extends TestSuite {
               Module("org.apache.avro", "avro"), "1.8.1"
             )
           )
-
           val res = await(resolve(deps))
-          val dependencyArtifacts = res.dependencyArtifacts
-          val artifacts = res.artifacts
-          for (art <- dependencyArtifacts.map(_._1)) {
-            println(art)
-          }
-//          println(artifacts.map(_.url).mkString("\n"))
-
+          val filenames: Set[String] = res.artifacts.map(_.url.split("/").last).toSet
+          assert(filenames.contains("avro-1.8.1.jar"))
+          assert(!filenames.contains("avro-1.8.1-tests.jar"))
         }
       }
 
-//      'vanilla - {
-//        async {
-//          val deps = Set(
-//            Dependency(
-//              Module("org.apache.avro", "avro"), "1.8.1", attributes=Attributes("","tests")
-//            )
-//          )
-//
-//          val res = await(resolve(deps))
-//          println(res.dependencyArtifacts)
-//          assert(true)
-//          //
-//                    assert(res.metadataErrors.isEmpty)
-//                    assert(res.conflicts.isEmpty)
-//                    assert(res.isDone)
-//
-//                    val artifacts = res.artifacts
-//
-//                    val map = artifacts.groupBy(a => a)
-//
-//                    val nonUnique = map.filter {
-//                      case (_, l) => l.length > 1
-//                    }
-//
-//                    if (nonUnique.nonEmpty)
-//                      println(
-//                        "Found non unique artifacts:\n" +
-//                          nonUnique.keys.toVector.map("  " + _).mkString("\n")
-//                      )
-//
-//                    assert(nonUnique.isEmpty)
-//        }
-//      }
+      'tests - {
+        async {
+          val deps = Set(
+            Dependency(
+              Module("org.apache.avro", "avro"), "1.8.1", attributes = Attributes("", "tests")
+            )
+          )
+          val res = await(resolve(deps))
+          val filenames: Set[String] = res.artifacts.map(_.url.split("/").last).toSet
+          assert(!filenames.contains("avro-1.8.1.jar"))
+          assert(filenames.contains("avro-1.8.1-tests.jar"))
+        }
+      }
+
+      'mixed - {
+        async {
+          val deps = Set(
+            Dependency(
+              Module("org.apache.avro", "avro"), "1.8.1"
+            ),
+            Dependency(
+              Module("org.apache.avro", "avro"), "1.8.1", attributes = Attributes("", "tests")
+            )
+          )
+          val res = await(resolve(deps))
+          val filenames: Set[String] = res.artifacts.map(_.url.split("/").last).toSet
+          assert(filenames.contains("avro-1.8.1.jar"))
+          assert(filenames.contains("avro-1.8.1-tests.jar"))
+        }
+      }
     }
 
     'artifacts - {

--- a/tests/shared/src/test/scala/coursier/test/ParseTests.scala
+++ b/tests/shared/src/test/scala/coursier/test/ParseTests.scala
@@ -51,7 +51,7 @@ object ParseTests extends TestSuite {
 
     // Module parsing tests
     "org:name:version" - {
-      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4", Set(), Map(), "2.11.11") match {
+      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4", Set(), Map(), transitive = true, "2.11.11") match {
         case Left(err) => assert(false)
         case Right(dep) =>
           assert(dep.module.organization == "org.apache.avro")
@@ -63,7 +63,7 @@ object ParseTests extends TestSuite {
     }
 
     "org:name:version:conifg" - {
-      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4:runtime", Set(), Map(), "2.11.11") match {
+      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4:runtime", Set(), Map(), transitive = true, "2.11.11") match {
         case Left(err) => assert(false)
         case Right(dep) =>
           assert(dep.module.organization == "org.apache.avro")
@@ -75,7 +75,7 @@ object ParseTests extends TestSuite {
     }
 
     "single attr" - {
-      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4:runtime,classifier=tests", Set(), Map(), "2.11.11") match {
+      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4:runtime,classifier=tests", Set(), Map(), transitive = true, "2.11.11") match {
         case Left(err) => assert(false)
         case Right(dep) =>
           assert(dep.module.organization == "org.apache.avro")
@@ -87,7 +87,7 @@ object ParseTests extends TestSuite {
     }
 
     "multiple attrs" - {
-      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4:runtime,classifier=tests,nickname=superman", Set(), Map(), "2.11.11") match {
+      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4:runtime,classifier=tests,nickname=superman", Set(), Map(), transitive = true, "2.11.11") match {
         case Left(err) => assert(false)
         case Right(dep) =>
           assert(dep.module.organization == "org.apache.avro")
@@ -99,7 +99,7 @@ object ParseTests extends TestSuite {
     }
 
     "single attr with org::name:version" - {
-      Parse.moduleVersionConfig("io.get-coursier.scala-native::sandbox_native0.3:0.3.0-coursier-1,attr1=val1", Set(), Map(), "2.11.11") match {
+      Parse.moduleVersionConfig("io.get-coursier.scala-native::sandbox_native0.3:0.3.0-coursier-1,attr1=val1", Set(), Map(), transitive = true, "2.11.11") match {
         case Left(err) => assert(false)
         case Right(dep) =>
           assert(dep.module.organization == "io.get-coursier.scala-native")
@@ -110,7 +110,7 @@ object ParseTests extends TestSuite {
 
     "illegal 1" - {
       try {
-        Parse.moduleVersionConfig("org.apache.avro:avro,1.7.4:runtime,classifier=tests", Set(), Map(), "2.11.11")
+        Parse.moduleVersionConfig("org.apache.avro:avro,1.7.4:runtime,classifier=tests", Set(), Map(), transitive = true, "2.11.11")
         assert(false) // Parsing should fail but succeeded.
       }
       catch {
@@ -121,7 +121,7 @@ object ParseTests extends TestSuite {
 
     "illegal 2" - {
       try {
-        Parse.moduleVersionConfig("junit:junit:4.12,attr", Set(), Map(), "2.11.11")
+        Parse.moduleVersionConfig("junit:junit:4.12,attr", Set(), Map(), transitive = true, "2.11.11")
         assert(false) // Parsing should fail but succeeded.
       }
       catch {

--- a/tests/shared/src/test/scala/coursier/test/ParseTests.scala
+++ b/tests/shared/src/test/scala/coursier/test/ParseTests.scala
@@ -1,9 +1,9 @@
 package coursier.test
 
-import coursier.{MavenRepository, Repository, Attributes}
+import coursier.{Attributes, MavenRepository, Repository}
 import coursier.ivy.IvyRepository
 import coursier.util.Parse
-import coursier.util.Parse.ModuleParseError
+import coursier.util.Parse.{ModuleParseError, ModuleRequirements}
 import utest._
 
 object ParseTests extends TestSuite {
@@ -51,19 +51,19 @@ object ParseTests extends TestSuite {
 
     // Module parsing tests
     "org:name:version" - {
-      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4", Set(), Map(), transitive = true, "2.11.11") match {
+      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4", ModuleRequirements(), transitive = true, "2.11.11") match {
         case Left(err) => assert(false)
         case Right(dep) =>
           assert(dep.module.organization == "org.apache.avro")
           assert(dep.module.name == "avro")
           assert(dep.version == "1.7.4")
-          assert(dep.configuration.isEmpty)
+          assert(dep.configuration == "default(compile)")
           assert(dep.attributes == Attributes())
       }
     }
 
     "org:name:version:conifg" - {
-      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4:runtime", Set(), Map(), transitive = true, "2.11.11") match {
+      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4:runtime", ModuleRequirements(), transitive = true, "2.11.11") match {
         case Left(err) => assert(false)
         case Right(dep) =>
           assert(dep.module.organization == "org.apache.avro")
@@ -75,7 +75,7 @@ object ParseTests extends TestSuite {
     }
 
     "single attr" - {
-      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4:runtime,classifier=tests", Set(), Map(), transitive = true, "2.11.11") match {
+      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4:runtime,classifier=tests", ModuleRequirements(), transitive = true, "2.11.11") match {
         case Left(err) => assert(false)
         case Right(dep) =>
           assert(dep.module.organization == "org.apache.avro")
@@ -87,7 +87,7 @@ object ParseTests extends TestSuite {
     }
 
     "multiple attrs" - {
-      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4:runtime,classifier=tests,nickname=superman", Set(), Map(), transitive = true, "2.11.11") match {
+      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4:runtime,classifier=tests,nickname=superman", ModuleRequirements(), transitive = true, "2.11.11") match {
         case Left(err) => assert(false)
         case Right(dep) =>
           assert(dep.module.organization == "org.apache.avro")
@@ -99,7 +99,7 @@ object ParseTests extends TestSuite {
     }
 
     "single attr with org::name:version" - {
-      Parse.moduleVersionConfig("io.get-coursier.scala-native::sandbox_native0.3:0.3.0-coursier-1,attr1=val1", Set(), Map(), transitive = true, "2.11.11") match {
+      Parse.moduleVersionConfig("io.get-coursier.scala-native::sandbox_native0.3:0.3.0-coursier-1,attr1=val1", ModuleRequirements(), transitive = true, "2.11.11") match {
         case Left(err) => assert(false)
         case Right(dep) =>
           assert(dep.module.organization == "io.get-coursier.scala-native")
@@ -110,7 +110,7 @@ object ParseTests extends TestSuite {
 
     "illegal 1" - {
       try {
-        Parse.moduleVersionConfig("org.apache.avro:avro,1.7.4:runtime,classifier=tests", Set(), Map(), transitive = true, "2.11.11")
+        Parse.moduleVersionConfig("org.apache.avro:avro,1.7.4:runtime,classifier=tests", ModuleRequirements(), transitive = true, "2.11.11")
         assert(false) // Parsing should fail but succeeded.
       }
       catch {
@@ -121,7 +121,7 @@ object ParseTests extends TestSuite {
 
     "illegal 2" - {
       try {
-        Parse.moduleVersionConfig("junit:junit:4.12,attr", Set(), Map(), transitive = true, "2.11.11")
+        Parse.moduleVersionConfig("junit:junit:4.12,attr", ModuleRequirements(), transitive = true, "2.11.11")
         assert(false) // Parsing should fail but succeeded.
       }
       catch {

--- a/tests/shared/src/test/scala/coursier/test/ParseTests.scala
+++ b/tests/shared/src/test/scala/coursier/test/ParseTests.scala
@@ -51,7 +51,7 @@ object ParseTests extends TestSuite {
 
     // Module parsing tests
     "org:name:version" - {
-      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4") match {
+      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4", "2.11.11") match {
         case Left(err) => assert(false)
         case Right(parsedModule) =>
           assert(parsedModule.module.organization == "org.apache.avro")
@@ -63,7 +63,7 @@ object ParseTests extends TestSuite {
     }
 
     "org:name:version:conifg" - {
-      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4:runtime") match {
+      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4:runtime", "2.11.11") match {
         case Left(err) => assert(false)
         case Right(parsedModule) =>
           assert(parsedModule.module.organization == "org.apache.avro")
@@ -75,7 +75,7 @@ object ParseTests extends TestSuite {
     }
 
     "single attr" - {
-      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4:runtime,classifier=tests") match {
+      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4:runtime,classifier=tests", "2.11.11") match {
         case Left(err) => assert(false)
         case Right(parsedModule) =>
           assert(parsedModule.module.organization == "org.apache.avro")
@@ -87,7 +87,7 @@ object ParseTests extends TestSuite {
     }
 
     "multiple attrs" - {
-      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4:runtime,classifier=tests,nickname=superman") match {
+      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4:runtime,classifier=tests,nickname=superman", "2.11.11") match {
         case Left(err) => assert(false)
         case Right(parsedModule) =>
           assert(parsedModule.module.organization == "org.apache.avro")
@@ -99,7 +99,7 @@ object ParseTests extends TestSuite {
     }
 
     "single attr with org::name:version" - {
-      Parse.moduleVersionConfig("io.get-coursier.scala-native::sandbox_native0.3:0.3.0-coursier-1,attr1=val1") match {
+      Parse.moduleVersionConfig("io.get-coursier.scala-native::sandbox_native0.3:0.3.0-coursier-1,attr1=val1", "2.11.11") match {
         case Left(err) => assert(false)
         case Right(parsedModule) =>
           assert(parsedModule.module.organization == "io.get-coursier.scala-native")
@@ -111,7 +111,7 @@ object ParseTests extends TestSuite {
 
     "illegal 1" - {
       try {
-        Parse.moduleVersionConfig("org.apache.avro:avro,1.7.4:runtime,classifier=tests")
+        Parse.moduleVersionConfig("org.apache.avro:avro,1.7.4:runtime,classifier=tests", "2.11.11")
         assert(false) // Parsing should fail but succeeded.
       }
       catch {
@@ -122,7 +122,7 @@ object ParseTests extends TestSuite {
 
     "illegal 2" - {
       try {
-        Parse.moduleVersionConfig("junit:junit:4.12,attr")
+        Parse.moduleVersionConfig("junit:junit:4.12,attr", "2.11.11")
         assert(false) // Parsing should fail but succeeded.
       }
       catch {

--- a/tests/shared/src/test/scala/coursier/test/ParseTests.scala
+++ b/tests/shared/src/test/scala/coursier/test/ParseTests.scala
@@ -74,8 +74,8 @@ object ParseTests extends TestSuite {
       }
     }
 
-    "org:name:version:conifg::attr1=val1" - {
-      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4:runtime::classifier=tests") match {
+    "single attr" - {
+      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4:runtime:::classifier=tests") match {
         case Left(err) => assert(false)
         case Right(parsedModule) =>
           assert(parsedModule.module.organization == "org.apache.avro")
@@ -86,8 +86,8 @@ object ParseTests extends TestSuite {
       }
     }
 
-    "org:name:version:conifg::attr1=val1::attr2=val2" - {
-      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4:runtime::classifier=tests::nickname=superman") match {
+    "multiple attrs" - {
+      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4:runtime:::classifier=tests:::nickname=superman") match {
         case Left(err) => assert(false)
         case Right(parsedModule) =>
           assert(parsedModule.module.organization == "org.apache.avro")
@@ -100,7 +100,7 @@ object ParseTests extends TestSuite {
 
     "illegal 1" - {
       try {
-        val s = "org.apache.avro:avro::1.7.4:runtime::classifier=tests"
+        val s = "org.apache.avro:avro:::1.7.4:runtime:::classifier=tests"
         Parse.moduleVersionConfig(s)
         assert(false) // Parsing should fail but succeeded.
       }
@@ -112,8 +112,7 @@ object ParseTests extends TestSuite {
 
     "illegal 2" - {
       try {
-        val s = "junit:junit:4.12::attr"
-        Parse.moduleVersionConfig(s)
+        Parse.moduleVersionConfig("junit:junit:4.12:::attr")
         assert(false) // Parsing should fail but succeeded.
       }
       catch {

--- a/tests/shared/src/test/scala/coursier/test/ParseTests.scala
+++ b/tests/shared/src/test/scala/coursier/test/ParseTests.scala
@@ -1,6 +1,6 @@
 package coursier.test
 
-import coursier.{MavenRepository, Repository}
+import coursier.{MavenRepository, Repository, Attributes}
 import coursier.ivy.IvyRepository
 import coursier.util.Parse
 import coursier.util.Parse.ModuleParseError
@@ -51,83 +51,82 @@ object ParseTests extends TestSuite {
 
     // Module parsing tests
     "org:name:version" - {
-      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4", "2.11.11") match {
+      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4", Set(), Map(), "2.11.11") match {
         case Left(err) => assert(false)
-        case Right(parsedModule) =>
-          assert(parsedModule.module.organization == "org.apache.avro")
-          assert(parsedModule.module.name == "avro")
-          assert(parsedModule.version == "1.7.4")
-          assert(parsedModule.config.isEmpty)
-          assert(parsedModule.attrs.isEmpty)
+        case Right(dep) =>
+          assert(dep.module.organization == "org.apache.avro")
+          assert(dep.module.name == "avro")
+          assert(dep.version == "1.7.4")
+          assert(dep.configuration.isEmpty)
+          assert(dep.attributes == Attributes())
       }
     }
 
     "org:name:version:conifg" - {
-      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4:runtime", "2.11.11") match {
+      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4:runtime", Set(), Map(), "2.11.11") match {
         case Left(err) => assert(false)
-        case Right(parsedModule) =>
-          assert(parsedModule.module.organization == "org.apache.avro")
-          assert(parsedModule.module.name == "avro")
-          assert(parsedModule.version == "1.7.4")
-          assert(parsedModule.config == Some("runtime"))
-          assert(parsedModule.attrs.isEmpty)
+        case Right(dep) =>
+          assert(dep.module.organization == "org.apache.avro")
+          assert(dep.module.name == "avro")
+          assert(dep.version == "1.7.4")
+          assert(dep.configuration == "runtime")
+          assert(dep.attributes == Attributes())
       }
     }
 
     "single attr" - {
-      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4:runtime,classifier=tests", "2.11.11") match {
+      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4:runtime,classifier=tests", Set(), Map(), "2.11.11") match {
         case Left(err) => assert(false)
-        case Right(parsedModule) =>
-          assert(parsedModule.module.organization == "org.apache.avro")
-          assert(parsedModule.module.name == "avro")
-          assert(parsedModule.version == "1.7.4")
-          assert(parsedModule.config == Some("runtime"))
-          assert(parsedModule.attrs == Map("classifier" -> "tests"))
+        case Right(dep) =>
+          assert(dep.module.organization == "org.apache.avro")
+          assert(dep.module.name == "avro")
+          assert(dep.version == "1.7.4")
+          assert(dep.configuration == "runtime")
+          assert(dep.attributes == Attributes("", "tests"))
       }
     }
 
     "multiple attrs" - {
-      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4:runtime,classifier=tests,nickname=superman", "2.11.11") match {
+      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4:runtime,classifier=tests,nickname=superman", Set(), Map(), "2.11.11") match {
         case Left(err) => assert(false)
-        case Right(parsedModule) =>
-          assert(parsedModule.module.organization == "org.apache.avro")
-          assert(parsedModule.module.name == "avro")
-          assert(parsedModule.version == "1.7.4")
-          assert(parsedModule.config == Some("runtime"))
-          assert(parsedModule.attrs == Map("classifier" -> "tests", "nickname" -> "superman"))
+        case Right(dep) =>
+          assert(dep.module.organization == "org.apache.avro")
+          assert(dep.module.name == "avro")
+          assert(dep.version == "1.7.4")
+          assert(dep.configuration == "runtime")
+          assert(dep.attributes == Attributes("", "tests"))
       }
     }
 
     "single attr with org::name:version" - {
-      Parse.moduleVersionConfig("io.get-coursier.scala-native::sandbox_native0.3:0.3.0-coursier-1,attr1=val1", "2.11.11") match {
+      Parse.moduleVersionConfig("io.get-coursier.scala-native::sandbox_native0.3:0.3.0-coursier-1,attr1=val1", Set(), Map(), "2.11.11") match {
         case Left(err) => assert(false)
-        case Right(parsedModule) =>
-          assert(parsedModule.module.organization == "io.get-coursier.scala-native")
-          assert(parsedModule.module.name.contains("sandbox_native0.3")) // use `contains` to be scala version agnostic
-          assert(parsedModule.version == "0.3.0-coursier-1")
-          assert(parsedModule.attrs == Map("attr1" -> "val1"))
+        case Right(dep) =>
+          assert(dep.module.organization == "io.get-coursier.scala-native")
+          assert(dep.module.name.contains("sandbox_native0.3")) // use `contains` to be scala version agnostic
+          assert(dep.version == "0.3.0-coursier-1")
       }
     }
 
     "illegal 1" - {
       try {
-        Parse.moduleVersionConfig("org.apache.avro:avro,1.7.4:runtime,classifier=tests", "2.11.11")
+        Parse.moduleVersionConfig("org.apache.avro:avro,1.7.4:runtime,classifier=tests", Set(), Map(), "2.11.11")
         assert(false) // Parsing should fail but succeeded.
       }
       catch {
         case foo: ModuleParseError => assert(foo.getMessage().contains("':' is not allowed in attribute")) // do nothing
-        case _: Throwable =>  assert(false) // Unexpected exception
+        case _: Throwable => assert(false) // Unexpected exception
       }
     }
 
     "illegal 2" - {
       try {
-        Parse.moduleVersionConfig("junit:junit:4.12,attr", "2.11.11")
+        Parse.moduleVersionConfig("junit:junit:4.12,attr", Set(), Map(), "2.11.11")
         assert(false) // Parsing should fail but succeeded.
       }
       catch {
         case foo: ModuleParseError => assert(foo.getMessage().contains("Failed to parse attribute")) // do nothing
-        case _: Throwable =>  assert(false) // Unexpected exception
+        case _: Throwable => assert(false) // Unexpected exception
       }
     }
   }

--- a/tests/shared/src/test/scala/coursier/test/ParseTests.scala
+++ b/tests/shared/src/test/scala/coursier/test/ParseTests.scala
@@ -98,7 +98,7 @@ object ParseTests extends TestSuite {
       }
     }
 
-    "single attr with org:<empty>:version" - {
+    "single attr with org::name:version" - {
       Parse.moduleVersionConfig("io.get-coursier.scala-native::sandbox_native0.3:0.3.0-coursier-1,attr1=val1") match {
         case Left(err) => assert(false)
         case Right(parsedModule) =>
@@ -111,8 +111,7 @@ object ParseTests extends TestSuite {
 
     "illegal 1" - {
       try {
-        val s = "org.apache.avro:avro,1.7.4:runtime,classifier=tests"
-        Parse.moduleVersionConfig(s)
+        Parse.moduleVersionConfig("org.apache.avro:avro,1.7.4:runtime,classifier=tests")
         assert(false) // Parsing should fail but succeeded.
       }
       catch {

--- a/tests/shared/src/test/scala/coursier/test/ParseTests.scala
+++ b/tests/shared/src/test/scala/coursier/test/ParseTests.scala
@@ -75,7 +75,7 @@ object ParseTests extends TestSuite {
     }
 
     "single attr" - {
-      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4:runtime:::classifier=tests") match {
+      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4:runtime,classifier=tests") match {
         case Left(err) => assert(false)
         case Right(parsedModule) =>
           assert(parsedModule.module.organization == "org.apache.avro")
@@ -87,7 +87,7 @@ object ParseTests extends TestSuite {
     }
 
     "multiple attrs" - {
-      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4:runtime:::classifier=tests:::nickname=superman") match {
+      Parse.moduleVersionConfig("org.apache.avro:avro:1.7.4:runtime,classifier=tests,nickname=superman") match {
         case Left(err) => assert(false)
         case Right(parsedModule) =>
           assert(parsedModule.module.organization == "org.apache.avro")
@@ -98,9 +98,20 @@ object ParseTests extends TestSuite {
       }
     }
 
+    "single attr with org:<empty>:version" - {
+      Parse.moduleVersionConfig("io.get-coursier.scala-native::sandbox_native0.3:0.3.0-coursier-1,attr1=val1") match {
+        case Left(err) => assert(false)
+        case Right(parsedModule) =>
+          assert(parsedModule.module.organization == "io.get-coursier.scala-native")
+          assert(parsedModule.module.name.contains("sandbox_native0.3")) // use `contains` to be scala version agnostic
+          assert(parsedModule.version == "0.3.0-coursier-1")
+          assert(parsedModule.attrs == Map("attr1" -> "val1"))
+      }
+    }
+
     "illegal 1" - {
       try {
-        val s = "org.apache.avro:avro:::1.7.4:runtime:::classifier=tests"
+        val s = "org.apache.avro:avro,1.7.4:runtime,classifier=tests"
         Parse.moduleVersionConfig(s)
         assert(false) // Parsing should fail but succeeded.
       }
@@ -112,7 +123,7 @@ object ParseTests extends TestSuite {
 
     "illegal 2" - {
       try {
-        Parse.moduleVersionConfig("junit:junit:4.12:::attr")
+        Parse.moduleVersionConfig("junit:junit:4.12,attr")
         assert(false) // Parsing should fail but succeeded.
       }
       catch {


### PR DESCRIPTION
Currently `--classifier` is applied to all modules requested on CLI, so this change add the capability to specify classifier for each module.
```
fetch -t \
org.apache.commons:commons-compress:1.5,classifier=tests \
org.apache.commons:commons-compress:1.5
```

Fix for #717