### PR TITLE
Remove more sbt._ types from sbt-shared

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -245,8 +245,9 @@ lazy val `sbt-shared` = project
     utest,
     // because we don't publish for 2.11 the following declaration
     // is more wordy than usual
+    // once support for sbt 0.13 is removed, this dependency can go away
     libs ++= {
-      val dependency = "com.dwijnand" % "sbt-compat" % "1.2.5"
+      val dependency = "com.dwijnand" % "sbt-compat" % "1.2.6"
       val sbtV = (sbtBinaryVersion in pluginCrossBuild).value
       val scalaV = (scalaBinaryVersion in update).value
       val m = Defaults.sbtPluginExtra(dependency, sbtV, scalaV)

--- a/sbt-shared/src/main/scala/coursier/ToSbt.scala
+++ b/sbt-shared/src/main/scala/coursier/ToSbt.scala
@@ -61,7 +61,7 @@ object ToSbt {
             .orElse(MavenSource.typeDefaultClassifierOpt(artifact.attributes.`type`))
         )
         // .withConfigurations(Vector())
-        .withUrl(Some(sbt.url(artifact.url)))
+        .withUrl(Some(url(artifact.url)))
         .withExtraAttributes(module.attributes ++ extraProperties)
   }
 
@@ -83,7 +83,7 @@ object ToSbt {
 
     val callers = dependees.map {
       case (dependee, dependeeProj) =>
-        sbt.Caller(
+        Caller(
           ToSbt.moduleId(dependee, dependeeProj.properties.toMap),
           dependeeProj.configurations.keys.toVector.map(ConfigRef(_)),
           dependee.module.attributes ++ dependeeProj.properties,
@@ -95,7 +95,7 @@ object ToSbt {
         )
     }
 
-    sbt.ModuleReport(
+    ModuleReport(
       ToSbt.moduleId(dependency, project.properties.toMap),
       sbtArtifacts.toVector,
       sbtMissingArtifacts.toVector
@@ -250,7 +250,7 @@ object ToSbt {
           } else
             reports.toVector
 
-        sbt.ConfigurationReport(
+        ConfigurationReport(
           ConfigRef(config),
           reports0,
           Vector()

--- a/sbt-shared/src/main/scala/coursier/ToSbt.scala
+++ b/sbt-shared/src/main/scala/coursier/ToSbt.scala
@@ -1,6 +1,7 @@
 package coursier
 
 import java.io.File
+import java.net.URL
 import java.util.GregorianCalendar
 import java.util.concurrent.ConcurrentHashMap
 
@@ -61,7 +62,7 @@ object ToSbt {
             .orElse(MavenSource.typeDefaultClassifierOpt(artifact.attributes.`type`))
         )
         // .withConfigurations(Vector())
-        .withUrl(Some(url(artifact.url)))
+        .withUrl(Some(new URL(artifact.url)))
         .withExtraAttributes(module.attributes ++ extraProperties)
   }
 


### PR DESCRIPTION
I found a few more types from the sbt._ namespace.