### PR TITLE
Don't rely on directory listings anymore

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,8 @@ lazy val `proxy-tests` = project
     coursierPrefix,
     libs ++= Seq(
       Deps.dockerClient,
-      Deps.scalaAsync.value
+      Deps.scalaAsync.value,
+      Deps.slf4JNop
     ),
     utest,
     sharedTestResources

--- a/core/shared/src/main/scala/coursier/core/Definitions.scala
+++ b/core/shared/src/main/scala/coursier/core/Definitions.scala
@@ -73,18 +73,19 @@ final case class Attributes(
   `type`: String,
   classifier: String
 ) {
-  def packaging: String = if (`type`.isEmpty)
+  def packaging: String =
+    if (`type`.isEmpty)
       "jar"
     else
       `type`
 
-  def packagingAndClassifier: String = if (isEmpty) {
+  def packagingAndClassifier: String =
+    if (isEmpty)
       ""
-    } else if (classifier.isEmpty) {
+    else if (classifier.isEmpty)
       packaging
-    } else {
+    else
       s"$packaging:$classifier"
-    }
 
   def publication(name: String, ext: String): Publication =
     Publication(name, `type`, ext, classifier)

--- a/core/shared/src/main/scala/coursier/core/Repository.scala
+++ b/core/shared/src/main/scala/coursier/core/Repository.scala
@@ -1,8 +1,8 @@
 package coursier.core
 
 import coursier.Fetch
-
 import coursier.core.compatibility.encodeURIComponent
+import coursier.maven.MavenSource
 import coursier.util.{EitherT, Monad}
 
 trait Repository extends Product with Serializable {
@@ -24,19 +24,28 @@ object Repository {
         "SHA-1" -> (underlying.url + ".sha1"),
         "SHA-256" -> (underlying.url + ".sha256")
       ))
-    def withDefaultSignature: Artifact =
+    def withDefaultSignature: Artifact = {
+
+      val underlyingExt =
+        if (underlying.attributes.`type`.isEmpty)
+          "jar"
+        else
+          // TODO move MavenSource.typeExtension elsewhere
+          MavenSource.typeExtension(underlying.attributes.`type`)
+
       underlying.copy(extra = underlying.extra ++ Seq(
         "sig" ->
           Artifact(
             underlying.url + ".asc",
             Map.empty,
             Map.empty,
-            Attributes("asc", ""),
+            Attributes(s"$underlyingExt.asc", ""),
             changing = underlying.changing,
             authentication = underlying.authentication
           )
             .withDefaultChecksums
       ))
+    }
   }
 }
 

