### PR TITLE
[sbt-shared] Use sbt.util.Logger instead of sbt.Logger

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -241,7 +241,7 @@ lazy val `sbt-shared` = project
     // because we don't publish for 2.11 the following declaration
     // is more wordy than usual
     libs ++= {
-      val dependency = "com.dwijnand" % "sbt-compat" % "1.2.1"
+      val dependency = "com.dwijnand" % "sbt-compat" % "1.2.2"
       val sbtV = (sbtBinaryVersion in pluginCrossBuild).value
       val scalaV = (scalaBinaryVersion in update).value
       val m = Defaults.sbtPluginExtra(dependency, sbtV, scalaV)

--- a/sbt-shared/src/main/scala/coursier/FromSbt.scala
+++ b/sbt-shared/src/main/scala/coursier/FromSbt.scala
@@ -8,6 +8,7 @@ import coursier.core.Authentication
 import sbt.internal.librarymanagement.mavenint.SbtPomExtraProperties
 import sbt.librarymanagement._
 import sbt.librarymanagement.Resolver
+import sbt.util.Logger
 import sbt.{CrossVersion, ModuleID}
 
 import scalaz.{-\/, \/-}
@@ -176,7 +177,7 @@ object FromSbt {
 
   private def mavenRepositoryOpt(
     root: String,
-    log: sbt.Logger,
+    log: Logger,
     authentication: Option[Authentication]
   ): Option[MavenRepository] =
     try {
@@ -203,7 +204,7 @@ object FromSbt {
   def repository(
     resolver: Resolver,
     ivyProperties: Map[String, String],
-    log: sbt.Logger,
+    log: Logger,
     authentication: Option[Authentication]
   ): Option[Repository] =
     resolver match {

--- a/sbt-shared/src/main/scala/coursier/ToSbt.scala
+++ b/sbt-shared/src/main/scala/coursier/ToSbt.scala
@@ -5,6 +5,7 @@ import java.util.GregorianCalendar
 import java.util.concurrent.ConcurrentHashMap
 
 import sbt.librarymanagement._
+import sbt.util.Logger
 import coursier.maven.MavenSource
 
 object ToSbt {
@@ -126,7 +127,7 @@ object ToSbt {
     res: Resolution,
     classifiersOpt: Option[Seq[String]],
     artifactFileOpt: (Module, String, Artifact) => Option[File],
-    log: sbt.Logger,
+    log: Logger,
     keepPomArtifact: Boolean = false,
     includeSignatures: Boolean = false
   ) = {
@@ -214,7 +215,7 @@ object ToSbt {
     configs: Map[String, Set[String]],
     classifiersOpt: Option[Seq[String]],
     artifactFileOpt: (Module, String, Artifact) => Option[File],
-    log: sbt.Logger,
+    log: Logger,
     keepPomArtifact: Boolean = false,
     includeSignatures: Boolean = false
   ): sbt.UpdateReport = {


### PR DESCRIPTION
This is the same problem as #746.

As of sbt 1.0.0 the type has moved to `sbt.util` and using the old one creates a weird compilation issue when trying to integrate with coursier with sbt.

See https://travis-ci.org/sbt/librarymanagement/jobs/336516938#L625