### PR TITLE
Remove deprecation prior to 1.1.0-SNAPSHOT and clarify versioning and deprecation strategy

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -165,3 +165,26 @@ Use either "Create merge commit" or "Squash and merge".
 Use "Create merge commit" if the commit list is clean enough (each commit has a clear message, and doesn't break simple compilation and test tasks).
 
 Use "Squash and merge" in the other cases.
+
+# General Versioning Guideline
+
+* Major Version 1.x.x : Increment this field when there is a major change.
+* Minor Version x.1.x : Increment this field when there is a minor change that breaks backward compatibility for an method.
+* Patch version x.x.1 : Increment this field when a minor format change that just adds information that an application can safely ignore.
+
+# Deprecation Strategy
+
+When deprecating a method/field, we want to know
+1. Since which version this field/method is being deprecated
+2. Migration path, i.e. what to use instead
+3. At which point the deprecation will be removed
+
+Due to scala's builtin deprecation works like
+```
+class deprecated(message: String = {},
+                 since: String = {})
+```
+we need to put 2) and 3) into `message`:
+```
+@deprecated(message = "<migration path>. <version to be removed>", since: "deprecation start version")
+```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -181,10 +181,13 @@ When deprecating a method/field, we want to know
 
 Due to scala's builtin deprecation works like
 ```
-class deprecated(message: String = {},
-                 since: String = {})
+class deprecated(message: String = {}, since: String = {})
 ```
 we need to put 2) and 3) into `message`:
 ```
 @deprecated(message = "<migration path>. <version to be removed>", since: "deprecation start version")
 ```
+
+Typically there needs to be at least 2 minor versions between since-version and to-be-removed-version to help migration.
+
+For example, if since version is 1.1.0, then deprecation can be removed in 1.3.0

