### PR TITLE
Test that fails when provided dependency is not in the classpath

### DIFF
--- a/sbt-coursier/src/sbt-test/sbt-coursier/provided-dependency/Main.scala
+++ b/sbt-coursier/src/sbt-test/sbt-coursier/provided-dependency/Main.scala
@@ -1,0 +1,5 @@
+import javax.jms.Message
+
+object Main {
+  def p(msg: Message) = println(msg)
+}

--- a/sbt-coursier/src/sbt-test/sbt-coursier/provided-dependency/build.sbt
+++ b/sbt-coursier/src/sbt-test/sbt-coursier/provided-dependency/build.sbt
@@ -1,0 +1,2 @@
+scalaVersion := "2.12.6"
+libraryDependencies += "javax.jms" % "jms" % "1.1" % Provided

--- a/sbt-coursier/src/sbt-test/sbt-coursier/provided-dependency/build.sbt
+++ b/sbt-coursier/src/sbt-test/sbt-coursier/provided-dependency/build.sbt
@@ -1,2 +1,3 @@
 scalaVersion := "2.12.6"
 libraryDependencies += "javax.jms" % "jms" % "1.1" % Provided
+resolvers += ("jboss" at "https://repository.jboss.org/nexus/content/groups/public")

--- a/sbt-coursier/src/sbt-test/sbt-coursier/provided-dependency/project/plugins.sbt
+++ b/sbt-coursier/src/sbt-test/sbt-coursier/provided-dependency/project/plugins.sbt
@@ -1,0 +1,11 @@
+{
+  val pluginVersion = sys.props.getOrElse(
+    "plugin.version",
+    throw new RuntimeException(
+      """|The system property 'plugin.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin
+    )
+  )
+
+  addSbtPlugin("io.get-coursier" % "sbt-coursier" % pluginVersion)
+}

--- a/sbt-coursier/src/sbt-test/sbt-coursier/provided-dependency/test
+++ b/sbt-coursier/src/sbt-test/sbt-coursier/provided-dependency/test
@@ -1,0 +1,2 @@
+> update
+> compile


### PR DESCRIPTION
This issue is a bit related to https://github.com/coursier/coursier/issues/200 but here the issue is that dependencies are resolved successfully however after that the compilation fails.

This test succeeds with the default sbt resolver.