### PR TITLE
fix build definition to compile on JDK 11

### DIFF
--- a/project/Release.scala
+++ b/project/Release.scala
@@ -153,8 +153,10 @@ object Release {
 
     val cmd = Seq(state.vcs.commandName, "tag", "--sort", "version:refname")
 
-    val tag = scala.sys.process.Process(cmd)
-      .!!
+    val tag =
+      // work around scala/bug#11125
+      Predef.augmentString(
+        scala.sys.process.Process(cmd).!!)
       .lines
       .toVector
       .lastOption


### PR DESCRIPTION
caught by https://scala-ci.typesafe.com/view/scala-2.12.x/job/scala-2.12.x-jdk11-integrate-community-build/34/