### PR TITLE
Use less things from scalaz

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,10 +181,9 @@ These would mean that the resolution wasn't able to get metadata about some depe
 Then fetch and get local copies of the artifacts themselves (the JARs) with
 ```scala
 import java.io.File
-import scalaz.\/
 import scalaz.concurrent.Task
 
-val localArtifacts: Seq[FileError \/ File] = Task.gatherUnordered(
+val localArtifacts: Seq[Either[FileError, File]] = Task.gatherUnordered(
   resolution.artifacts.map(Cache.file(_).run)
 ).unsafePerformSync
 ```
@@ -509,7 +508,7 @@ res6: coursier.maven.MavenRepository = MavenRepository(https://nexus.corp.com/co
 
 Now that we have repositories, we're going to mix these with things from the `coursier-cache` module,
 for resolution to happen via the cache. We'll create a function
-of type `Seq[(Module, String)] => F[Seq[((Module, String), Seq[String] \/ (Artifact.Source, Project))]]`.
+of type `Seq[(Module, String)] => F[Seq[((Module, String), Either[Seq[String], (Artifact.Source, Project)])]]`.
 Given a sequence of dependencies, designated by their `Module` (organisation and name in most cases)
 and version (just a `String`), it gives either errors (`Seq[String]`) or metadata (`(Artifact.Source, Project)`),
 wrapping the whole in a monad `F`.
@@ -564,10 +563,9 @@ which are dependencies whose versions could not be unified.
 Then, if all went well, we can fetch and get local copies of the artifacts themselves (the JARs) with
 ```scala
 import java.io.File
-import scalaz.\/
 import scalaz.concurrent.Task
 
-val localArtifacts: Seq[FileError \/ File] = Task.gatherUnordered(
+val localArtifacts: Seq[Either[FileError, File]] = Task.gatherUnordered(
   resolution.artifacts.map(Cache.file(_).run)
 ).unsafePerformSync
 ```

--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ libraryDependencies ++= Seq(
 )
 ```
 
+Note that the examples below are validated against the current sources of coursier. You may want to read the [documentation of the latest release](https://github.com/coursier/coursier/blob/v1.0.2/README.md#api) of coursier instead.
+
 Add an import for coursier,
 ```scala
 import coursier._
@@ -420,6 +422,8 @@ libraryDependencies ++= Seq(
   "io.get-coursier" %% "coursier-cache" % "1.0.1"
 )
 ```
+
+Note that the examples below are validated against the current sources of coursier. You may want to read the [documentation of the latest release](https://github.com/coursier/coursier/blob/v1.0.2/README.md#api-1) of coursier instead.
 
 The first module, `"io.get-coursier" %% "coursier" % "1.0.1"`, mainly depends on
 `scalaz-core` (and only it, *not* `scalaz-concurrent` for example). It contains among others,

--- a/cache/src/main/scala/coursier/CachePolicy.scala
+++ b/cache/src/main/scala/coursier/CachePolicy.scala
@@ -1,5 +1,7 @@
 package coursier
 
+import scalaz.{Failure, Success}
+
 sealed abstract class CachePolicy extends Product with Serializable
 
 object CachePolicy {
@@ -80,14 +82,14 @@ object CachePolicy {
       value.filter(_.nonEmpty).flatMap {
         str =>
           CacheParse.cachePolicies(str) match {
-            case scalaz.Success(Seq()) =>
+            case Success(Seq()) =>
               Console.err.println(
                 s"Warning: no mode found in $description, ignoring it."
               )
               None
-            case scalaz.Success(policies) =>
+            case Success(policies) =>
               Some(policies)
-            case scalaz.Failure(errors) =>
+            case Failure(errors) =>
               Console.err.println(
                 s"Warning: unrecognized mode in $description, ignoring it."
               )

--- a/cli/src/main/scala-2.12/coursier/cli/Helper.scala
+++ b/cli/src/main/scala-2.12/coursier/cli/Helper.scala
@@ -17,7 +17,7 @@ import coursier.util.{Parse, Print}
 import scala.annotation.tailrec
 import scala.concurrent.duration.Duration
 import scalaz.concurrent.{Strategy, Task}
-import scalaz.{-\/, Failure, Nondeterminism, Success, \/-}
+import scalaz.{Failure, Nondeterminism, Success}
 
 
 object Helper {
@@ -182,14 +182,14 @@ class Helper(
 
       logger.foreach(_.stop())
 
-      val errors = res.collect { case -\/(err) => err }
+      val errors = res.collect { case Left(err) => err }
 
       prematureExitIf(errors.nonEmpty) {
         s"Error getting scaladex infos:\n" + errors.map("  " + _).mkString("\n")
       }
 
       res
-        .collect { case \/-(l) => l }
+        .collect { case Right(l) => l }
         .flatten
         .map { case (mod, ver) => (Dependency(mod, ver), Map[String, String]()) }
     }
@@ -644,7 +644,7 @@ class Helper(
 
     val (ignoredErrors, errors) = results
       .collect {
-        case (artifact, -\/(err)) =>
+        case (artifact, Left(err)) =>
           artifact -> err
       }
       .partition {
@@ -657,7 +657,7 @@ class Helper(
       }
 
     val artifactToFile = results.collect {
-      case (artifact: Artifact, \/-(f)) =>
+      case (artifact: Artifact, Right(f)) =>
         (artifact.url, f)
     }.toMap
 

--- a/cli/src/main/scala-2.12/coursier/cli/spark/Assembly.scala
+++ b/cli/src/main/scala-2.12/coursier/cli/spark/Assembly.scala
@@ -14,7 +14,6 @@ import coursier.cli.util.Zip
 import coursier.internal.FileUtil
 
 import scala.collection.mutable
-import scalaz.\/-
 
 object Assembly {
 
@@ -273,8 +272,8 @@ object Assembly {
         // FIXME Acquire lock on tmpDest
         Assembly.make(jars, tmpDest, assemblyRules)
         FileUtil.atomicMove(tmpDest, dest)
-        \/-((dest, jars))
-      }.leftMap(_.describe).toEither
+        Right((dest, jars))
+      }.left.map(_.describe)
   }
 
 }

--- a/core/shared/src/main/scala/coursier/Fetch.scala
+++ b/core/shared/src/main/scala/coursier/Fetch.scala
@@ -1,8 +1,9 @@
 package coursier
 
-import scala.language.higherKinds
+import coursier.util.EitherT
 
-import scalaz._
+import scala.language.higherKinds
+import scalaz.{Monad, Nondeterminism}
 
 object Fetch {
 
@@ -11,7 +12,7 @@ object Fetch {
 
   type MD = Seq[(
     (Module, String),
-    Seq[String] \/ (Artifact.Source, Project)
+    Either[Seq[String], (Artifact.Source, Project)]
   )]
 
   type Metadata[F[_]] = Seq[(Module, String)] => F[MD]
@@ -39,17 +40,18 @@ object Fetch {
     val lookups = repositories
       .map(repo => repo -> repo.find(module, version, fetch).run)
 
-    val task = lookups.foldLeft[F[Seq[String] \/ (Artifact.Source, Project)]](F.point(-\/(Nil))) {
-      case (acc, (repo, eitherProjTask)) =>
+    val task0 = lookups.foldLeft[F[Either[Seq[String], (Artifact.Source, Project)]]](F.point(Left(Nil))) {
+      case (acc, (_, eitherProjTask)) =>
         F.bind(acc) {
-          case -\/(errors) =>
-            F.map(eitherProjTask)(_.leftMap(error => error +: errors))
-          case res @ \/-(_) =>
+          case Left(errors) =>
+            F.map(eitherProjTask)(_.left.map(error => error +: errors))
+          case res @ Right(_) =>
             F.point(res)
         }
     }
 
-    EitherT(F.map(task)(_.leftMap(_.reverse)))
+    val task = F.map(task0)(e => e.left.map(_.reverse): Either[Seq[String], (Artifact.Source, Project)])
+    EitherT(task)
   }
 
   def from[F[_]](
@@ -62,14 +64,13 @@ object Fetch {
 
     modVers =>
       F.map(
-        F.gatherUnordered(
-          modVers.map { case (module, version) =>
-            def get(fetch: Content[F]) =
-              find(repositories, module, version, fetch)
-            F.map((get(fetch) /: extra)(_ orElse get(_))
-              .run)((module, version) -> _)
+        F.gatherUnordered {
+          modVers.map {
+            case (module, version) =>
+              def get(fetch: Content[F]) = find(repositories, module, version, fetch)
+              F.map((get(fetch) /: extra)(_ orElse get(_)).run)(d => (module, version) -> d)
           }
-        )
+        }
       )(_.toSeq)
   }
 

--- a/core/shared/src/main/scala/coursier/core/Activation.scala
+++ b/core/shared/src/main/scala/coursier/core/Activation.scala
@@ -1,12 +1,10 @@
 package coursier.core
 
-import scalaz.{-\/, \/, \/-}
-
 // Maven-specific
 final case class Activation(
   properties: Seq[(String, Option[String])],
   os: Activation.Os,
-  jdk: Option[VersionInterval \/ Seq[Version]]
+  jdk: Option[Either[VersionInterval, Seq[Version]]]
 ) {
 
   def isEmpty: Boolean = properties.isEmpty && os.isEmpty && jdk.isEmpty
@@ -35,9 +33,9 @@ final case class Activation(
     def fromOs = os.isActive(osInfo)
 
     def fromJdk = jdk.forall {
-      case -\/(itv) =>
+      case Left(itv) =>
         jdkVersion.exists(itv.contains)
-      case \/-(versions) =>
+      case Right(versions) =>
         jdkVersion.exists(versions.contains)
     }
 

--- a/core/shared/src/main/scala/coursier/core/Repository.scala
+++ b/core/shared/src/main/scala/coursier/core/Repository.scala
@@ -3,10 +3,9 @@ package coursier.core
 import coursier.Fetch
 
 import scala.language.higherKinds
-
-import scalaz._
-
+import scalaz.Monad
 import coursier.core.compatibility.encodeURIComponent
+import coursier.util.EitherT
 
 trait Repository extends Product with Serializable {
   def find[F[_]](

--- a/core/shared/src/main/scala/coursier/core/Versions.scala
+++ b/core/shared/src/main/scala/coursier/core/Versions.scala
@@ -1,8 +1,5 @@
 package coursier.core
 
-import scalaz.{ -\/, \/, \/- }
-import scalaz.Scalaz.ToEitherOps
-
 final case class VersionInterval(
   from: Option[Version],
   to: Option[Version],
@@ -91,25 +88,25 @@ final case class VersionConstraint(
   interval: VersionInterval,
   preferred: Seq[Version]
 ) {
-  def blend: Option[VersionInterval \/ Version] =
+  def blend: Option[Either[VersionInterval, Version]] =
     if (interval.isValid) {
       val preferredInInterval = preferred.filter(interval.contains)
 
       if (preferredInInterval.isEmpty)
-        Some(interval.left)
+        Some(Left(interval))
       else
-        Some(preferredInInterval.max.right)
+        Some(Right(preferredInInterval.max))
     } else
       None
 
   def repr: Option[String] =
     blend.map {
-      case -\/(itv) =>
+      case Left(itv) =>
         if (itv == VersionInterval.zero)
           ""
         else
           itv.repr
-      case \/-(v) => v.repr
+      case Right(v) => v.repr
     }
 }
 

--- a/core/shared/src/main/scala/coursier/util/EitherT.scala
+++ b/core/shared/src/main/scala/coursier/util/EitherT.scala
@@ -1,0 +1,58 @@
+package coursier.util
+
+import scala.language.higherKinds
+import scalaz.Monad
+
+final case class EitherT[F[_], L, R](run: F[Either[L, R]]) {
+
+  def map[S](f: R => S)(implicit M: Monad[F]): EitherT[F, L, S] =
+    EitherT(
+      M.map(run)(e => e.right.map(f))
+    )
+
+  def flatMap[S](f: R => EitherT[F, L, S])(implicit M: Monad[F]): EitherT[F, L, S] =
+    EitherT(
+      M.bind(run) {
+        case Left(l) =>
+          M.point(Left(l))
+        case Right(r) =>
+          f(r).run
+      }
+    )
+
+  def leftMap[M](f: L => M)(implicit M: Monad[F]): EitherT[F, M, R] =
+    EitherT(
+      M.map(run)(e => e.left.map(f))
+    )
+
+  def orElse(other: => EitherT[F, L, R])(implicit M: Monad[F]): EitherT[F, L, R] =
+    EitherT(
+      M.bind(run) {
+        case Left(_) =>
+          other.run
+        case Right(r) =>
+          M.point(Right(r))
+      }
+    )
+
+  def scalaz(implicit M: Monad[F]): _root_.scalaz.EitherT[F, L, R] =
+    _root_.scalaz.EitherT(
+      M.map(run)(_root_.scalaz.\/.fromEither)
+    )
+
+}
+
+object EitherT {
+
+  def point[F[_], L, R](r: R)(implicit M: Monad[F]): EitherT[F, L, R] =
+    EitherT(M.point(Right(r)))
+
+  def fromEither[F[_]]: FromEither[F] =
+    new FromEither[F]
+
+  final class FromEither[F[_]] {
+    def apply[L, R](either: Either[L, R])(implicit M: Monad[F]): EitherT[F, L, R] =
+      EitherT(M.point(either))
+  }
+
+}

--- a/core/shared/src/main/scala/coursier/util/Parse.scala
+++ b/core/shared/src/main/scala/coursier/util/Parse.scala
@@ -6,8 +6,6 @@ import coursier.ivy.IvyRepository
 import coursier.maven.MavenRepository
 
 import scala.collection.mutable.ArrayBuffer
-import scalaz.\/
-import scalaz.Scalaz.ToEitherOps
 
 object Parse {
 
@@ -354,35 +352,35 @@ object Parse {
                            defaultScalaVersion: String): (Seq[String], Seq[(Dependency, Map[String, String])]) =
     valuesAndErrors(moduleVersionConfig(_, req, transitive, defaultScalaVersion), l)
 
-  def repository(s: String): String \/ Repository =
+  def repository(s: String): Either[String, Repository] =
     if (s == "central")
-      MavenRepository("https://repo1.maven.org/maven2").right
+      Right(MavenRepository("https://repo1.maven.org/maven2"))
     else if (s.startsWith("sonatype:"))
-      MavenRepository(s"https://oss.sonatype.org/content/repositories/${s.stripPrefix("sonatype:")}").right
+      Right(MavenRepository(s"https://oss.sonatype.org/content/repositories/${s.stripPrefix("sonatype:")}"))
     else if (s.startsWith("bintray:"))
-      MavenRepository(s"https://dl.bintray.com/${s.stripPrefix("bintray:")}").right
+      Right(MavenRepository(s"https://dl.bintray.com/${s.stripPrefix("bintray:")}"))
     else if (s.startsWith("bintray-ivy:"))
-      IvyRepository.fromPattern(
+      Right(IvyRepository.fromPattern(
         s"https://dl.bintray.com/${s.stripPrefix("bintray-ivy:").stripSuffix("/")}/" +:
           coursier.ivy.Pattern.default
-      ).right
+      ))
     else if (s.startsWith("typesafe:ivy-"))
-      IvyRepository.fromPattern(
+      Right(IvyRepository.fromPattern(
         s"https://repo.typesafe.com/typesafe/ivy-${s.stripPrefix("typesafe:ivy-")}/" +:
           coursier.ivy.Pattern.default
-      ).right
+      ))
     else if (s.startsWith("typesafe:"))
-      MavenRepository(s"https://repo.typesafe.com/typesafe/${s.stripPrefix("typesafe:")}").right
+      Right(MavenRepository(s"https://repo.typesafe.com/typesafe/${s.stripPrefix("typesafe:")}"))
     else if (s.startsWith("sbt-plugin:"))
-      IvyRepository.fromPattern(
+      Right(IvyRepository.fromPattern(
         s"https://repo.scala-sbt.org/scalasbt/sbt-plugin-${s.stripPrefix("sbt-plugin:")}/" +:
           coursier.ivy.Pattern.default
-      ).right
+      ))
     else if (s.startsWith("ivy:"))
       IvyRepository.parse(s.stripPrefix("ivy:"))
     else if (s == "jitpack")
-      MavenRepository("https://jitpack.io").right
+      Right(MavenRepository("https://jitpack.io"))
     else
-      MavenRepository(s).right
+      Right(MavenRepository(s))
 
 }

--- a/core/shared/src/main/scala/coursier/util/Xml.scala
+++ b/core/shared/src/main/scala/coursier/util/Xml.scala
@@ -2,8 +2,6 @@ package coursier.util
 
 import coursier.core.Versions
 
-import scalaz.{\/-, -\/, \/, Scalaz}
-
 object Xml {
 
   /** A representation of an XML node/document, with different implementations on JVM and JS */
@@ -23,10 +21,10 @@ object Xml {
       }
 
     lazy val attributesMap = attributes.map { case (_, k, v) => k -> v }.toMap
-    def attribute(name: String): String \/ String =
+    def attribute(name: String): Either[String, String] =
       attributesMap.get(name) match {
-        case None => -\/(s"Missing attribute $name")
-        case Some(value) => \/-(value)
+        case None => Left(s"Missing attribute $name")
+        case Some(value) => Right(value)
       }
   }
 
@@ -48,14 +46,11 @@ object Xml {
       else None
   }
 
-  def text(elem: Node, label: String, description: String) = {
-    import Scalaz.ToOptionOpsFromOption
-
+  def text(elem: Node, label: String, description: String): Either[String, String] =
     elem.children
       .find(_.label == label)
       .flatMap(_.children.collectFirst{case Text(t) => t})
-      .toRightDisjunction(s"$description not found")
-  }
+      .toRight(s"$description not found")
 
   def parseDateTime(s: String): Option[Versions.DateTime] =
     if (s.length == 14 && s.forall(_.isDigit))

--- a/doc/readme/README.md
+++ b/doc/readme/README.md
@@ -208,10 +208,9 @@ These would mean that the resolution wasn't able to get metadata about some depe
 Then fetch and get local copies of the artifacts themselves (the JARs) with
 ```tut:silent
 import java.io.File
-import scalaz.\/
 import scalaz.concurrent.Task
 
-val localArtifacts: Seq[FileError \/ File] = Task.gatherUnordered(
+val localArtifacts: Seq[Either[FileError, File]] = Task.gatherUnordered(
   resolution.artifacts.map(Cache.file(_).run)
 ).unsafePerformSync
 ```
@@ -536,7 +535,7 @@ MavenRepository(
 
 Now that we have repositories, we're going to mix these with things from the `coursier-cache` module,
 for resolution to happen via the cache. We'll create a function
-of type `Seq[(Module, String)] => F[Seq[((Module, String), Seq[String] \/ (Artifact.Source, Project))]]`.
+of type `Seq[(Module, String)] => F[Seq[((Module, String), Either[Seq[String], (Artifact.Source, Project)])]]`.
 Given a sequence of dependencies, designated by their `Module` (organisation and name in most cases)
 and version (just a `String`), it gives either errors (`Seq[String]`) or metadata (`(Artifact.Source, Project)`),
 wrapping the whole in a monad `F`.
@@ -591,10 +590,9 @@ which are dependencies whose versions could not be unified.
 Then, if all went well, we can fetch and get local copies of the artifacts themselves (the JARs) with
 ```tut:silent
 import java.io.File
-import scalaz.\/
 import scalaz.concurrent.Task
 
-val localArtifacts: Seq[FileError \/ File] = Task.gatherUnordered(
+val localArtifacts: Seq[Either[FileError, File]] = Task.gatherUnordered(
   resolution.artifacts.map(Cache.file(_).run)
 ).unsafePerformSync
 ```

--- a/doc/readme/README.md
+++ b/doc/readme/README.md
@@ -131,6 +131,8 @@ libraryDependencies ++= Seq(
 )
 ```
 
+Note that the examples below are validated against the current sources of coursier. You may want to read the [documentation of the latest release](https://github.com/coursier/coursier/blob/v1.0.2/README.md#api) of coursier instead.
+
 Add an import for coursier,
 ```scala
 import coursier._
@@ -449,6 +451,8 @@ libraryDependencies ++= Seq(
   "io.get-coursier" %% "coursier-cache" % "1.0.1"
 )
 ```
+
+Note that the examples below are validated against the current sources of coursier. You may want to read the [documentation of the latest release](https://github.com/coursier/coursier/blob/v1.0.2/README.md#api-1) of coursier instead.
 
 The first module, `"io.get-coursier" %% "coursier" % "1.0.1"`, mainly depends on
 `scalaz-core` (and only it, *not* `scalaz-concurrent` for example). It contains among others,

--- a/fetch-js/src/main/scala/coursier/Platform.scala
+++ b/fetch-js/src/main/scala/coursier/Platform.scala
@@ -1,16 +1,13 @@
 package coursier
 
-import org.scalajs.dom.raw.{ Event, XMLHttpRequest }
+import coursier.util.EitherT
+import org.scalajs.dom.raw.{Event, XMLHttpRequest}
 
-import scala.concurrent.{ ExecutionContext, Promise, Future }
-
+import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.language.implicitConversions
-
 import scala.scalajs.js
-import js.Dynamic.{ global => g }
-
+import js.Dynamic.{global => g}
 import scala.scalajs.js.timers._
-import scalaz.{ -\/, \/-, EitherT }
 
 object Platform {
 
@@ -80,9 +77,9 @@ object Platform {
     EitherT(
       Task { implicit ec =>
         get(artifact.url)
-          .map(\/-(_))
+          .map(Right(_))
           .recover { case e: Exception =>
-          -\/(e.toString + Option(e.getMessage).fold("")(" (" + _ + ")"))
+          Left(e.toString + Option(e.getMessage).fold("")(" (" + _ + ")"))
         }
       }
     )
@@ -104,11 +101,11 @@ object Platform {
       Task { implicit ec =>
         Future(logger.fetching(artifact.url))
           .flatMap(_ => get(artifact.url))
-          .map { s => logger.fetched(artifact.url); \/-(s) }
+          .map { s => logger.fetched(artifact.url); Right(s) }
           .recover { case e: Exception =>
             val msg = e.toString + Option(e.getMessage).fold("")(" (" + _ + ")")
             logger.other(artifact.url, msg)
-            -\/(msg)
+            Left(msg)
           }
       }
     )

--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -10,25 +10,6 @@ object Mima {
 
   // Important: the line with the "binary compatibility versions" comment below is matched during releases
   def binaryCompatibilityVersions = Set(
-    "1.0.0-RC1",
-    "1.0.0-RC2",
-    "1.0.0-RC3",
-    "1.0.0-RC4",
-    "1.0.0-RC5",
-    "1.0.0-RC6",
-    "1.0.0-RC7",
-    "1.0.0-RC8",
-    "1.0.0-RC9",
-    "1.0.0-RC10",
-    "1.0.0-RC11",
-    "1.0.0-RC12",
-    "1.0.0-RC12-1",
-    "1.0.0-RC13",
-    "1.0.0-RC14",
-    "1.0.0",
-    "1.0.1-M1",
-    "1.0.1",
-    "1.0.2",
     "" // binary compatibility versions
   )
 

--- a/sbt-coursier/src/main/scala/coursier/Keys.scala
+++ b/sbt-coursier/src/main/scala/coursier/Keys.scala
@@ -8,7 +8,6 @@ import sbt.librarymanagement.GetClassifiersModule
 import sbt.{Resolver, SettingKey, TaskKey}
 
 import scala.concurrent.duration.Duration
-import scalaz.\/
 
 object Keys {
   val coursierParallelDownloads = SettingKey[Int]("coursier-parallel-downloads")
@@ -65,8 +64,8 @@ object Keys {
     "Prints dependencies and transitive dependencies as an inverted tree (dependees as children)"
   )
 
-  val coursierArtifacts = TaskKey[Map[Artifact, FileError \/ File]]("coursier-artifacts")
-  val coursierSignedArtifacts = TaskKey[Map[Artifact, FileError \/ File]]("coursier-signed-artifacts")
-  val coursierClassifiersArtifacts = TaskKey[Map[Artifact, FileError \/ File]]("coursier-classifiers-artifacts")
-  val coursierSbtClassifiersArtifacts = TaskKey[Map[Artifact, FileError \/ File]]("coursier-sbt-classifiers-artifacts")
+  val coursierArtifacts = TaskKey[Map[Artifact, Either[FileError, File]]]("coursier-artifacts")
+  val coursierSignedArtifacts = TaskKey[Map[Artifact, Either[FileError, File]]]("coursier-signed-artifacts")
+  val coursierClassifiersArtifacts = TaskKey[Map[Artifact, Either[FileError, File]]]("coursier-classifiers-artifacts")
+  val coursierSbtClassifiersArtifacts = TaskKey[Map[Artifact, Either[FileError, File]]]("coursier-sbt-classifiers-artifacts")
 }

--- a/sbt-shading/src/main/scala/coursier/Shading.scala
+++ b/sbt-shading/src/main/scala/coursier/Shading.scala
@@ -11,8 +11,6 @@ import com.tonicsystems.jarjar.transform.jar.DefaultJarProcessor
 import coursier.core.Orders
 import sbt.file
 
-import scalaz.{\/, \/-}
-
 object Shading {
 
   // FIXME Also vaguely in cli
@@ -58,7 +56,7 @@ object Shading {
     currentProject: Project,
     res: Resolution,
     configs: Map[String, Set[String]],
-    artifactFilesOrErrors: Map[Artifact, FileError \/ File],
+    artifactFilesOrErrors: Map[Artifact, Either[FileError, File]],
     classpathTypes: Set[String],
     baseConfig: String,
     shadedConf: String,
@@ -101,7 +99,7 @@ object Shading {
 
     val artifactFilesOrErrors0 = artifactFilesOrErrors
       .collect {
-        case (a, \/-(f)) => a.url -> f
+        case (a, Right(f)) => a.url -> f
       }
 
     val compileDeps = configDependencies(baseConfig)

--- a/sbt-shared/src/main/scala/coursier/FromSbt.scala
+++ b/sbt-shared/src/main/scala/coursier/FromSbt.scala
@@ -10,8 +10,6 @@ import sbt.librarymanagement._
 import sbt.librarymanagement.Resolver
 import sbt.util.Logger
 
-import scalaz.{-\/, \/-}
-
 object FromSbt {
 
   def sbtModuleIdName(
@@ -227,11 +225,11 @@ object FromSbt {
               dropInfoAttributes = true,
               authentication = authentication
             ) match {
-              case -\/(err) =>
+              case Left(err) =>
                 sys.error(
                   s"Cannot parse Ivy patterns ${r.patterns.artifactPatterns.head} and ${r.patterns.ivyPatterns.head}: $err"
                 )
-              case \/-(repo) =>
+              case Right(repo) =>
                 repo
             }
 
@@ -258,11 +256,11 @@ object FromSbt {
               dropInfoAttributes = true,
               authentication = authentication
             ) match {
-              case -\/(err) =>
+              case Left(err) =>
                 sys.error(
                   s"Cannot parse Ivy patterns ${r.patterns.artifactPatterns.head} and ${r.patterns.ivyPatterns.head}: $err"
                 )
-              case \/-(repo) =>
+              case Right(repo) =>
                 repo
             }
 

--- a/tests/js/src/test/scala/coursier/test/compatibility/package.scala
+++ b/tests/js/src/test/scala/coursier/test/compatibility/package.scala
@@ -1,12 +1,11 @@
 package coursier.test
 
-import coursier.util.TestEscape
+import coursier.util.{EitherT, TestEscape}
 import coursier.{Fetch, Task}
 
-import scala.concurrent.{Promise, ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.scalajs.js
 import js.Dynamic.{global => g}
-import scalaz.{-\/, EitherT, \/-}
 
 package object compatibility {
 
@@ -40,10 +39,10 @@ package object compatibility {
 
       Task { implicit ec =>
         textResource0(path)
-          .map(\/-(_))
+          .map(Right(_))
           .recoverWith {
             case e: Exception =>
-              Future.successful(-\/(e.getMessage))
+              Future.successful(Left(e.getMessage))
           }
       }
     }

--- a/tests/jvm/src/test/scala/coursier/test/IvyTests.scala
+++ b/tests/jvm/src/test/scala/coursier/test/IvyTests.scala
@@ -14,7 +14,7 @@ object IvyTests extends TestSuite {
       "[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)" +
       "[revision]/[type]s/[artifact](-[classifier]).[ext]",
     dropInfoAttributes = true
-  ).getOrElse(
+  ).right.getOrElse(
     throw new Exception("Cannot happen")
   )
 

--- a/tests/jvm/src/test/scala/coursier/test/ResolutionProcessTests.scala
+++ b/tests/jvm/src/test/scala/coursier/test/ResolutionProcessTests.scala
@@ -8,7 +8,6 @@ import utest._
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.DurationInt
-import scalaz.{-\/, \/-}
 import scalaz.concurrent.Task
 
 object ResolutionProcessTests extends TestSuite {
@@ -40,7 +39,7 @@ object ResolutionProcessTests extends TestSuite {
           case Seq(mv @ (`mod`, v)) =>
             Task.async { cb =>
               called.put(v, ())
-              cb(\/-(Seq((mv, -\/(Seq("w/e"))))))
+              cb(scalaz.\/-(Seq((mv, Left(Seq("w/e"))))))
             }
 
           case _ => sys.error(s"Cannot happen ($modVers)")

--- a/tests/shared/src/test/resources/resolutions/io.get-coursier/coursier_2.11/1.1.0-SNAPSHOT
+++ b/tests/shared/src/test/resources/resolutions/io.get-coursier/coursier_2.11/1.1.0-SNAPSHOT
@@ -1,4 +1,4 @@
-io.get-coursier:coursier_2.11:1.0.3-SNAPSHOT:compile
+io.get-coursier:coursier_2.11:1.1.0-SNAPSHOT:compile
 org.scala-lang:scala-library:2.11.12:default
 org.scala-lang.modules:scala-xml_2.11:1.0.6:default
 org.scalaz:scalaz-core_2.11:7.2.16:default

--- a/tests/shared/src/test/scala/coursier/test/ActivationTests.scala
+++ b/tests/shared/src/test/scala/coursier/test/ActivationTests.scala
@@ -4,8 +4,6 @@ import coursier.core.{Activation, Parse}
 import coursier.core.Activation.Os
 import utest._
 
-import scalaz.{-\/, \/-}
-
 object ActivationTests extends TestSuite {
 
   def parseVersion(s: String) = Parse.version(s).getOrElse(???)
@@ -210,7 +208,7 @@ object ActivationTests extends TestSuite {
           val activation = Activation(
             Nil,
             Os.empty,
-            Some(\/-(Seq(parseVersion("1.8.0_112"))))
+            Some(Right(Seq(parseVersion("1.8.0_112"))))
           )
 
           val isActive = activation.isActive(Map(), Os.empty, Some(jdkVersion))
@@ -222,7 +220,7 @@ object ActivationTests extends TestSuite {
           val activation = Activation(
             Nil,
             Os.empty,
-            Some(\/-(Seq(parseVersion("1.8.0_102"), parseVersion("1.8.0_112"))))
+            Some(Right(Seq(parseVersion("1.8.0_102"), parseVersion("1.8.0_112"))))
           )
 
           val isActive = activation.isActive(Map(), Os.empty, Some(jdkVersion))
@@ -235,7 +233,7 @@ object ActivationTests extends TestSuite {
           val activation = Activation(
             Nil,
             Os.empty,
-            Some(\/-(Seq(parseVersion("1.8.0_102"))))
+            Some(Right(Seq(parseVersion("1.8.0_102"))))
           )
 
           val isActive = activation.isActive(Map(), Os.empty, Some(jdkVersion))
@@ -248,7 +246,7 @@ object ActivationTests extends TestSuite {
           val activation = Activation(
             Nil,
             Os.empty,
-            Some(\/-(Seq(parseVersion("1.8.0_92"), parseVersion("1.8.0_102"))))
+            Some(Right(Seq(parseVersion("1.8.0_92"), parseVersion("1.8.0_102"))))
           )
 
           val isActive = activation.isActive(Map(), Os.empty, Some(jdkVersion))
@@ -260,7 +258,7 @@ object ActivationTests extends TestSuite {
           val activation = Activation(
             Nil,
             Os.empty,
-            Some(-\/(parseVersionInterval("[1.8,)")))
+            Some(Left(parseVersionInterval("[1.8,)")))
           )
 
           val isActive = activation.isActive(Map(), Os.empty, Some(jdkVersion))
@@ -272,7 +270,7 @@ object ActivationTests extends TestSuite {
           val activation = Activation(
             Nil,
             Os.empty,
-            Some(-\/(parseVersionInterval("[1.7,1.8)")))
+            Some(Left(parseVersionInterval("[1.7,1.8)")))
           )
 
           val isActive = activation.isActive(Map(), Os.empty, Some(jdkVersion))
@@ -290,7 +288,7 @@ object ActivationTests extends TestSuite {
           "requiredWithNegValue" -> Some("!bar")
         ),
         Os(None, Set("mac"), None, None),
-        Some(-\/(parseVersionInterval("[1.8,)")))
+        Some(Left(parseVersionInterval("[1.8,)")))
       )
 
       'match - {

--- a/tests/shared/src/test/scala/coursier/test/IvyPatternParserTests.scala
+++ b/tests/shared/src/test/scala/coursier/test/IvyPatternParserTests.scala
@@ -6,8 +6,6 @@ import coursier.ivy.PropertiesPattern.ChunkOrProperty._
 
 import utest._
 
-import scalaz.Scalaz.ToEitherOps
-
 object IvyPatternParserTests extends TestSuite {
 
   val tests = TestSuite {
@@ -23,7 +21,7 @@ object IvyPatternParserTests extends TestSuite {
         "/resolved.xml.", Var("ext")
       )
 
-      assert(PropertiesPattern.parse(strPattern).map(_.chunks) == expectedChunks.right)
+      assert(PropertiesPattern.parse(strPattern).right.map(_.chunks) == Right(expectedChunks))
     }
 
     'activatorLaunchLocal - {
@@ -50,48 +48,48 @@ object IvyPatternParserTests extends TestSuite {
       )
 
       val pattern0 = PropertiesPattern.parse(strPattern)
-      assert(pattern0.map(_.chunks) == expectedChunks.right)
+      assert(pattern0.right.map(_.chunks) == Right(expectedChunks))
 
-      val pattern = pattern0.toOption.get
+      val pattern = pattern0.right.get
 
       * - {
         val varPattern = pattern.substituteProperties(Map(
           "activator.local.repository" -> "xyz"
-        )).map(_.string)
+        )).right.map(_.string)
 
         val expectedVarPattern =
           "file://xyz" +
             "/[organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)" +
             "[revision]/[type]s/[artifact](-[classifier]).[ext]"
 
-        assert(varPattern == expectedVarPattern.right)
+        assert(varPattern == Right(expectedVarPattern))
       }
 
       * - {
         val varPattern = pattern.substituteProperties(Map(
           "activator.local.repository" -> "xyz",
           "activator.home" -> "aaaa"
-        )).map(_.string)
+        )).right.map(_.string)
 
         val expectedVarPattern =
           "file://xyz" +
             "/[organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)" +
             "[revision]/[type]s/[artifact](-[classifier]).[ext]"
 
-        assert(varPattern == expectedVarPattern.right)
+        assert(varPattern == Right(expectedVarPattern))
       }
 
       * - {
         val varPattern = pattern.substituteProperties(Map(
           "activator.home" -> "aaaa"
-        )).map(_.string)
+        )).right.map(_.string)
 
         val expectedVarPattern =
           "file://aaaa/repository" +
             "/[organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)" +
             "[revision]/[type]s/[artifact](-[classifier]).[ext]"
 
-        assert(varPattern == expectedVarPattern.right)
+        assert(varPattern == Right(expectedVarPattern))
       }
 
       * - {
@@ -104,9 +102,9 @@ object IvyPatternParserTests extends TestSuite {
             "/[organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)" +
             "[revision]/[type]s/[artifact](-[classifier]).[ext]"
 
-        assert(varPattern0.map(_.string) == expectedVarPattern.right)
+        assert(varPattern0.right.map(_.string) == Right(expectedVarPattern))
 
-        val varPattern = varPattern0.toOption.get
+        val varPattern = varPattern0.right.toOption.get
 
         * - {
           val res = varPattern.substituteVariables(Map(
@@ -117,10 +115,10 @@ object IvyPatternParserTests extends TestSuite {
             "artifact" -> "art",
             "classifier" -> "docc",
             "ext" -> "jrr"
-          )).map(_.string)
+          )).right.map(_.string)
           val expectedRes = "file://homez/.activator/repository/org/mod/1.1.x/jarrs/art-docc.jrr"
 
-          assert(res == expectedRes.right)
+          assert(res == Right(expectedRes))
         }
       }
 

--- a/tests/shared/src/test/scala/coursier/test/ParseTests.scala
+++ b/tests/shared/src/test/scala/coursier/test/ParseTests.scala
@@ -25,30 +25,30 @@ object ParseTests extends TestSuite {
   val tests = TestSuite {
     "bintray-ivy:" - {
       val obtained = Parse.repository("bintray-ivy:scalameta/maven")
-      assert(obtained.exists(isIvyRepo))
+      assert(obtained.right.exists(isIvyRepo))
     }
     "bintray:" - {
       val obtained = Parse.repository("bintray:scalameta/maven")
-      assert(obtained.exists(isMavenRepo))
+      assert(obtained.right.exists(isMavenRepo))
     }
 
     "sbt-plugin:" - {
       val res = Parse.repository("sbt-plugin:releases")
-      assert(res.exists(isIvyRepo))
+      assert(res.right.exists(isIvyRepo))
     }
 
     "typesafe:ivy-" - {
       val res = Parse.repository("typesafe:ivy-releases")
-      assert(res.exists(isIvyRepo))
+      assert(res.right.exists(isIvyRepo))
     }
     "typesafe:" - {
       val res = Parse.repository("typesafe:releases")
-      assert(res.exists(isMavenRepo))
+      assert(res.right.exists(isMavenRepo))
     }
 
     "jitpack" - {
       val res = Parse.repository("jitpack")
-      assert(res.exists(isMavenRepo))
+      assert(res.right.exists(isMavenRepo))
     }
 
     // Module parsing tests

--- a/tests/shared/src/test/scala/coursier/test/PomParsingTests.scala
+++ b/tests/shared/src/test/scala/coursier/test/PomParsingTests.scala
@@ -2,7 +2,6 @@ package coursier
 package test
 
 import utest._
-import scalaz._
 
 import coursier.maven.Pom
 
@@ -21,7 +20,7 @@ object PomParsingTests extends TestSuite {
         </dependency>
                    """
 
-      val expected = \/-(
+      val expected = Right(
         "" -> Dependency(
           Module("comp", "lib"),
           "2.1",
@@ -40,7 +39,7 @@ object PomParsingTests extends TestSuite {
         </profile>
                        """
 
-      val expected = \/-(Profile("profile1", None, Profile.Activation(Nil), Nil, Nil, Map.empty))
+      val expected = Right(Profile("profile1", None, Profile.Activation(Nil), Nil, Nil, Map.empty))
 
       val result = Pom.profile(xmlParse(profileNode).right.get)
 
@@ -55,7 +54,7 @@ object PomParsingTests extends TestSuite {
         </profile>
                        """
 
-      val expected = \/-(Profile("", Some(true), Profile.Activation(Nil), Nil, Nil, Map.empty))
+      val expected = Right(Profile("", Some(true), Profile.Activation(Nil), Nil, Nil, Map.empty))
 
       val result = Pom.profile(xmlParse(profileNode).right.get)
 
@@ -71,7 +70,7 @@ object PomParsingTests extends TestSuite {
         </profile>
                        """
 
-      val expected = \/-(Profile("profile1", Some(true), Profile.Activation(Nil), Nil, Nil, Map.empty))
+      val expected = Right(Profile("profile1", Some(true), Profile.Activation(Nil), Nil, Nil, Map.empty))
 
       val result = Pom.profile(xmlParse(profileNode).right.get)
 
@@ -88,7 +87,7 @@ object PomParsingTests extends TestSuite {
           </activation>
         </profile>
                        """
-      val expected = \/-(Profile("profile1", None, Profile.Activation(List("hadoop.profile" -> None)), Nil, Nil, Map.empty))
+      val expected = Right(Profile("profile1", None, Profile.Activation(List("hadoop.profile" -> None)), Nil, Nil, Map.empty))
       val result = Pom.profile(xmlParse(profileNode).right.get)
 
       assert(result == expected)
@@ -106,7 +105,7 @@ object PomParsingTests extends TestSuite {
           </activation>
         </profile>
                        """
-      val expected = \/-(Profile("profile1", None, Profile.Activation(List("hadoop.profile" -> Some("yes"))), Nil, Nil, Map.empty))
+      val expected = Right(Profile("profile1", None, Profile.Activation(List("hadoop.profile" -> Some("yes"))), Nil, Nil, Map.empty))
       val result = Pom.profile(xmlParse(profileNode).right.get)
 
       assert(result == expected)
@@ -126,7 +125,7 @@ object PomParsingTests extends TestSuite {
         </profile>
                        """
 
-      val expected = \/-(Profile(
+      val expected = Right(Profile(
         "profile1",
         None,
         Profile.Activation(Nil),
@@ -157,7 +156,7 @@ object PomParsingTests extends TestSuite {
         </profile>
                        """
 
-      val expected = \/-(Profile(
+      val expected = Right(Profile(
         "profile1",
         None,
         Profile.Activation(Nil),
@@ -181,7 +180,7 @@ object PomParsingTests extends TestSuite {
         </profile>
                        """
 
-      val expected = \/-(Profile(
+      val expected = Right(Profile(
         "profile1",
         None,
         Profile.Activation(Nil),
@@ -204,7 +203,7 @@ object PomParsingTests extends TestSuite {
         </profile>
                        """
 
-      val expected = \/-(Profile(
+      val expected = Right(Profile(
         "profile1",
         None,
         Profile.Activation(Nil),
@@ -218,7 +217,7 @@ object PomParsingTests extends TestSuite {
       assert(result == expected)
     }
     'beFineWithCommentsInProperties{
-      import scalaz._, Scalaz._
+      import scalaz.Scalaz.{eitherMonad, listInstance, ToTraverseOps}
 
       val properties =
         """
@@ -258,12 +257,12 @@ object PomParsingTests extends TestSuite {
       val node = parsed.right.get
       assert(node.label == "properties")
 
-      val children = node.children.collect{case elem if elem.isElement => elem}
+      val children = node.children.collect { case elem if elem.isElement => elem }
       val props0 = children.toList.traverseU(Pom.property)
 
       assert(props0.isRight)
 
-      val props = props0.getOrElse(???).toMap
+      val props = props0.right.getOrElse(???).toMap
 
       assert(props.contains("commons.release.2.desc"))
       assert(props.contains("commons.osgi.export"))

--- a/tests/shared/src/test/scala/coursier/test/TestRepository.scala
+++ b/tests/shared/src/test/scala/coursier/test/TestRepository.scala
@@ -2,11 +2,10 @@ package coursier
 package test
 
 import coursier.core._
+import coursier.util.EitherT
 
 import scala.language.higherKinds
-
-import scalaz.{ Monad, EitherT }
-import scalaz.Scalaz._
+import scalaz.Monad
 
 final case class TestRepository(projects: Map[(Module, String), Project]) extends Repository {
   val source = new core.Artifact.Source {
@@ -23,7 +22,9 @@ final case class TestRepository(projects: Map[(Module, String), Project]) extend
   )(implicit
     F: Monad[F]
   ) =
-    EitherT(F.point(
-      projects.get((module, version)).map((source, _)).toRightDisjunction("Not found")
-    ))
+    EitherT(
+      F.point(
+        projects.get((module, version)).map((source, _)).toRight("Not found")
+      )
+    )
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.3-SNAPSHOT"
+version in ThisBuild := "1.1.0-SNAPSHOT"


### PR DESCRIPTION
This PR is a first step towards fixing https://github.com/coursier/coursier/issues/175. It substitutes  `scala.Either` to `scalaz.\/` everywhere, and a custom `coursier.util.EitherT` to `scalaz.EitherT`.