### PR TITLE
Mention `brew tap` before `brew install` in docs

### DIFF
--- a/doc/docs/cli-intro.md
+++ b/doc/docs/cli-intro.md
@@ -26,6 +26,7 @@ tag of a specific version, to download the launcher of that exact version, like
 
 Alternatively on OS X, install it via homebrew, that puts the `coursier` launcher directly in your PATH,
 ```
+$ brew tap coursier/formulas
 $ brew install --HEAD coursier/formulas/coursier
 ```
 


### PR DESCRIPTION
When I tried it without `tap`, I got:
```
Error: No available formula with the name "coursier/formulas/coursier"
Please tap it and then try again: brew tap coursier/formulas
```