--- a/cache/src/main/scala/coursier/Cache.scala
+++ b/cache/src/main/scala/coursier/Cache.scala
@@ -1129,13 +1129,6 @@ object Cache {
 
     def downloadingArtifact(url: String, file: File): Unit = {}
 
-    @deprecated("extend Logger.Extended instead and use / override the variant with 4 arguments", "1.0.0-M10")
-    def downloadLength(url: String, length: Long): Unit = {}
-    @deprecated("extend Logger.Extended instead and use / override the variant with 4 arguments", "1.0.0-RC4")
-    def downloadLength(url: String, length: Long, alreadyDownloaded: Long): Unit = {
-      downloadLength(url, length)
-    }
-
     def downloadProgress(url: String, downloaded: Long): Unit = {}
 
     def downloadedArtifact(url: String, success: Boolean): Unit = {}
@@ -1147,7 +1140,7 @@ object Cache {
     // adding new methods to this one, not to break bin compat in 2.10 / 2.11
     abstract class Extended extends Logger {
       def downloadLength(url: String, totalLength: Long, alreadyDownloaded: Long, watching: Boolean): Unit = {
-        downloadLength(url, totalLength, 0L)
+        downloadLength(url, totalLength, 0L, watching)
       }
 
       def gettingLength(url: String): Unit = {}
@@ -1165,11 +1158,6 @@ object Cache {
 
               override def downloadingArtifact(url: String, file: File) =
                 logger.downloadingArtifact(url, file)
-
-              override def downloadLength(url: String, length: Long) =
-                logger.downloadLength(url, length)
-              override def downloadLength(url: String, length: Long, alreadyDownloaded: Long) =
-                logger.downloadLength(url, length, alreadyDownloaded)
 
               override def downloadProgress(url: String, downloaded: Long) =
                 logger.downloadProgress(url, downloaded)

--- a/core/shared/src/main/scala/coursier/core/Resolution.scala
+++ b/core/shared/src/main/scala/coursier/core/Resolution.scala
@@ -116,10 +116,6 @@ object Resolution {
     }
   }
 
-  @deprecated("Originally intended for internal use only", "1.0.0-RC7")
-  def propertiesMap(props: Seq[(String, String)]): Map[String, String] =
-    substitute(props).toMap
-
   /**
    * Substitutes `properties` in `dependencies`.
    */

--- a/core/shared/src/main/scala/coursier/core/Resolution.scala
+++ b/core/shared/src/main/scala/coursier/core/Resolution.scala
@@ -1088,19 +1088,6 @@ final case class Resolution(
   def metadataErrors: Seq[(ModuleVersion, Seq[String])] = errorCache.toSeq
 
   /**
-    * Returns errors on dependencies, but that don't have POM-related errors
-    * @return errors
-    */
-  @deprecated("use metadataErrors instead", "1.0.0-RC1")
-  def errors: Seq[(Dependency, Seq[String])] =
-    for {
-      dep <- dependencies.toSeq
-      err <- errorCache
-        .get(dep.moduleVersion)
-        .toSeq
-    } yield (dep, err)
-
-  /**
     * Removes from this `Resolution` dependencies that are not in `dependencies` neither brought
     * transitively by them.
     *

--- a/core/shared/src/main/scala/coursier/core/ResolutionProcess.scala
+++ b/core/shared/src/main/scala/coursier/core/ResolutionProcess.scala
@@ -127,10 +127,6 @@ final case class Missing(
     cont0(current0)
   }
 
-  @deprecated("Intended for internal use only", "1.0.0-RC7")
-  def uniqueModules: Missing =
-    this
-
 }
 
 final case class Continue(

--- a/core/shared/src/main/scala/coursier/ivy/IvyRepository.scala
+++ b/core/shared/src/main/scala/coursier/ivy/IvyRepository.scala
@@ -340,33 +340,4 @@ object IvyRepository {
       dropInfoAttributes,
       authentication
     )
-
-  @deprecated("Can now raise exceptions - use parse instead", "1.0.0-M13")
-  def apply(
-    pattern: String,
-    metadataPatternOpt: Option[String] = None,
-    changing: Option[Boolean] = None,
-    properties: Map[String, String] = Map.empty,
-    withChecksums: Boolean = true,
-    withSignatures: Boolean = true,
-    withArtifacts: Boolean = true,
-    // hack for SBT putting infos in properties
-    dropInfoAttributes: Boolean = false,
-    authentication: Option[Authentication] = None
-  ): IvyRepository =
-    parse(
-      pattern,
-      metadataPatternOpt,
-      changing,
-      properties,
-      withChecksums,
-      withSignatures,
-      withArtifacts,
-      dropInfoAttributes,
-      authentication
-    ) match {
-      case Right(repo) => repo
-      case Left(msg) =>
-        throw new IllegalArgumentException(s"Error while parsing Ivy patterns: $msg")
-    }
 }

--- a/core/shared/src/main/scala/coursier/util/Parse.scala
+++ b/core/shared/src/main/scala/coursier/util/Parse.scala
@@ -115,31 +115,6 @@ object Parse {
                               private val cause: Throwable = None.orNull)
     extends Exception(message, cause)
 
-  @deprecated("use the variant accepting a default scala version", "1.0.0-M13")
-  def moduleVersionConfig(s: String, defaultScalaVersion: String): Either[String, (Module, String, Option[String])] = {
-    val mvc: Either[String, (Dependency, Map[String, String])] =
-      moduleVersionConfig(s, ModuleRequirements(), transitive = true, defaultScalaVersion)
-    mvc match {
-      case Left(x) => Left(x)
-      case Right(depsWithParams) =>
-        val (dep, _) = depsWithParams
-        Right(dep.module, dep.version, Option(dep.configuration).filter(_.trim.nonEmpty))
-    }
-  }
-
-
-  @deprecated("use the variant accepting a default scala version", "1.0.0-M13")
-  def moduleVersionConfig(s: String): Either[String, (Module, String, Option[String])] = {
-    val mvc: Either[String, (Dependency, Map[String, String])] =
-      moduleVersionConfig(s, ModuleRequirements(), transitive = true, defaultScalaVersion)
-    mvc match {
-      case Left(x) => Left(x)
-      case Right(depsWithParams) =>
-        val (dep, _) = depsWithParams
-        Right(dep.module, dep.version, Option(dep.configuration).filter(_.trim.nonEmpty))
-    }
-  }
-
   /**
     * Parses coordinates like
     *   org:name:version

--- a/core/shared/src/main/scala/coursier/util/Parse.scala
+++ b/core/shared/src/main/scala/coursier/util/Parse.scala
@@ -11,10 +11,6 @@ object Parse {
 
   private def defaultScalaVersion = scala.util.Properties.versionNumberString
 
-  @deprecated("use the variant accepting a default scala version", "1.0.0-M13")
-  def module(s: String): Either[String, Module] =
-    module(s, defaultScalaVersion)
-
   /**
     * Parses a module like
     *   org:name
@@ -69,10 +65,6 @@ object Parse {
     (errors, values)
   }
 
-  @deprecated("use the variant accepting a default scala version", "1.0.0-M13")
-  def modules(l: Seq[String]): (Seq[String], Seq[Module]) =
-    modules(l, defaultScalaVersion)
-
   /**
     * Parses a sequence of coordinates.
     *
@@ -80,10 +72,6 @@ object Parse {
     */
   def modules(l: Seq[String], defaultScalaVersion: String): (Seq[String], Seq[Module]) =
     valuesAndErrors(module(_, defaultScalaVersion), l)
-
-  @deprecated("use the variant accepting a default scala version", "1.0.0-M13")
-  def moduleVersion(s: String): Either[String, (Module, String)] =
-    moduleVersion(s, defaultScalaVersion)
 
   /**
     * Parses coordinates like
@@ -276,10 +264,6 @@ object Parse {
     else None
   }
 
-  @deprecated("use the variant accepting a default scala version", "1.0.0-M13")
-  def moduleVersions(l: Seq[String]): (Seq[String], Seq[(Module, String)]) =
-    moduleVersions(l, defaultScalaVersion)
-
   /**
     * Parses a sequence of coordinates.
     *
@@ -287,23 +271,6 @@ object Parse {
     */
   def moduleVersions(l: Seq[String], defaultScalaVersion: String): (Seq[String], Seq[(Module, String)]) =
     valuesAndErrors(moduleVersion(_, defaultScalaVersion), l)
-
-  @deprecated("use the variant accepting a default scala version", "1.0.0-M13")
-  def moduleVersionConfigs(l: Seq[String]): (Seq[String], Seq[(Module, String, Option[String])]) = {
-    val mvc: (Seq[String], Seq[(Dependency, Map[String, String])]) =
-      moduleVersionConfigs(l, ModuleRequirements(), transitive = true, defaultScalaVersion)
-    val errorsAndDeps = (mvc._1, mvc._2.map(d => d._1))
-    // convert empty config to None
-    (errorsAndDeps._1, errorsAndDeps._2.map(d => (d.module, d.version, Option(d.configuration).filter(_.trim.nonEmpty))))
-  }
-
-  @deprecated("use the variant accepting a default scala version", "1.0.0-M13")
-  def moduleVersionConfigs(l: Seq[String], defaultScalaVersion: String): (Seq[String], Seq[(Module, String, Option[String])]) = {
-    val mvc: (Seq[String], Seq[(Dependency, Map[String, String])]) =
-      moduleVersionConfigs(l, ModuleRequirements(), transitive = true, defaultScalaVersion)
-    val errorsAndDeps = (mvc._1, mvc._2.map(d => d._1))
-    (errorsAndDeps._1, errorsAndDeps._2.map(d => (d.module, d.version, Option(d.configuration).filter(_.trim.nonEmpty))))
-  }
 
   /**
     * Data holder for additional info that needs to be considered when parsing the module.


### PR DESCRIPTION
Version was bumped to 1.1.0-SNAPSHOT and backward compatiliby was removed for up to 1.0.2 at 0123a377e2d8cd19c8887a41122efad14632265c, so it should be safe to remove all the deprecations.