### PR TITLE
Allow to add classifier artifacts in bootstraps

### DIFF
--- a/modules/cli/src/main/scala-2.12/coursier/cli/Bootstrap.scala
+++ b/modules/cli/src/main/scala-2.12/coursier/cli/Bootstrap.scala
@@ -27,7 +27,7 @@ object Bootstrap extends CaseApp[BootstrapOptions] {
     val files = helper.fetch(
       sources = false,
       javadoc = false,
-      artifactTypes = options.artifactOptions.artifactTypes(sources = false, javadoc = false)
+      artifactTypes = options.artifactOptions.artifactTypes()
     )
 
     val log: String => Unit =
@@ -168,7 +168,7 @@ object Bootstrap extends CaseApp[BootstrapOptions] {
           val m = helper.fetchMap(
             sources = false,
             javadoc = false,
-            artifactTypes = options.artifactOptions.artifactTypes(sources = false, javadoc = false),
+            artifactTypes = options.artifactOptions.artifactTypes(),
             subset = isolatedDeps.getOrElse(target, Seq.empty).toSet
           )
 
@@ -353,7 +353,7 @@ object Bootstrap extends CaseApp[BootstrapOptions] {
         helper.fetchMap(
           sources = false,
           javadoc = false,
-          artifactTypes = options.artifactOptions.artifactTypes(sources = false, javadoc = false)
+          artifactTypes = options.artifactOptions.artifactTypes()
         ).toList.foldLeft((List.empty[String], List.empty[File])){
           case ((urls, files), (url, file)) =>
             if (options.options.assembly || options.options.standalone) (urls, file :: files)

--- a/modules/cli/src/main/scala-2.12/coursier/cli/Bootstrap.scala
+++ b/modules/cli/src/main/scala-2.12/coursier/cli/Bootstrap.scala
@@ -167,10 +167,10 @@ object Bootstrap extends CaseApp[BootstrapOptions] {
           // TODO Add non regression test checking that optional artifacts indeed land in the isolated loader URLs
 
           val m = helper.fetchMap(
-            sources = false,
-            javadoc = false,
-            default = true,
-            artifactTypes = options.artifactOptions.artifactTypes(),
+            sources = options.artifactOptions.sources,
+            javadoc = options.artifactOptions.javadoc,
+            default = options.artifactOptions.default0(options.options.common.classifier0),
+            artifactTypes = options.artifactOptions.artifactTypes(options.options.common.classifier0),
             subset = isolatedDeps.getOrElse(target, Seq.empty).toSet
           )
 

--- a/modules/cli/src/main/scala-2.12/coursier/cli/Bootstrap.scala
+++ b/modules/cli/src/main/scala-2.12/coursier/cli/Bootstrap.scala
@@ -27,6 +27,7 @@ object Bootstrap extends CaseApp[BootstrapOptions] {
     val files = helper.fetch(
       sources = false,
       javadoc = false,
+      default = true,
       artifactTypes = options.artifactOptions.artifactTypes()
     )
 
@@ -168,6 +169,7 @@ object Bootstrap extends CaseApp[BootstrapOptions] {
           val m = helper.fetchMap(
             sources = false,
             javadoc = false,
+            default = true,
             artifactTypes = options.artifactOptions.artifactTypes(),
             subset = isolatedDeps.getOrElse(target, Seq.empty).toSet
           )
@@ -353,6 +355,7 @@ object Bootstrap extends CaseApp[BootstrapOptions] {
         helper.fetchMap(
           sources = false,
           javadoc = false,
+          default = true,
           artifactTypes = options.artifactOptions.artifactTypes()
         ).toList.foldLeft((List.empty[String], List.empty[File])){
           case ((urls, files), (url, file)) =>

--- a/modules/cli/src/main/scala-2.12/coursier/cli/Bootstrap.scala
+++ b/modules/cli/src/main/scala-2.12/coursier/cli/Bootstrap.scala
@@ -25,10 +25,10 @@ object Bootstrap extends CaseApp[BootstrapOptions] {
   ): Unit = {
 
     val files = helper.fetch(
-      sources = false,
-      javadoc = false,
-      default = true,
-      artifactTypes = options.artifactOptions.artifactTypes()
+      sources = options.artifactOptions.sources,
+      javadoc = options.artifactOptions.javadoc,
+      default = options.artifactOptions.default0(options.options.common.classifier0),
+      artifactTypes = options.artifactOptions.artifactTypes(options.options.common.classifier0)
     )
 
     val log: String => Unit =
@@ -353,10 +353,10 @@ object Bootstrap extends CaseApp[BootstrapOptions] {
 
       val (urls, files) =
         helper.fetchMap(
-          sources = false,
-          javadoc = false,
-          default = true,
-          artifactTypes = options.artifactOptions.artifactTypes()
+          sources = options.artifactOptions.sources,
+          javadoc = options.artifactOptions.javadoc,
+          default = options.artifactOptions.default0(options.options.common.classifier0),
+          artifactTypes = options.artifactOptions.artifactTypes(options.options.common.classifier0)
         ).toList.foldLeft((List.empty[String], List.empty[File])){
           case ((urls, files), (url, file)) =>
             if (options.options.assembly || options.options.standalone) (urls, file :: files)

--- a/modules/cli/src/main/scala-2.12/coursier/cli/Fetch.scala
+++ b/modules/cli/src/main/scala-2.12/coursier/cli/Fetch.scala
@@ -11,18 +11,18 @@ final class Fetch(options: FetchOptions, args: RemainingArgs) {
 
   val helper = new Helper(options.common, args.all, ignoreErrors = options.artifactOptions.force)
 
-  val default = options.default.getOrElse {
-    (!options.sources && !options.javadoc && options.common.classifier0.isEmpty) ||
+  val default = options.artifactOptions.default.getOrElse {
+    (!options.artifactOptions.sources && !options.artifactOptions.javadoc && options.common.classifier0.isEmpty) ||
       options.common.classifier0(Classifier("_"))
   }
 
   val files0 = helper.fetch(
-    sources = options.sources,
-    javadoc = options.javadoc,
+    sources = options.artifactOptions.sources,
+    javadoc = options.artifactOptions.javadoc,
     default = default,
     artifactTypes = options.artifactOptions.artifactTypes(
-      options.sources || options.common.classifier0(Classifier.sources),
-      options.javadoc || options.common.classifier0(Classifier.javadoc),
+      options.artifactOptions.sources || options.common.classifier0(Classifier.sources),
+      options.artifactOptions.javadoc || options.common.classifier0(Classifier.javadoc),
       default
     )
   )

--- a/modules/cli/src/main/scala-2.12/coursier/cli/Fetch.scala
+++ b/modules/cli/src/main/scala-2.12/coursier/cli/Fetch.scala
@@ -11,20 +11,13 @@ final class Fetch(options: FetchOptions, args: RemainingArgs) {
 
   val helper = new Helper(options.common, args.all, ignoreErrors = options.artifactOptions.force)
 
-  val default = options.artifactOptions.default.getOrElse {
-    (!options.artifactOptions.sources && !options.artifactOptions.javadoc && options.common.classifier0.isEmpty) ||
-      options.common.classifier0(Classifier("_"))
-  }
+  val default = options.artifactOptions.default0(options.common.classifier0)
 
   val files0 = helper.fetch(
     sources = options.artifactOptions.sources,
     javadoc = options.artifactOptions.javadoc,
     default = default,
-    artifactTypes = options.artifactOptions.artifactTypes(
-      options.artifactOptions.sources || options.common.classifier0(Classifier.sources),
-      options.artifactOptions.javadoc || options.common.classifier0(Classifier.javadoc),
-      default
-    )
+    artifactTypes = options.artifactOptions.artifactTypes(options.common.classifier0)
   )
 
 }

--- a/modules/cli/src/main/scala-2.12/coursier/cli/Fetch.scala
+++ b/modules/cli/src/main/scala-2.12/coursier/cli/Fetch.scala
@@ -11,13 +11,19 @@ final class Fetch(options: FetchOptions, args: RemainingArgs) {
 
   val helper = new Helper(options.common, args.all, ignoreErrors = options.artifactOptions.force)
 
+  val default = options.default.getOrElse {
+    (!options.sources && !options.javadoc && options.common.classifier0.isEmpty) ||
+      options.common.classifier0(Classifier("_"))
+  }
+
   val files0 = helper.fetch(
     sources = options.sources,
     javadoc = options.javadoc,
+    default = default,
     artifactTypes = options.artifactOptions.artifactTypes(
       options.sources || options.common.classifier0(Classifier.sources),
       options.javadoc || options.common.classifier0(Classifier.javadoc),
-      (!options.sources && !options.javadoc) || options.common.classifier0(Classifier("_"))
+      default
     )
   )
 

--- a/modules/cli/src/main/scala-2.12/coursier/cli/Fetch.scala
+++ b/modules/cli/src/main/scala-2.12/coursier/cli/Fetch.scala
@@ -16,7 +16,8 @@ final class Fetch(options: FetchOptions, args: RemainingArgs) {
     javadoc = options.javadoc,
     artifactTypes = options.artifactOptions.artifactTypes(
       options.sources || options.common.classifier0(Classifier.sources),
-      options.javadoc || options.common.classifier0(Classifier.javadoc)
+      options.javadoc || options.common.classifier0(Classifier.javadoc),
+      (!options.sources && !options.javadoc) || options.common.classifier0(Classifier("_"))
     )
   )
 

--- a/modules/cli/src/main/scala-2.12/coursier/cli/Helper.scala
+++ b/modules/cli/src/main/scala-2.12/coursier/cli/Helper.scala
@@ -599,11 +599,22 @@ class Helper(
   }
 
   private def getDepArtifactsForClassifier(sources: Boolean, javadoc: Boolean, res0: Resolution): Seq[(Dependency, Attributes, Artifact)] = {
+
     val raw =
-      if (hasOverrideClassifiers(sources, javadoc))
-        //TODO: this function somehow gives duplicated things
-        res0.dependencyArtifacts(Some(overrideClassifiers(sources, javadoc).toVector.sorted))
-      else
+      if (hasOverrideClassifiers(sources, javadoc)) {
+        val classifiers = overrideClassifiers(sources, javadoc)
+
+        val baseArtifacts =
+          if (classifiers(Classifier("_")))
+            res0.dependencyArtifacts(None)
+          else
+            Nil
+
+        val classifierArtifacts =
+          res0.dependencyArtifacts(Some(classifiers.filter(_ != Classifier("_")).toVector.sorted))
+
+        baseArtifacts ++ classifierArtifacts
+      } else
         res0.dependencyArtifacts(None)
 
     raw.map {

--- a/modules/cli/src/main/scala-2.12/coursier/cli/SparkSubmit.scala
+++ b/modules/cli/src/main/scala-2.12/coursier/cli/SparkSubmit.scala
@@ -65,7 +65,7 @@ object SparkSubmit extends CaseApp[SparkSubmitOptions] {
       helper.fetch(
         sources = false,
         javadoc = false,
-        artifactTypes = options.artifactOptions.artifactTypes(sources = false, javadoc = false)
+        artifactTypes = options.artifactOptions.artifactTypes()
       ) ++ options.extraJars.map(new File(_))
 
     val (scalaVersion, sparkVersion) =
@@ -93,7 +93,7 @@ object SparkSubmit extends CaseApp[SparkSubmitOptions] {
           options.assemblyDependencies.flatMap(_.split(",")).filter(_.nonEmpty) ++
             options.sparkAssemblyDependencies.flatMap(_.split(",")).filter(_.nonEmpty).map(_ + s":$sparkVersion"),
           options.common,
-          options.artifactOptions.artifactTypes(sources = false, javadoc = false)
+          options.artifactOptions.artifactTypes()
         )
 
         val extraConf =
@@ -115,7 +115,7 @@ object SparkSubmit extends CaseApp[SparkSubmitOptions] {
           options.assemblyDependencies.flatMap(_.split(",")).filter(_.nonEmpty) ++
             options.sparkAssemblyDependencies.flatMap(_.split(",")).filter(_.nonEmpty).map(_ + s":$sparkVersion"),
           options.common,
-          options.artifactOptions.artifactTypes(sources = false, javadoc = false)
+          options.artifactOptions.artifactTypes()
         )
 
         val (assembly, assemblyJars) = assemblyAndJarsOrError match {
@@ -191,7 +191,7 @@ object SparkSubmit extends CaseApp[SparkSubmitOptions] {
       sparkVersion,
       options.noDefaultSubmitDependencies,
       options.submitDependencies.flatMap(_.split(",")).filter(_.nonEmpty),
-      options.artifactOptions.artifactTypes(sources = false, javadoc = false),
+      options.artifactOptions.artifactTypes(),
       options.common
     )
 

--- a/modules/cli/src/main/scala-2.12/coursier/cli/SparkSubmit.scala
+++ b/modules/cli/src/main/scala-2.12/coursier/cli/SparkSubmit.scala
@@ -65,6 +65,7 @@ object SparkSubmit extends CaseApp[SparkSubmitOptions] {
       helper.fetch(
         sources = false,
         javadoc = false,
+        default = true,
         artifactTypes = options.artifactOptions.artifactTypes()
       ) ++ options.extraJars.map(new File(_))
 

--- a/modules/cli/src/main/scala-2.12/coursier/cli/options/ArtifactOptions.scala
+++ b/modules/cli/src/main/scala-2.12/coursier/cli/options/ArtifactOptions.scala
@@ -11,6 +11,14 @@ object ArtifactOptions {
 }
 
 final case class ArtifactOptions(
+  @Help("Fetch source artifacts")
+  @Short("S")
+    sources: Boolean = false,
+  @Help("Fetch javadoc artifacts")
+  @Short("D")
+    javadoc: Boolean = false,
+  @Help("Fetch default artifacts (default: false if --sources or --javadoc or --classifier are passed, true else)")
+    default: Option[Boolean] = None,
   @Help("Artifact types that should be retained (e.g. jar, src, doc, etc.) - defaults to jar,bundle")
   @Value("type1,type2,...")
   @Short("A")

--- a/modules/cli/src/main/scala-2.12/coursier/cli/options/ArtifactOptions.scala
+++ b/modules/cli/src/main/scala-2.12/coursier/cli/options/ArtifactOptions.scala
@@ -12,10 +12,8 @@ object ArtifactOptions {
 
 final case class ArtifactOptions(
   @Help("Fetch source artifacts")
-  @Short("S")
     sources: Boolean = false,
   @Help("Fetch javadoc artifacts")
-  @Short("D")
     javadoc: Boolean = false,
   @Help("Fetch default artifacts (default: false if --sources or --javadoc or --classifier are passed, true else)")
     default: Option[Boolean] = None,

--- a/modules/cli/src/main/scala-2.12/coursier/cli/options/ArtifactOptions.scala
+++ b/modules/cli/src/main/scala-2.12/coursier/cli/options/ArtifactOptions.scala
@@ -18,7 +18,9 @@ final case class ArtifactOptions(
   @Help("Fetch artifacts even if the resolution is errored")
     force: Boolean = false
 ) {
-  def artifactTypes(sources: Boolean, javadoc: Boolean): Set[Type] = {
+  def artifactTypes(): Set[Type] =
+    artifactTypes(sources = false, javadoc = false, default = true)
+  def artifactTypes(sources: Boolean, javadoc: Boolean, default: Boolean): Set[Type] = {
 
     val types0 = artifactType
       .flatMap(_.split(','))
@@ -27,10 +29,10 @@ final case class ArtifactOptions(
       .toSet
 
     if (types0.isEmpty) {
-      if (sources || javadoc)
-        Some(Type.source).filter(_ => sources).toSet ++ Some(Type.doc).filter(_ => javadoc)
-      else
-        ArtifactOptions.defaultArtifactTypes
+      val sourceTypes = Some(Type.source).filter(_ => sources).toSet
+      val javadocTypes = Some(Type.doc).filter(_ => javadoc).toSet
+      val defaultTypes = if (default) ArtifactOptions.defaultArtifactTypes else Set()
+      sourceTypes ++ javadocTypes ++ defaultTypes
     } else if (types0(Type("*")))
       Set(Type("*"))
     else

--- a/modules/cli/src/main/scala-2.12/coursier/cli/options/FetchOptions.scala
+++ b/modules/cli/src/main/scala-2.12/coursier/cli/options/FetchOptions.scala
@@ -9,6 +9,8 @@ final case class FetchOptions(
   @Help("Fetch javadoc artifacts")
   @Short("D")
     javadoc: Boolean = false,
+  @Help("Fetch default artifacts (default: false if --sources or --javadoc or --classifier are passed, true else)")
+    default: Option[Boolean] = None,
   @Help("Print java -cp compatible output")
   @Short("p")
     classpath: Boolean = false,

--- a/modules/cli/src/main/scala-2.12/coursier/cli/options/FetchOptions.scala
+++ b/modules/cli/src/main/scala-2.12/coursier/cli/options/FetchOptions.scala
@@ -3,14 +3,6 @@ package coursier.cli.options
 import caseapp.{ HelpMessage => Help, ExtraName => Short, _ }
 
 final case class FetchOptions(
-  @Help("Fetch source artifacts")
-  @Short("S")
-    sources: Boolean = false,
-  @Help("Fetch javadoc artifacts")
-  @Short("D")
-    javadoc: Boolean = false,
-  @Help("Fetch default artifacts (default: false if --sources or --javadoc or --classifier are passed, true else)")
-    default: Option[Boolean] = None,
   @Help("Print java -cp compatible output")
   @Short("p")
     classpath: Boolean = false,

--- a/modules/cli/src/main/scala-2.12/coursier/cli/spark/SparkAssembly.scala
+++ b/modules/cli/src/main/scala-2.12/coursier/cli/spark/SparkAssembly.scala
@@ -82,7 +82,7 @@ object SparkAssembly {
 
     val helper = sparkJarsHelper(scalaVersion, sparkVersion, yarnVersion, default, extraDependencies, options)
 
-    helper.fetch(sources = false, javadoc = false, artifactTypes = artifactTypes)
+    helper.fetch(sources = false, javadoc = false, default = true, artifactTypes = artifactTypes)
   }
 
   def spark(
@@ -99,8 +99,8 @@ object SparkAssembly {
 
     val helper = sparkJarsHelper(scalaVersion, sparkVersion, yarnVersion, default, extraDependencies, options)
 
-    val artifacts = helper.artifacts(sources = false, javadoc = false, artifactTypes = artifactTypes)
-    val jars = helper.fetch(sources = false, javadoc = false, artifactTypes = artifactTypes)
+    val artifacts = helper.artifacts(sources = false, javadoc = false, default = true, artifactTypes = artifactTypes)
+    val jars = helper.fetch(sources = false, javadoc = false, default = true, artifactTypes = artifactTypes)
 
     val checksums = artifacts.map { a =>
       val f = a.checksumUrls.get("SHA-1") match {

--- a/modules/cli/src/main/scala-2.12/coursier/cli/spark/Submit.scala
+++ b/modules/cli/src/main/scala-2.12/coursier/cli/spark/Submit.scala
@@ -51,6 +51,7 @@ object Submit {
     helper.fetch(
       sources = false,
       javadoc = false,
+      default = true,
       artifactTypes = artifactTypes
     ) ++ extraCp
   }

--- a/modules/cli/src/test/scala-2.12/coursier/cli/CliBootstrapIntegrationTest.scala
+++ b/modules/cli/src/test/scala-2.12/coursier/cli/CliBootstrapIntegrationTest.scala
@@ -82,6 +82,12 @@ class CliBootstrapIntegrationTest extends FlatSpec with CliTestLib {
       assert(!fooLines.exists(_.endsWith("/scalameta_2.12-1.7.0.jar")))
       assert(lines.exists(_.endsWith("/scalameta_2.12-1.7.0.jar")))
 
+      // checking that there are no sources just in case…
+      assert(!fooLines.exists(_.endsWith("/scalaparse_2.12-0.4.2-sources.jar")))
+      assert(!lines.exists(_.endsWith("/scalaparse_2.12-0.4.2-sources.jar")))
+      assert(!fooLines.exists(_.endsWith("/scalameta_2.12-1.7.0-sources.jar")))
+      assert(!lines.exists(_.endsWith("/scalameta_2.12-1.7.0-sources.jar")))
+
       val extensions = fooLines
         .map { l =>
           val idx = l.lastIndexOf('.')
@@ -126,5 +132,49 @@ class CliBootstrapIntegrationTest extends FlatSpec with CliTestLib {
 
       assert(lines.exists(_.endsWith("/scalaparse_2.12-0.4.2.jar")))
       assert(lines.exists(_.endsWith("/scalaparse_2.12-0.4.2-sources.jar")))
+  }
+
+  "bootstrap" should "add standard and source JARs to the classpath with classloader isolation" in withFile() {
+
+    (bootstrapFile, _) =>
+      val repositoryOpt = RepositoryOptions(repository = List("bintray:scalameta/maven"))
+      val artifactOptions = ArtifactOptions(
+        sources = true,
+        default = Some(true)
+      )
+      val common = CommonOptions(
+        repositoryOptions = repositoryOpt
+      )
+      val isolatedLoaderOptions = IsolatedLoaderOptions(
+        isolateTarget = List("foo"),
+        isolated = List("foo:org.scalameta:trees_2.12:1.7.0")
+      )
+      val bootstrapSpecificOptions = BootstrapSpecificOptions(
+        output = bootstrapFile.getPath,
+        isolated = isolatedLoaderOptions,
+        force = true,
+        common = common
+      )
+      val bootstrapOptions = BootstrapOptions(artifactOptions, bootstrapSpecificOptions)
+
+      Bootstrap.run(
+        bootstrapOptions,
+        RemainingArgs(Seq("com.geirsson:scalafmt-cli_2.12:1.4.0"), Seq())
+      )
+
+      def zis = new ZipInputStream(new ByteArrayInputStream(actualContent(bootstrapFile)))
+
+      val fooLines = new String(zipEntryContent(zis, "bootstrap-isolation-foo-jar-urls"), UTF_8).lines.toVector
+      val lines = new String(zipEntryContent(zis, "bootstrap-jar-urls"), UTF_8).lines.toVector
+
+      assert(fooLines.exists(_.endsWith("/scalaparse_2.12-0.4.2.jar")))
+      assert(fooLines.exists(_.endsWith("/scalaparse_2.12-0.4.2-sources.jar")))
+      assert(!lines.exists(_.endsWith("/scalaparse_2.12-0.4.2.jar")))
+      assert(!lines.exists(_.endsWith("/scalaparse_2.12-0.4.2-sources.jar")))
+
+      assert(!fooLines.exists(_.endsWith("/scalameta_2.12-1.7.0.jar")))
+      assert(!fooLines.exists(_.endsWith("/scalameta_2.12-1.7.0-sources.jar")))
+      assert(lines.exists(_.endsWith("/scalameta_2.12-1.7.0.jar")))
+      assert(lines.exists(_.endsWith("/scalameta_2.12-1.7.0-sources.jar")))
   }
 }

--- a/modules/cli/src/test/scala-2.12/coursier/cli/CliBootstrapIntegrationTest.scala
+++ b/modules/cli/src/test/scala-2.12/coursier/cli/CliBootstrapIntegrationTest.scala
@@ -71,11 +71,18 @@ class CliBootstrapIntegrationTest extends FlatSpec with CliTestLib {
         RemainingArgs(Seq("com.geirsson:scalafmt-cli_2.12:1.4.0"), Seq())
       )
 
-      val zis = new ZipInputStream(new ByteArrayInputStream(actualContent(bootstrapFile)))
+      def zis = new ZipInputStream(new ByteArrayInputStream(actualContent(bootstrapFile)))
 
-      val lines = new String(zipEntryContent(zis, "bootstrap-isolation-foo-jar-urls"), UTF_8).lines.toVector
+      val fooLines = new String(zipEntryContent(zis, "bootstrap-isolation-foo-jar-urls"), UTF_8).lines.toVector
+      val lines = new String(zipEntryContent(zis, "bootstrap-jar-urls"), UTF_8).lines.toVector
 
-      val extensions = lines
+      assert(fooLines.exists(_.endsWith("/scalaparse_2.12-0.4.2.jar")))
+      assert(!lines.exists(_.endsWith("/scalaparse_2.12-0.4.2.jar")))
+
+      assert(!fooLines.exists(_.endsWith("/scalameta_2.12-1.7.0.jar")))
+      assert(lines.exists(_.endsWith("/scalameta_2.12-1.7.0.jar")))
+
+      val extensions = fooLines
         .map { l =>
           val idx = l.lastIndexOf('.')
           if (idx < 0)

--- a/modules/cli/src/test/scala-2.12/coursier/cli/CliFetchIntegrationTest.scala
+++ b/modules/cli/src/test/scala-2.12/coursier/cli/CliFetchIntegrationTest.scala
@@ -55,9 +55,12 @@ class CliFetchIntegrationTest extends FlatSpec with CliTestLib with Matchers {
     val commonOpt = CommonOptions(
       classifier = List("_")
     )
+    val artifactOpt = ArtifactOptions(
+      sources = true
+    )
     val fetchOpt = FetchOptions(
       common = commonOpt,
-      sources = true
+      artifactOptions = artifactOpt
     )
     val fetch = Fetch(fetchOpt, RemainingArgs(Seq("junit:junit:4.12"), Seq()))
     assert(fetch.files0.map(_.getName).toSet.equals(Set(
@@ -69,10 +72,13 @@ class CliFetchIntegrationTest extends FlatSpec with CliTestLib with Matchers {
   }
 
   "Default and source options" should "fetch default and source files" in {
-    val fetchOpt = FetchOptions(
-      common = CommonOptions(),
+    val artifactOpt = ArtifactOptions(
       default = Some(true),
       sources = true
+    )
+    val fetchOpt = FetchOptions(
+      common = CommonOptions(),
+      artifactOptions = artifactOpt
     )
     val fetch = Fetch(fetchOpt, RemainingArgs(Seq("junit:junit:4.12"), Seq()))
     assert(fetch.files0.map(_.getName).toSet.equals(Set(
@@ -722,7 +728,8 @@ class CliFetchIntegrationTest extends FlatSpec with CliTestLib with Matchers {
   "classifier sources" should "fetch sources jar" in withFile() {
     (jsonFile, _) => {
       val commonOpt = CommonOptions(jsonOutputFile = jsonFile.getPath)
-      val fetchOpt = FetchOptions(common = commonOpt, sources=true)
+      val artifactOpt = ArtifactOptions(sources = true)
+      val fetchOpt = FetchOptions(common = commonOpt, artifactOptions = artifactOpt)
 
       // encode path to different jar than requested
 

--- a/modules/cli/src/test/scala-2.12/coursier/cli/CliFetchIntegrationTest.scala
+++ b/modules/cli/src/test/scala-2.12/coursier/cli/CliFetchIntegrationTest.scala
@@ -42,6 +42,32 @@ class CliFetchIntegrationTest extends FlatSpec with CliTestLib with Matchers {
     assert(fetch.files0.map(_.getName).toSet.equals(Set("junit-4.12.jar", "hamcrest-core-1.3.jar")))
   }
 
+  "Underscore classifier" should "fetch default files" in {
+    val commonOpt = CommonOptions(
+      classifier = List("_")
+    )
+    val fetchOpt = FetchOptions(common = commonOpt)
+    val fetch = Fetch(fetchOpt, RemainingArgs(Seq("junit:junit:4.12"), Seq()))
+    assert(fetch.files0.map(_.getName).toSet.equals(Set("junit-4.12.jar", "hamcrest-core-1.3.jar")))
+  }
+
+  "Underscore and source classifier" should "fetch default and source files" in {
+    val commonOpt = CommonOptions(
+      classifier = List("_")
+    )
+    val fetchOpt = FetchOptions(
+      common = commonOpt,
+      sources = true
+    )
+    val fetch = Fetch(fetchOpt, RemainingArgs(Seq("junit:junit:4.12"), Seq()))
+    assert(fetch.files0.map(_.getName).toSet.equals(Set(
+      "junit-4.12.jar",
+      "junit-4.12-sources.jar",
+      "hamcrest-core-1.3.jar",
+      "hamcrest-core-1.3-sources.jar"
+    )))
+  }
+
   "scalafmt-cli fetch" should "discover all main classes" in {
     val fetchOpt = FetchOptions(common = CommonOptions())
     val fetch = Fetch(fetchOpt, RemainingArgs(Seq("com.geirsson:scalafmt-cli_2.12:1.4.0"), Seq()))

--- a/modules/cli/src/test/scala-2.12/coursier/cli/CliFetchIntegrationTest.scala
+++ b/modules/cli/src/test/scala-2.12/coursier/cli/CliFetchIntegrationTest.scala
@@ -68,6 +68,21 @@ class CliFetchIntegrationTest extends FlatSpec with CliTestLib with Matchers {
     )))
   }
 
+  "Default and source options" should "fetch default and source files" in {
+    val fetchOpt = FetchOptions(
+      common = CommonOptions(),
+      default = Some(true),
+      sources = true
+    )
+    val fetch = Fetch(fetchOpt, RemainingArgs(Seq("junit:junit:4.12"), Seq()))
+    assert(fetch.files0.map(_.getName).toSet.equals(Set(
+      "junit-4.12.jar",
+      "junit-4.12-sources.jar",
+      "hamcrest-core-1.3.jar",
+      "hamcrest-core-1.3-sources.jar"
+    )))
+  }
+
   "scalafmt-cli fetch" should "discover all main classes" in {
     val fetchOpt = FetchOptions(common = CommonOptions())
     val fetch = Fetch(fetchOpt, RemainingArgs(Seq("com.geirsson:scalafmt-cli_2.12:1.4.0"), Seq()))

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -12,7 +12,7 @@ object Deps {
   def jsoup = "org.jsoup" % "jsoup" % "1.10.3"
   def scalaXml = "org.scala-lang.modules" %% "scala-xml" % "1.1.0"
   def scalazConcurrent = "org.scalaz" %% "scalaz-concurrent" % SharedVersions.scalaz
-  def caseApp = "com.github.alexarchambault" %% "case-app" % "2.0.0-M3"
+  def caseApp = "com.github.alexarchambault" %% "case-app" % "2.0.0-M5"
   def okhttpUrlConnection = "com.squareup.okhttp" % "okhttp-urlconnection" % "2.7.5"
   def argonautShapeless = "com.github.alexarchambault" %% "argonaut-shapeless_6.2" % "1.2.0-M8"
   def scalatest = "org.scalatest" %% "scalatest" % "3.0.5"

--- a/scripts/generate-launcher.sh
+++ b/scripts/generate-launcher.sh
@@ -16,6 +16,7 @@ fi
 "$SBTPACK_LAUNCHER" bootstrap \
   --intransitive "io.get-coursier::coursier-cli:$ACTUAL_VERSION" \
   --classifier standalone \
+  -A jar \
   -J "-noverify" \
   --no-default \
   -r central \


### PR DESCRIPTION
Source JARs in particular, which should be useful when generating launchers for [almond](https://github.com/almond-sh/almond) or [Ammonite](https://github.com/lihaoyi/Ammonite) (as Ammonite passes the source JARs to the presentation compiler).