### PR TITLE
Import correct resolver from librarymanagement

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -237,9 +237,9 @@ lazy val `sbt-shared` = project
   .settings(
     plugin,
     utest,
-//  addSbtPlugin("com.dwijnand" % "sbt-compat" % "1.2.0")
+//  addSbtPlugin("com.dwijnand" % "sbt-compat" % "1.2.0+2-f30b82f4")
     libs ++= {
-      val dependency = "com.dwijnand" % "sbt-compat" % "1.2.0"
+      val dependency = "com.dwijnand" % "sbt-compat" % "1.2.0+2-f30b82f4"
       val sbtV = (sbtBinaryVersion in pluginCrossBuild).value
       val scalaV = (scalaBinaryVersion in update).value
       val m = Defaults.sbtPluginExtra(dependency, sbtV, scalaV)

--- a/sbt-shared/src/main/scala/coursier/FromSbt.scala
+++ b/sbt-shared/src/main/scala/coursier/FromSbt.scala
@@ -7,7 +7,7 @@ import java.net.{MalformedURLException, URL}
 import coursier.core.Authentication
 import sbt.internal.librarymanagement.mavenint.SbtPomExtraProperties
 import sbt.librarymanagement._
-import sbt.{CrossVersion, ModuleID, Resolver}
+import sbt.{CrossVersion, ModuleID}
 
 import scalaz.{-\/, \/-}
 

--- a/sbt-shared/src/main/scala/coursier/FromSbt.scala
+++ b/sbt-shared/src/main/scala/coursier/FromSbt.scala
@@ -7,6 +7,7 @@ import java.net.{MalformedURLException, URL}
 import coursier.core.Authentication
 import sbt.internal.librarymanagement.mavenint.SbtPomExtraProperties
 import sbt.librarymanagement._
+import sbt.librarymanagement.Resolver
 import sbt.{CrossVersion, ModuleID}
 
 import scalaz.{-\/, \/-}

--- a/tests/shared/src/test/resources/resolutions/org.webjars.bower/malihu-custom-scrollbar-plugin/3.1.5
+++ b/tests/shared/src/test/resources/resolutions/org.webjars.bower/malihu-custom-scrollbar-plugin/3.1.5
@@ -1,3 +1,3 @@
-org.webjars.bower:jquery:3.2.1:compile
+org.webjars.bower:jquery:3.3.1:compile
 org.webjars.bower:jquery-mousewheel:3.1.13:compile
 org.webjars.bower:malihu-custom-scrollbar-plugin:3.1.5:compile

--- a/tests/shared/src/test/resources/resolutions/org.webjars.bower/malihu-custom-scrollbar-plugin/3.1.5
+++ b/tests/shared/src/test/resources/resolutions/org.webjars.bower/malihu-custom-scrollbar-plugin/3.1.5
@@ -1,3 +1,3 @@
-org.webjars.bower:jquery:3.3.1:compile
+org.webjars.bower:jquery:3.2.1:compile
 org.webjars.bower:jquery-mousewheel:3.1.13:compile
 org.webjars.bower:malihu-custom-scrollbar-plugin:3.1.5:compile


### PR DESCRIPTION
This might be a solution for #745 by importing the correct version of the `Resolver` type from `sbt.librarymanagement` rather than `sbt` thereby sidestepping the issue described here: https://github.com/sbt/librarymanagement/pull/190#issuecomment-358897786