### PR TITLE
Added configuration properties for http timeouts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -248,7 +248,10 @@ lazy val okhttp = project("okhttp")
   .settings(
     shared,
     coursierPrefix,
-    libs += Deps.okhttpUrlConnection
+    libs ++= List(
+      Deps.okhttpUrlConnection,
+      Deps.scalatest % Test
+    )
   )
 
 lazy val meta = crossProject("meta")(JSPlatform, JVMPlatform)

--- a/modules/okhttp/src/main/scala/coursier/cache/protocol/HttpHandler.scala
+++ b/modules/okhttp/src/main/scala/coursier/cache/protocol/HttpHandler.scala
@@ -1,17 +1,51 @@
 package coursier.cache.protocol
 
 import java.net.{URLStreamHandler, URLStreamHandlerFactory}
+import java.util.concurrent.TimeUnit
 
 import com.squareup.okhttp.{OkHttpClient, OkUrlFactory}
 
+import scala.concurrent.duration.FiniteDuration
+
+/**
+  * Contains the default values for the OK Http client.
+  *
+  * The default client can be configured using properties which are first checked from the system properties, then environment variables:
+  *
+  * - COURSIER_CONN_TIMEOUT_SECONDS : the http connection timeout, in seconds
+  * - COURSIER_READ_TIMEOUT_SECONDS : the http read timeout, in seconds
+  *
+  */
 object HttpHandler {
-  lazy val okHttpClient = new OkHttpClient
-  lazy val okHttpFactory = new OkUrlFactory(okHttpClient)
+
+  private def durationInSecondsFromEnv(key : String): Option[FiniteDuration] = {
+    import concurrent.duration._
+    sys.props.get(key).orElse(sys.env.get(key)).map(_.toInt.seconds)
+  }
+
+  def newClient() = {
+    val client = new OkHttpClient
+
+    durationInSecondsFromEnv("COURSIER_CONN_TIMEOUT_SECONDS").foreach { timeoutSeconds =>
+      client.setConnectTimeout(timeoutSeconds.toSeconds, TimeUnit.SECONDS)
+    }
+
+    durationInSecondsFromEnv("COURSIER_READ_TIMEOUT_SECONDS").foreach { timeoutSeconds =>
+      client.setReadTimeout(timeoutSeconds.toSeconds, TimeUnit.SECONDS)
+    }
+
+    client
+  }
+
+  lazy val okHttpClient = newClient
+
+  lazy val okHttpFactory: OkUrlFactory = new OkUrlFactory(okHttpClient)
 }
 
-class HttpHandler extends URLStreamHandlerFactory {
-  def createURLStreamHandler(protocol: String): URLStreamHandler =
-    HttpHandler.okHttpFactory.createURLStreamHandler(protocol)
+class HttpHandler(okHttpFactory: OkUrlFactory = HttpHandler.okHttpFactory) extends URLStreamHandlerFactory {
+  def createURLStreamHandler(protocol: String): URLStreamHandler = {
+    okHttpFactory.createURLStreamHandler(protocol)
+  }
 }
 
-class HttpsHandler extends HttpHandler
+class HttpsHandler(okHttpFactory: OkUrlFactory = HttpHandler.okHttpFactory) extends HttpHandler(okHttpFactory)

--- a/modules/okhttp/src/test/scala/coursier/cache/protocol/HttpHandlerTest.scala
+++ b/modules/okhttp/src/test/scala/coursier/cache/protocol/HttpHandlerTest.scala
@@ -1,0 +1,38 @@
+package coursier.cache.protocol
+
+import org.scalatest.{Matchers, WordSpec}
+
+import sys.SystemProperties
+import concurrent.duration._
+
+class HttpHandlerTest extends WordSpec with Matchers {
+
+  "HttpHandler" should {
+    "set timeouts" in {
+
+      val props = new SystemProperties
+      val beforeConn = props.get("COURSIER_CONN_TIMEOUT_SECONDS")
+      val beforeRead = props.get("COURSIER_READ_TIMEOUT_SECONDS")
+
+      try {
+
+        val expectedConn = System.currentTimeMillis().toString.take(6)
+        val expectedRead = expectedConn.reverse
+        props += (
+          "COURSIER_CONN_TIMEOUT_SECONDS" -> expectedConn,
+          "COURSIER_READ_TIMEOUT_SECONDS" -> expectedRead
+        )
+        val c = HttpHandler.newClient
+        c.getConnectTimeout shouldBe expectedConn.toInt.seconds.toMillis
+        c.getReadTimeout shouldBe expectedRead.toInt.seconds.toMillis
+      } finally {
+        beforeConn.foreach { oldValue =>
+          props += ("COURSIER_CONN_TIMEOUT_SECONDS" -> oldValue)
+        }
+        beforeRead.foreach { oldValue =>
+          props += ("COURSIER_READ_TIMEOUT_SECONDS" -> oldValue)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
We've experienced some long-running builds due to our nexus configuration, so it'd be a real boon to be able to configure the default http client, e.g. by setting these time-outs.