### PR TITLE
Adjust tests relying on cache path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,4 @@ cache:
   - $HOME/.m2
   - $HOME/.ivy2/cache
   - $HOME/.sbt
-  - $HOME/.coursier
-  # Pants cache
   - $HOME/.cache

--- a/cli/src/main/scala-2.12/coursier/cli/options/CacheOptions.scala
+++ b/cli/src/main/scala-2.12/coursier/cli/options/CacheOptions.scala
@@ -4,7 +4,7 @@ import caseapp.{ExtraName => Short, HelpMessage => Help, _}
 import coursier.Cache
 
 final case class CacheOptions(
-  @Help("Cache directory (defaults to environment variable COURSIER_CACHE or ~/.coursier/cache/v1)")
+  @Help("Cache directory (defaults to environment variable COURSIER_CACHE, or ~/.cache/coursier/v1 on Linux and ~/Library/Caches/Coursier/v1 on Mac)")
     cache: String = Cache.default.toString
 )
 

--- a/cli/src/test/scala-2.12/coursier/cli/CliFetchIntegrationTest.scala
+++ b/cli/src/test/scala-2.12/coursier/cli/CliFetchIntegrationTest.scala
@@ -506,7 +506,11 @@ class CliFetchIntegrationTest extends FlatSpec with CliTestLib with Matchers {
           assert(depNodes2.length == 1)
 
           val urlInJsonFile2 = depNodes2.head.file.get
-          assert(urlInJsonFile2.contains("coursier/cache") && urlInJsonFile2.contains(testFile.toString))
+          val inCoursierCache =
+            urlInJsonFile2.contains("/.coursier/") || // Former cache path
+              urlInJsonFile2.contains("/coursier/") || // New cache path, Linux
+              urlInJsonFile2.contains("/Coursier/") // New cache path, OS X
+          assert(inCoursierCache && urlInJsonFile2.contains(testFile.toString))
         }
       }
     }

--- a/sbt-pgp-coursier/src/sbt-test/sbt-pgp-coursier/simple/build.sbt
+++ b/sbt-pgp-coursier/src/sbt-test/sbt-pgp-coursier/simple/build.sbt
@@ -24,8 +24,18 @@ check := {
     signatures.nonEmpty,
     "No signatures found"
   )
+  def isCoursierCachePath(p: File) = {
+    val abs = p.getAbsolutePath
+    abs.contains("/.coursier/") || // Former cache path
+      abs.contains("/coursier/") || // New cache path, Linux
+      abs.contains("/Coursier/")  // New cache path, OS X
+  }
   assert(
-    signatures.forall(_.getAbsolutePath.contains("/.coursier/cache/")),
-    s"Found signatures not provided by coursier:\n${signatures.map("  " + _).mkString("\n")}"
+    signatures.forall(isCoursierCachePath),
+    s"Found signatures not provided by coursier:\n" +
+      signatures
+        .filter(!isCoursierCachePath(_))
+        .map("  " + _)
+        .mkString("\n")
   )
 }


### PR DESCRIPTION
The default cache path changed some time ago, from `~/.coursier/cache/v1` to `~/.cache/coursier/v1` (Linux) or `~/Library/Caches/Coursier/v1` (OS X).

The former is still used if it is found locally and the new one isn't found. Else the new one is created if necessary, and used.