### PR TITLE
fixing sbt build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -89,6 +89,7 @@ lazy val `proxy-tests` = project
 lazy val paths = project
   .disablePlugins(ScriptedPlugin)
   .settings(
+    libs += Deps.soc,
     pureJava,
     dontPublish,
     addDirectoriesSources
@@ -101,7 +102,7 @@ lazy val cache = project
     shared,
     Mima.previousArtifacts,
     coursierPrefix,
-    libs += Deps.scalazConcurrent,
+    libs ++= Seq(Deps.scalazConcurrent, Deps.soc),
     Mima.cacheFilters,
     addPathsSources
   )
@@ -112,6 +113,7 @@ lazy val bootstrap = project
     pureJava,
     dontPublish,
     addPathsSources,
+    libs += Deps.soc,
     // seems not to be automatically found with sbt 0.13.16-M1 :-/
     mainClass := Some("coursier.Bootstrap"),
     renameMainJar("bootstrap.jar")

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -16,7 +16,7 @@ object Deps {
   def jackson = "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.8.4"
   def scalatest = "org.scalatest" %% "scalatest" % "3.0.0"
   def junit = "junit" % "junit" % "4.12"
-
+  def soc = "io.github.soc" % "directories" % "5"
   def sbtPgp = Def.setting {
     val sbtv = CrossVersion.binarySbtVersion(sbtVersion.in(pluginCrossBuild).value)
     val sv = scalaBinaryVersion.value


### PR DESCRIPTION
sbt missing dependencies in in cache and paths subprojects

[error] /usr/share/src/coursier/paths/src/main/java/coursier/CoursierPaths.java:5:1: package io.github.soc.directories does not exist
[error] import io.github.soc.directories.ProjectDirectories;
[error] /usr/share/src/coursier/paths/src/main/java/coursier/CoursierPaths.java:19:1: cannot find symbol
[error]   symbol:   class ProjectDirectories
[error]   location: class coursier.CoursierPaths
[error]     private static ProjectDirectories coursierDirectories;
[error] /usr/share/src/coursier/paths/src/main/java/coursier/CoursierPaths.java:61:1: cannot find symbol
[error]   symbol:   variable ProjectDirectories
[error]   location: class coursier.CoursierPaths
[error]                     coursierDirectories = ProjectDirectories.fromProjectName("Coursier");
[error] (cache/compile:compileIncremental) javac returned non-zero exit code
[error] Total time: 6 s, completed Jan 12, 2018 2:24:28 AM