--- a/core/shared/src/main/scala/coursier/ivy/IvyRepository.scala
+++ b/core/shared/src/main/scala/coursier/ivy/IvyRepository.scala
@@ -79,9 +79,12 @@ final case class IvyRepository(
                   }
                 else if (dependency.attributes.`type`.nonEmpty)
                   project.publications.collect {
-                    case (_, p)
-                      if p.classifier.isEmpty && (
-                        p.`type` == dependency.attributes.`type` ||
+                    case (conf, p)
+                      if (conf == "*" ||
+                        conf == dependency.configuration ||
+                        project.allConfigurations.getOrElse(dependency.configuration, Set.empty).contains(conf)) &&
+                        (
+                          p.`type` == dependency.attributes.`type` ||
                           (p.ext == dependency.attributes.`type` && project.packagingOpt.toSeq.contains(p.`type`)) // wow
                         ) =>
                       p

--- a/core/shared/src/main/scala/coursier/maven/MavenSource.scala
+++ b/core/shared/src/main/scala/coursier/maven/MavenSource.scala
@@ -46,22 +46,17 @@ final case class MavenSource(
       )
 
       val changing0 = changing.getOrElse(isSnapshot(project.actualVersion))
-      var artifact =
-        Artifact(
-          root + path.mkString("/"),
-          Map.empty,
-          Map.empty,
-          publication.attributes,
-          changing = changing0,
-          authentication = authentication
-        )
-          .withDefaultChecksums
-          .withDefaultSignature
 
-      if (publication.ext == "jar")
-        artifact = artifact.withDefaultSignature
-
-      artifact
+      Artifact(
+        root + path.mkString("/"),
+        Map.empty,
+        Map.empty,
+        publication.attributes,
+        changing = changing0,
+        authentication = authentication
+      )
+        .withDefaultChecksums
+        .withDefaultSignature
     }
 
     val metadataArtifact = artifactOf(Publication(dependency.module.name, "pom", "pom", ""))

--- a/core/shared/src/main/scala/coursier/maven/MavenSource.scala
+++ b/core/shared/src/main/scala/coursier/maven/MavenSource.scala
@@ -32,7 +32,11 @@ final case class MavenSource(
       val versioning = project
         .snapshotVersioning
         .flatMap(versioning =>
-          mavenVersioning(versioning, publication.classifier, publication.`type`)
+          mavenVersioning(
+            versioning,
+            publication.classifier,
+            MavenSource.typeExtension(publication.`type`)
+          )
         )
 
       val path = dependency.module.organization.split('.').toSeq ++ Seq(
@@ -52,6 +56,7 @@ final case class MavenSource(
           authentication = authentication
         )
           .withDefaultChecksums
+          .withDefaultSignature
 
       if (publication.ext == "jar")
         artifact = artifact.withDefaultSignature
@@ -133,142 +138,6 @@ final case class MavenSource(
       .map(artifactWithExtra)
   }
 
-  private val types = Map("sha1" -> "SHA-1", "sha256" -> "SHA-256", "md5" -> "MD5", "asc" -> "sig")
-
-  private def artifactsKnownPublications(
-    dependency: Dependency,
-    project: Project,
-    overrideClassifiers: Option[Seq[String]]
-  ): Seq[Artifact] = {
-
-    final case class EnrichedPublication(
-      publication: Publication,
-      extra: Map[String, EnrichedPublication]
-    ) {
-      def artifact: Artifact =
-        artifact(publication.`type`)
-      def artifact(versioningType: String): Artifact = {
-
-        val versioningExtension = MavenSource.typeExtensions.getOrElse(versioningType, versioningType)
-
-        val versioning = project
-          .snapshotVersioning
-          .flatMap(versioning =>
-            mavenVersioning(versioning, publication.classifier, versioningExtension)
-          )
-
-        val path = dependency.module.organization.split('.').toSeq ++ Seq(
-          MavenRepository.dirModuleName(dependency.module, sbtAttrStub),
-          project.actualVersion,
-          s"${dependency.module.name}-${versioning getOrElse project.actualVersion}${Some(publication.classifier).filter(_.nonEmpty).map("-" + _).mkString}.${publication.ext}"
-        )
-
-        val changing0 = changing.getOrElse(isSnapshot(project.actualVersion))
-
-        val extra0 = extra.mapValues(_.artifact(versioningType)).iterator.toMap
-
-        Artifact(
-          root + path.mkString("/"),
-          extra0.filterKeys(MavenSource.checksumTypes).mapValues(_.url).iterator.toMap,
-          extra0,
-          publication.attributes,
-          changing = changing0,
-          authentication = authentication
-        )
-      }
-    }
-
-    def groupedEnrichedPublications(publications: Seq[Publication]): Seq[EnrichedPublication] = {
-
-      def helper(publications: Seq[Publication]): Seq[EnrichedPublication] = {
-
-        var publications0 = publications
-          .map { pub =>
-            pub.ext -> EnrichedPublication(pub, Map())
-          }
-          .toMap
-
-        val byLength = publications0.toVector.sortBy(-_._1.length)
-
-        for {
-          (ext, _) <- byLength
-          idx = ext.lastIndexOf('.')
-          if idx >= 0
-          subExt = ext.substring(idx + 1)
-          baseExt = ext.substring(0, idx)
-          tpe <- types.get(subExt)
-          mainPub <- publications0.get(baseExt)
-        } {
-          val pub = publications0(ext)
-          publications0 += baseExt -> mainPub.copy(
-            extra = mainPub.extra + (tpe -> pub)
-          )
-          publications0 -= ext
-        }
-
-        publications0.values.toVector
-      }
-
-      publications
-        .groupBy(p => (p.name, p.classifier))
-        .mapValues(helper)
-        .values
-        .toVector
-        .flatten
-    }
-
-    val enrichedPublications = groupedEnrichedPublications(project.publications.map(_._2))
-
-    val metadataArtifactOpt = enrichedPublications.collectFirst {
-      case pub if pub.publication.name == dependency.module.name &&
-          pub.publication.ext == "pom" &&
-          pub.publication.classifier.isEmpty =>
-        pub.artifact
-    }
-
-    def withMetadataExtra(artifact: Artifact) =
-      metadataArtifactOpt.fold(artifact) { metadataArtifact =>
-        artifact.copy(
-          extra = artifact.extra + ("metadata" -> metadataArtifact)
-        )
-      }
-
-    val res = overrideClassifiers match {
-      case Some(classifiers) =>
-        val classifiersSet = classifiers.toSet
-
-        enrichedPublications.collect {
-          case p if classifiersSet(p.publication.classifier) =>
-            p.artifact
-        }
-
-      case None =>
-
-        if (dependency.attributes.classifier.nonEmpty)
-          // FIXME We're ignoring dependency.attributes.`type` in this case
-          enrichedPublications.collect {
-            case p if p.publication.classifier == dependency.attributes.classifier =>
-              p.artifact
-          }
-        else if (dependency.attributes.`type`.nonEmpty)
-          enrichedPublications.collect {
-            case p
-              if (p.publication.classifier.isEmpty || p.publication.classifier == MavenSource.typeDefaultClassifier(dependency.attributes.`type`)) && (
-                   p.publication.`type` == dependency.attributes.`type` ||
-                   (p.publication.ext == dependency.attributes.`type` && project.packagingOpt.toSeq.contains(p.publication.`type`)) // wow
-                ) =>
-              p.artifact
-          }
-        else
-          enrichedPublications.collect {
-            case p if p.publication.classifier.isEmpty =>
-              p.artifact
-          }
-    }
-
-    res.map(withMetadataExtra)
-  }
-
   private val dummyArtifact = Artifact("", Map(), Map(), Attributes("", ""), changing = false, None)
 
   def artifacts(
@@ -285,51 +154,12 @@ final case class MavenSource(
           extra = a.extra.mapValues(makeOptional).iterator.toMap + (Artifact.optionalKey -> dummyArtifact)
         )
 
-      def merge(a: Artifact, other: Artifact): Artifact = {
-
-        assert(a.url == other.url, s"Merging artifacts with different URLs (${a.url}, ${other.url})")
-
-        val extra =
-          a.extra.map {
-            case (k, v) =>
-              k -> other.extra.get(k).fold(v)(merge(v, _))
-          } ++
-          other.extra
-            .filterKeys(k => !a.extra.contains(k) && k != Artifact.optionalKey)
-
-        a.copy(
-          checksumUrls = other.checksumUrls ++ a.checksumUrls,
-          extra = extra
-        )
-      }
-
-      val defaultPublications = artifactsUnknownPublications(dependency, project, overrideClassifiers)
+      artifactsUnknownPublications(dependency, project, overrideClassifiers)
         .map(makeOptional)
-
-      if (project.publications.isEmpty)
-        defaultPublications
-      else {
-        val listedPublications = artifactsKnownPublications(dependency, project, overrideClassifiers)
-        val listedUrls = listedPublications.map(_.url).toSet
-        val defaultPublicationsMap = defaultPublications
-          .map(a => a.url -> a)
-          .toMap
-        val listedPublications0 = listedPublications.map { a =>
-          defaultPublicationsMap
-            .get(a.url)
-            .fold(a)(merge(a, _))
-        }
-        val extraPublications = defaultPublications
-          .filter(a => !listedUrls(a.url))
-
-        listedPublications0 ++ extraPublications
-      }
     }
 }
 
 object MavenSource {
-
-  private val checksumTypes = Set("MD5", "SHA-1", "SHA-256")
 
   val typeExtensions: Map[String, String] = Map(
     "eclipse-plugin" -> "jar",
@@ -372,13 +202,5 @@ object MavenSource {
 
   def classifierExtensionDefaultTypeOpt(classifier: String, ext: String): Option[String] =
     classifierExtensionDefaultTypes.get((classifier, ext))
-
-  val typeDefaultConfigs: Map[String, String] = Map(
-    "doc" -> "docs",
-    "src" -> "sources"
-  )
-
-  def typeDefaultConfig(`type`: String): Option[String] =
-    typeDefaultConfigs.get(`type`)
 
 }

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -45,4 +45,6 @@ object Deps {
   def scalaNativeNir = "org.scala-native" %% "nir" % SharedVersions.scalaNative
   def scalaNativeTools = "org.scala-native" %% "tools" % SharedVersions.scalaNative
   def scalaNativeUtil = "org.scala-native" %% "util" % SharedVersions.scalaNative
+
+  def slf4JNop = "org.slf4j" % "slf4j-nop" % "1.7.25"
 }

--- a/sbt-pgp-coursier/src/sbt-test/sbt-pgp-coursier/simple/build.sbt
+++ b/sbt-pgp-coursier/src/sbt-test/sbt-pgp-coursier/simple/build.sbt
@@ -16,7 +16,6 @@ check := {
       sys.error("No configuration report found for configuration 'compile'")
     }
   val moduleReports = configReport.modules
-  val artifacts = moduleReports.flatMap(_.artifacts.map(_._1))
   val signatures = moduleReports
     .flatMap(_.artifacts)
     .filter(_._1.extension == "jar.asc")

--- a/tests/jvm/src/it/scala/coursier/test/DirectoryListingTests.scala
+++ b/tests/jvm/src/it/scala/coursier/test/DirectoryListingTests.scala
@@ -9,13 +9,8 @@ object DirectoryListingTests extends TestSuite {
   val user = "user"
   val password = "pass"
 
-  val withListingRepo = MavenRepository(
+  val repo = MavenRepository(
     "http://localhost:8080",
-    authentication = Some(Authentication(user, password))
-  )
-
-  val withoutListingRepo = MavenRepository(
-    "http://localhost:8081",
     authentication = Some(Authentication(user, password))
   )
 
@@ -23,48 +18,26 @@ object DirectoryListingTests extends TestSuite {
   val version = "0.1"
 
   val tests = Tests {
-    'withListing - {
-      'jar - CentralTests.withArtifacts(
-        module,
-        version,
-        "jar",
-        extraRepos = Seq(withListingRepo)
-      ) {
-        artifacts =>
-          assert(artifacts.length == 1)
-      }
-
-      'jarFoo - CentralTests.withArtifacts(
-        module,
-        version,
-        "jar-foo",
-        extraRepos = Seq(withListingRepo)
-      ) {
-        artifacts =>
-          assert(artifacts.length == 1)
-      }
+    'jar - CentralTests.withArtifacts(
+      module,
+      version,
+      attributes = Attributes("jar"),
+      extraRepos = Seq(repo)
+    ) {
+      artifacts =>
+        assert(artifacts.length == 1)
+        assert(artifacts.headOption.exists(_.url.endsWith(".jar")))
     }
 
-    'withoutListing - {
-      'jar - CentralTests.withArtifacts(
-        module,
-        version,
-        "jar",
-        extraRepos = Seq(withoutListingRepo)
-      ) {
-        artifacts =>
-          assert(artifacts.length == 1)
-      }
-
-      'jarFoo - CentralTests.withArtifacts(
-        module,
-        version,
-        "jar-foo",
-        extraRepos = Seq(withoutListingRepo)
-      ) {
-        artifacts =>
-          assert(artifacts.length == 0)
-      }
+    'jarFoo - CentralTests.withArtifacts(
+      module,
+      version,
+      attributes = Attributes("jar-foo"),
+      extraRepos = Seq(repo)
+    ) {
+      artifacts =>
+        assert(artifacts.length == 1)
+        assert(artifacts.headOption.exists(_.url.endsWith(".jar-foo")))
     }
   }
 

--- a/tests/jvm/src/test/scala/coursier/test/IvyTests.scala
+++ b/tests/jvm/src/test/scala/coursier/test/IvyTests.scala
@@ -81,14 +81,26 @@ object IvyTests extends TestSuite {
           throw new Exception(s"Unexpected number of artifacts\n${other.mkString("\n")}")
       }
 
-      "test conf" - CentralTests.withArtifacts(
-        dep = dep.copy(configuration = "test"),
-        extraRepos = Seq(repo),
-        classifierOpt = None
-      ) { artifacts =>
-        val urls = artifacts.map(_.url).toSet
-        assert(urls(mainJarUrl))
-        assert(urls(testJarUrl))
+      "test conf" - {
+        "no attributes" - CentralTests.withArtifacts(
+          dep = dep.copy(configuration = "test"),
+          extraRepos = Seq(repo),
+          classifierOpt = None
+        ) { artifacts =>
+          val urls = artifacts.map(_.url).toSet
+          assert(urls(mainJarUrl))
+          assert(urls(testJarUrl))
+        }
+
+        "attributes" - CentralTests.withArtifacts(
+          dep = dep.copy(configuration = "test", attributes = Attributes("jar")),
+          extraRepos = Seq(repo),
+          classifierOpt = None
+        ) { artifacts =>
+          val urls = artifacts.map(_.url).toSet
+          assert(urls(mainJarUrl))
+          assert(urls(testJarUrl))
+        }
       }
 
       "tests classifier" - {

--- a/tests/jvm/src/test/scala/coursier/test/IvyTests.scala
+++ b/tests/jvm/src/test/scala/coursier/test/IvyTests.scala
@@ -46,8 +46,8 @@ object IvyTests extends TestSuite {
         extraRepos = Seq(sbtRepo)
       )
 
-      * - CentralTests.withArtifact(mod, ver, "jar", extraRepos = Seq(sbtRepo)) { artifact =>
-        assert(artifact.url == expectedArtifactUrl)
+      * - CentralTests.withArtifacts(mod, ver, Attributes("jar"), extraRepos = Seq(sbtRepo)) { artifacts =>
+        assert(artifacts.exists(_.url == expectedArtifactUrl))
       }
     }
 
@@ -71,11 +71,9 @@ object IvyTests extends TestSuite {
       val testJarUrl = repoBase + "com.example/a_2.11/0.1.0-SNAPSHOT/jars/a_2.11-tests.jar"
 
       "no conf or classifier" - CentralTests.withArtifacts(
-        dep = dep,
-        artifactType = "jar",
+        dep = dep.copy(attributes = Attributes("jar")),
         extraRepos = Seq(repo),
-        classifierOpt = None,
-        optional = true
+        classifierOpt = None
       ) {
         case Seq(artifact) =>
           assert(artifact.url == mainJarUrl)
@@ -85,19 +83,12 @@ object IvyTests extends TestSuite {
 
       "test conf" - CentralTests.withArtifacts(
         dep = dep.copy(configuration = "test"),
-        artifactType = "jar",
         extraRepos = Seq(repo),
-        classifierOpt = None,
-        optional = true
-      ) {
-        case Seq(artifact1, artifact2) =>
-          val urls = Set(
-            artifact1.url,
-            artifact2.url
-          )
-          assert(urls == Set(mainJarUrl, testJarUrl))
-        case other =>
-          throw new Exception(s"Unexpected number of artifacts\n${other.mkString("\n")}")
+        classifierOpt = None
+      ) { artifacts =>
+        val urls = artifacts.map(_.url).toSet
+        assert(urls(mainJarUrl))
+        assert(urls(testJarUrl))
       }
 
       "tests classifier" - {
@@ -105,27 +96,18 @@ object IvyTests extends TestSuite {
 
         * - CentralTests.withArtifacts(
           deps = Set(dep, testsDep),
-          artifactType = "jar",
           extraRepos = Seq(repo),
-          classifierOpt = None,
-          optional = true
-        ) {
-          case Seq(artifact1, artifact2) =>
-            val urls = Set(
-              artifact1.url,
-              artifact2.url
-            )
-            assert(urls == Set(mainJarUrl, testJarUrl))
-          case other =>
-            throw new Exception(s"Unexpected number of artifacts\n${other.mkString("\n")}")
+          classifierOpt = None
+        ) { artifacts =>
+          val urls = artifacts.map(_.url).toSet
+          assert(urls(mainJarUrl))
+          assert(urls(testJarUrl))
         }
 
         * - CentralTests.withArtifacts(
           dep = testsDep,
-          artifactType = "jar",
           extraRepos = Seq(repo),
-          classifierOpt = None,
-          optional = true
+          classifierOpt = None
         ) {
           case Seq(artifact) =>
             assert(artifact.url == testJarUrl)

--- a/tests/jvm/src/test/scala/coursier/test/MavenTests.scala
+++ b/tests/jvm/src/test/scala/coursier/test/MavenTests.scala
@@ -26,11 +26,9 @@ object MavenTests extends TestSuite {
       val sourcesJarUrl = repoBase + "com/abc/test-snapshot-special/0.1.0-SNAPSHOT/test-snapshot-special-0.1.0-20170421.034426-82-sources.jar"
 
       * - CentralTests.withArtifacts(
-        dep = dep,
-        artifactType = "jar",
+        dep = dep.copy(attributes = Attributes("jar")),
         extraRepos = Seq(repo),
-        classifierOpt = None,
-        optional = true
+        classifierOpt = None
       ) {
         case Seq(artifact) =>
           assert(artifact.url == mainJarUrl)
@@ -39,11 +37,9 @@ object MavenTests extends TestSuite {
       }
 
       * - CentralTests.withArtifacts(
-        dep = dep,
-        artifactType = "src",
+        dep = dep.copy(attributes = Attributes("src")),
         extraRepos = Seq(repo),
-        classifierOpt = Some("sources"),
-        optional = true
+        classifierOpt = Some("sources")
       ) {
         case Seq(artifact) =>
           assert(artifact.url == sourcesJarUrl)


### PR DESCRIPTION
This should save some bandwidth, and avoid round-trips with repositories.

Fixes https://github.com/coursier/coursier/issues/896.