### PR TITLE
Introduce Scalafmt via Pants

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,20 @@
+maxColumn = 100
+
+docstrings = JavaDoc
+
+assumeStandardLibraryStripMargin = false
+
+align = none
+
+continuationIndent.callSite = 2
+continuationIndent.defnSite = 2
+
+danglingParentheses = true
+
+spaces.inImportCurlyBraces = false
+spaces.afterTripleEquals = true
+
+newlines.sometimesBeforeColonInMethodReturnType = true
+
+binPack.parentConstructors = false
+

--- a/BUILD.tools
+++ b/BUILD.tools
@@ -7,7 +7,7 @@ jar_library(
             rev = "2.12.6",
         ),
     ],
-    scope = 'runtime'
+    scope = "runtime",
 )
 
 jar_library(
@@ -17,6 +17,17 @@ jar_library(
             org = "org.scala-lang",
             name = "scala-compiler",
             rev = "2.12.6",
+        ),
+    ],
+)
+
+jar_library(
+    name = "scalafmt",
+    jars = [
+        jar(
+            org = "com.geirsson",
+            name = "scalafmt-cli_2.12",
+            rev = "1.5.1",
         ),
     ],
 )

--- a/pants.ini
+++ b/pants.ini
@@ -1,5 +1,6 @@
 [DEFAULT]
 local_artifact_cache: %(pants_bootstrapdir)s/artifact_cache
+scalafmt_conf: .scalafmt.conf
 
 [GLOBAL]
 pants_version: 1.8.0rc0
@@ -35,3 +36,8 @@ resolver: coursier
 [test.junit]
 jvm_options = ['-Xmx2048m']
 
+[fmt.scalafmt]
+configuration: %(scalafmt_conf)s
+
+[lint.scalafmt]
+configuration: %(scalafmt_conf)s

--- a/pants.ini
+++ b/pants.ini
@@ -36,6 +36,13 @@ resolver: coursier
 [test.junit]
 jvm_options = ['-Xmx2048m']
 
+# Disable all fmt tasks except scalafmt
+[fmt]
+skip: True
+
+[fmt.scalafmt]
+skip: False
+
 [fmt.scalafmt]
 configuration: %(scalafmt_conf)s
 

--- a/pants.ini
+++ b/pants.ini
@@ -39,5 +39,10 @@ jvm_options = ['-Xmx2048m']
 [fmt.scalafmt]
 configuration: %(scalafmt_conf)s
 
+# Disable all lint tasks except scalafmt
+[lint]
+skip: True
+
 [lint.scalafmt]
 configuration: %(scalafmt_conf)s
+skip: False

--- a/pants.ini
+++ b/pants.ini
@@ -1,6 +1,6 @@
 [DEFAULT]
 local_artifact_cache: %(pants_bootstrapdir)s/artifact_cache
-scalafmt_conf: .scalafmt.conf
+scalafmt_conf: %(buildroot)s/.scalafmt.conf
 
 [GLOBAL]
 pants_version: 1.8.0rc0


### PR DESCRIPTION
This introduces scalafmt as an automated formatter and linter via Pants.

### To format:
```
./pants fmt ::
```

### To lint (which would run in CI):
```
./pants lint ::
```

Example changes are visible at: https://github.com/coursier/coursier/compare/master...wisechengyi:eg?expand=1

A separate PR would be made once this gets in to format all targets covered by Pants and to enforce it via CI.