### PR TITLE
improvement: print out the content that failed to parse as XML

### DIFF
--- a/core/jvm/src/main/scala/coursier/core/compatibility/package.scala
+++ b/core/jvm/src/main/scala/coursier/core/compatibility/package.scala
@@ -33,7 +33,13 @@ package object compatibility {
 
     def parse =
       try Right(scala.xml.XML.loadString(content.stripPrefix(utf8Bom)))
-      catch { case e: Exception => Left(e.toString + Option(e.getMessage).fold("")(" (" + _ + ")")) }
+      catch {
+        case e: Exception =>
+          val message = e.toString +
+            Option(e.getMessage).fold("")(" (" + _ + ")") +
+            s" while parsing following content:\n $content"
+          Left(message)
+      }
 
     def fromNode(node: scala.xml.Node): Xml.Node =
       new Xml.Node {


### PR DESCRIPTION
Having coursier print out the whole content of the invalid XML can be helpful in various troubleshooting situations. For example it already allowed me to figure out, that my repository address was configured incorrectly (with http instead of https, which made the nexus send a HTML redirect page) - more details at https://github.com/coursier/coursier/issues/889

Ideally the error message would additionally include the original URL, but I don't know coursier's codebase well enough to do it quickly and the full string content of invalid XML should let the users troubleshoot more easily.