### PR TITLE
Replace @ symbol with `_at_` in cache directory path

### DIFF
--- a/paths/src/main/java/coursier/CachePath.java
+++ b/paths/src/main/java/coursier/CachePath.java
@@ -69,7 +69,7 @@ public class CachePath {
 
         String userPart = "";
         if (user != null)
-            userPart = user + "@";
+            userPart = user + "_at_";
 
         return new File(cache, escape(protocol + "/" + userPart + remaining));
     }


### PR DESCRIPTION
There are a couple reasons as  to why I'm requesting this change:

  * google Guava ClassPath scanner breaks when project is built with coursier due to '%40' symbols that separate username and hostname in cache path. This bug was fixed in guava 24.1, but it may impact enterprise users unable to upgrade
  * We're leaking part of the credentials outside of user's credentials file
  * `ivy` doesn't do this, so unless there's a specific use case, it's may be safe to drop this feature. Please correct me if I'm wrong.

Alternatively, an alphabetic separator could be used instead of `@`/`%40`, using i.e. Z-encoding