### PR TITLE
add global maven2Local cache shortcut for ease of use

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,6 @@ import coursier.util.Task
 
 val repositories = Seq(
   Cache.ivy2Local,
-  Cache.maven2Local,
   MavenRepository("https://repo1.maven.org/maven2")
 )
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ import coursier.util.Task
 
 val repositories = Seq(
   Cache.ivy2Local,
+  Cache.maven2Local,
   MavenRepository("https://repo1.maven.org/maven2")
 )
 

--- a/cache/jvm/src/main/scala/coursier/Cache.scala
+++ b/cache/jvm/src/main/scala/coursier/Cache.scala
@@ -1128,8 +1128,6 @@ object Cache {
     throw new Exception("Cannot happen")
   )
 
-  lazy val maven2Local = MavenRepository(s"file://${System.getProperty("user.home")}/.m2/repository")
-
   lazy val default: File = CachePath.defaultCacheDirectory()
 
   val defaultConcurrentDownloadCount = 6
@@ -1182,4 +1180,13 @@ object Cache {
     }
   }
 
+  object Dangerous {
+    /**
+      * m2 local isn't guaranteed to always work fine with coursier (it sometimes has only the
+      * metadata of some dependencies, and coursier isn't fine with that - coursier requires
+      * both the metadata and the JARs to be in the same repo)
+      * see https://github.com/coursier/coursier/pull/868#issuecomment-398779799
+      */
+    lazy val maven2Local = MavenRepository(s"file://${System.getProperty("user.home")}/.m2/repository")
+  }
 }

--- a/cache/jvm/src/main/scala/coursier/Cache.scala
+++ b/cache/jvm/src/main/scala/coursier/Cache.scala
@@ -1128,6 +1128,8 @@ object Cache {
     throw new Exception("Cannot happen")
   )
 
+  lazy val maven2Local = MavenRepository(s"file://${System.getProperty("user.home")}/.m2/repository")
+
   lazy val default: File = CachePath.defaultCacheDirectory()
 
   val defaultConcurrentDownloadCount = 6

--- a/cache/jvm/src/main/scala/coursier/Cache.scala
+++ b/cache/jvm/src/main/scala/coursier/Cache.scala
@@ -1187,6 +1187,19 @@ object Cache {
       * both the metadata and the JARs to be in the same repo)
       * see https://github.com/coursier/coursier/pull/868#issuecomment-398779799
       */
-    lazy val maven2Local = MavenRepository(s"file://${System.getProperty("user.home")}/.m2/repository")
+    lazy val maven2Local = {
+
+      // TODO Add a small unit test for that repo…
+
+      // a bit touchy on Windows... - don't try to manually write down the URI with s"file://..."
+      val str = new File(sys.props("user.home")).toURI.toString
+      val homeUri =
+        if (str.endsWith("/"))
+          str
+        else
+          str + "/"
+
+      MavenRepository(homeUri + ".m2/repository")
+    }
   }
 }


### PR DESCRIPTION
When using the coursier API I was looking for a constant that links to
maven local, just like sbt's `Resolver.mavenLocal`. Didn't find it, so here it is.