### PR TITLE
Update Pants development instructions for Scala 2.12

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -142,17 +142,17 @@ $ sbt ++2.12.4 proxy-tests/it:test
 
 [Pants](https://github.com/pantsbuild/pants) build tool is also added to an experimental path to build the software
 
-Currently only the CLI command can be built via Pants with Scala 2.11.11.
+Currently only the CLI command can be built via Pants with Scala 2.12.4.
 
 To iterate on code changes:
 
 ```
-./pants run cli/src/main/scala-2.11:coursier-cli -- fetch --help
+./pants run cli/src/main/scala-2.12:coursier-cli -- fetch --help
 ```
 
 To build a distributable binary
 ```
-./pants binary cli/src/main/scala-2.11:coursier-cli
+./pants binary cli/src/main/scala-2.12:coursier-cli
 
 # Artifact will be placed under dist/
 java -jar dist/coursier-cli.jar fetch --help


### PR DESCRIPTION
The Pants build targets have moved to 2.12. This updates the instructions to account for that.