### PR TITLE
Add a Task.tailRecM for stack safe loops

### DIFF
--- a/cache/shared/src/main/scala/coursier/util/Task.scala
+++ b/cache/shared/src/main/scala/coursier/util/Task.scala
@@ -31,14 +31,14 @@ object Task extends PlatformTask {
 
   def tailRecM[A, B](a: A)(fn: A => Task[Either[A, B]]): Task[B] =
     Task[B] { implicit ec =>
-      // this loop is safe, because
-      // Future.flatMap is stack-safe
-      // but Task.flatMap is not stack safe because it
-      // involves function composition
       def loop(a: A): Future[B] =
         fn(a).future().flatMap {
-          case Right(b) => Future.successful(b)
-          case Left(a) => loop(a)
+          case Right(b) =>
+            Future.successful(b)
+          case Left(a) =>
+            // this is safe because recursive
+            // flatMap is safe on Future
+            loop(a)
         }
       loop(a)
     }

--- a/cache/shared/src/main/scala/coursier/util/Task.scala
+++ b/cache/shared/src/main/scala/coursier/util/Task.scala
@@ -29,5 +29,18 @@ object Task extends PlatformTask {
   def never[A]: Task[A] =
     Task(_ => Promise[A].future)
 
+  def tailRecM[A, B](a: A)(fn: A => Task[Either[A, B]]): Task[B] =
+    Task[B] { implicit ec =>
+      // this loop is safe, because
+      // Future.flatMap is stack-safe
+      // but Task.flatMap is not stack safe because it
+      // involves function composition
+      def loop(a: A): Future[B] =
+        fn(a).future().flatMap {
+          case Right(b) => Future.successful(b)
+          case Left(a) => loop(a)
+        }
+      loop(a)
+    }
 }
 

--- a/tests/shared/src/test/scala/coursier/util/TaskTests.scala
+++ b/tests/shared/src/test/scala/coursier/util/TaskTests.scala
@@ -16,7 +16,7 @@ object TaskTests extends TestSuite {
           case x if x >= i => Task.delay(Right(i))
           case toosmall => Task.delay(Left(toosmall + 1))
         }
-      assert(Await.result(countTo(500000).map(_ == 500000).future(), Duration.Inf))
+      countTo(500000).map(_ == 500000).future().map(assert(_))
     }
   }
 }

--- a/tests/shared/src/test/scala/coursier/util/TaskTests.scala
+++ b/tests/shared/src/test/scala/coursier/util/TaskTests.scala
@@ -1,0 +1,22 @@
+package coursier.util
+
+import utest._
+
+import scala.concurrent.{Await, ExecutionContext}
+import scala.concurrent.duration.Duration
+
+object TaskTests extends TestSuite {
+
+  val tests = Tests {
+    'tailRecM {
+      import ExecutionContext.Implicits.global
+
+      def countTo(i: Int): Task[Int] =
+        Task.tailRecM(0) {
+          case x if x >= i => Task.delay(Right(i))
+          case toosmall => Task.delay(Left(toosmall + 1))
+        }
+      assert(Await.result(countTo(500000).map(_ == 500000).future(), Duration.Inf))
+    }
+  }
+}


### PR DESCRIPTION
this is useful for anyone writing loops with Task (or implementing a cats Monad for Task).

