### PR TITLE
Publish core as coursier-core

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ lazy val core = crossProject("core")(JSPlatform, JVMPlatform)
   )
   .settings(
     shared,
-    name := "coursier",
+    coursierPrefix,
     Mima.previousArtifacts,
     Mima.coreFilters
   )
@@ -244,6 +244,20 @@ lazy val okhttp = project("okhttp")
     libs += Deps.okhttpUrlConnection
   )
 
+lazy val meta = crossProject("meta")(JSPlatform, JVMPlatform)
+  .dependsOn(core, cache)
+  .settings(
+    shared,
+    moduleName := "coursier",
+    // POM only
+    publishArtifact.in(Compile, packageDoc) := false,
+    publishArtifact.in(Compile, packageSrc) := false,
+    publishArtifact.in(Compile, packageBin) := false
+  )
+
+lazy val metaJvm = meta.jvm
+lazy val metaJs = meta.js
+
 lazy val jvm = project("jvm")
   .dummy
   .aggregate(
@@ -257,7 +271,8 @@ lazy val jvm = project("jvm")
     extra,
     cli,
     readme,
-    okhttp
+    okhttp,
+    metaJvm
   )
   .settings(
     shared,
@@ -271,7 +286,8 @@ lazy val js = project("js")
     coreJs,
     cacheJs,
     testsJs,
-    web
+    web,
+    metaJs
   )
   .settings(
     shared,
@@ -297,7 +313,9 @@ lazy val coursier = project("coursier")
     scalazJs,
     web,
     readme,
-    okhttp
+    okhttp,
+    metaJvm,
+    metaJs
   )
   .settings(
     shared,

--- a/modules/tests/jvm/src/it/scala/coursier/test/IvyLocalTests.scala
+++ b/modules/tests/jvm/src/it/scala/coursier/test/IvyLocalTests.scala
@@ -11,7 +11,7 @@ object IvyLocalTests extends TestSuite {
 
   val tests = TestSuite{
     'coursier {
-      val module = Module("io.get-coursier", "coursier_2.11")
+      val module = Module("io.get-coursier", "coursier-core_2.11")
       val version = coursier.util.Properties.version
 
       val extraRepos = Seq(Cache.ivy2Local)

--- a/modules/tests/shared/src/test/resources/resolutions/io.get-coursier/coursier-core_2.11/1.1.0-SNAPSHOT
+++ b/modules/tests/shared/src/test/resources/resolutions/io.get-coursier/coursier-core_2.11/1.1.0-SNAPSHOT
@@ -1,3 +1,3 @@
-io.get-coursier:coursier_2.11:1.1.0-SNAPSHOT:compile
+io.get-coursier:coursier-core_2.11:1.1.0-SNAPSHOT:compile
 org.scala-lang:scala-library:2.11.12:default
 org.scala-lang.modules:scala-xml_2.11:1.1.0:default


### PR DESCRIPTION
And add POM only `io.get-coursier:coursier` module depending both on `io.get-coursier:coursier-core` and `io.get-coursier:coursier-cache`.