### PR TITLE
Make bootstrap --standalone handle duplicate filenames

### DIFF
--- a/modules/cli/src/main/scala-2.12/coursier/cli/Bootstrap.scala
+++ b/modules/cli/src/main/scala-2.12/coursier/cli/Bootstrap.scala
@@ -270,10 +270,14 @@ object Bootstrap extends CaseApp[BootstrapOptions] {
   private def uniqueNames(files: Seq[File]): Seq[String] = {
     val fileIndex = mutable.Map.empty[String, Int]
     def pathFor(f: File) = {
-      val ambiguousName = f.getName
-      val index = fileIndex.getOrElseUpdate(ambiguousName, 0)
-      fileIndex(ambiguousName) = index + 1
-      val uniqueName = ambiguousName.stripSuffix(".jar") + s"-$index.jar"
+      val name = f.getName
+      val index = fileIndex.getOrElse(name, 0)
+      fileIndex(name) = index + 1
+      val uniqueName =
+        if (index == 0)
+          name
+        else
+          name.stripSuffix(".jar") + s"-$index.jar"
       s"jars/$uniqueName"
     }
     files.map(pathFor)


### PR DESCRIPTION
Fixes #971

Previously, `coursier bootstrap --standalone` would fail with a
"ZipException: duplicate entry:" error if the classpath contained
two dependencies with the same artifact name+version, for example
`org.scalameta:fastparse_2.12:1.0.0` and
`com.lihaoyi:fastparse_2.12:1.0.0`. Now, bootstrap disambiguates
those jars by appending a unique suffix ID to the filenames.