### PR TITLE
Allow to follow HTTP -> HTTPS redirections

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,7 @@ environment:
   TEST_REPOSITORY_USER: user
   TEST_REPOSITORY_PASSWORD: pass
   TEST_REPOSITORY: http://localhost:8080
+  TEST_REDIRECT_REPOSITORY: disabled
 build_script:
   - sbt cli/pack
   - cmd: .\modules\cli\target\pack\bin\coursier bootstrap io.get-coursier:echo:1.0.1 -o cs-echo

--- a/modules/cli/src/main/scala-2.12/coursier/cli/Helper.scala
+++ b/modules/cli/src/main/scala-2.12/coursier/cli/Helper.scala
@@ -145,7 +145,15 @@ class Helper(
           None
 
       val fetchs = cachePolicies.map(p =>
-        Cache.fetch[Task](cache, p, checksums = Nil, logger = logger, pool = pool, ttl = ttl0)
+        Cache.fetch[Task](
+          cache,
+          p,
+          checksums = Nil,
+          logger = logger,
+          pool = pool,
+          ttl = ttl0,
+          followHttpToHttpsRedirections = common.cacheOptions.followHttpToHttpsRedirect
+        )
       )
 
       logger.foreach(_.init())
@@ -353,7 +361,15 @@ class Helper(
       None
 
   val fetchs = cachePolicies.map(p =>
-    Cache.fetch[Task](cache, p, checksums = checksums, logger = logger, pool = pool, ttl = ttl0)
+    Cache.fetch[Task](
+      cache,
+      p,
+      checksums = checksums,
+      logger = logger,
+      pool = pool,
+      ttl = ttl0,
+      followHttpToHttpsRedirections = common.cacheOptions.followHttpToHttpsRedirect
+    )
   )
   val fetchQuiet = coursier.Fetch.from(
     repositories,
@@ -685,7 +701,8 @@ class Helper(
         pool = pool,
         ttl = ttl0,
         retry = common.cacheOptions.retryCount,
-        common.cacheOptions.cacheFileArtifacts
+        localArtifactsShouldBeCached = common.cacheOptions.cacheFileArtifacts,
+        followHttpToHttpsRedirections = common.cacheOptions.followHttpToHttpsRedirect
       )
 
       (file(cachePolicies.head) /: cachePolicies.tail)(_ orElse file(_))

--- a/modules/cli/src/main/scala-2.12/coursier/cli/options/shared/CacheOptions.scala
+++ b/modules/cli/src/main/scala-2.12/coursier/cli/options/shared/CacheOptions.scala
@@ -31,7 +31,10 @@ final case class CacheOptions(
 
   @Help("Flag that specifies if a local artifact should be cached.")
   @Short("cfa")
-    cacheFileArtifacts: Boolean = false
+    cacheFileArtifacts: Boolean = false,
+
+  @Help("Whether to follow http to https redirections")
+    followHttpToHttpsRedirect: Boolean = true
 
 )
 

--- a/modules/cli/src/main/scala-2.12/coursier/cli/params/shared/CacheParams.scala
+++ b/modules/cli/src/main/scala-2.12/coursier/cli/params/shared/CacheParams.scala
@@ -16,7 +16,8 @@ final case class CacheParams(
   parallel: Int, // positive
   checksum: Seq[Option[String]],
   retryCount: Int,
-  cacheLocalArtifacts: Boolean
+  cacheLocalArtifacts: Boolean,
+  followHttpToHttpsRedirections: Boolean
 )
 
 object CacheParams {
@@ -78,6 +79,7 @@ object CacheParams {
         Validated.invalidNel(s"Retry count must be > 0 (got ${options.retryCount})")
 
     val cacheLocalArtifacts = options.cacheFileArtifacts
+    val followHttpToHttpsRedirections = options.followHttpToHttpsRedirect
 
     (cachePoliciesV, ttlV, parallelV, checksumV, retryCountV).mapN {
       (cachePolicy, ttl, parallel, checksum, retryCount) =>
@@ -88,7 +90,8 @@ object CacheParams {
           parallel,
           checksum,
           retryCount,
-          cacheLocalArtifacts
+          cacheLocalArtifacts,
+          followHttpToHttpsRedirections
         )
     }
   }

--- a/modules/cli/src/main/scala-2.12/coursier/cli/resolve/Resolve.scala
+++ b/modules/cli/src/main/scala-2.12/coursier/cli/resolve/Resolve.scala
@@ -56,7 +56,15 @@ object Resolve extends CaseApp[ResolveOptions] {
     params
       .cachePolicies
       .map { p =>
-        Cache.fetch[Task](params.cache, p, checksums = Nil, logger = logger, pool = pool, ttl = params.ttl)
+        Cache.fetch[Task](
+          params.cache,
+          p,
+          checksums = Nil,
+          logger = logger,
+          pool = pool,
+          ttl = params.ttl,
+          followHttpToHttpsRedirections = params.followHttpToHttpsRedirections
+        )
       }
 
   private def runResolution(

--- a/modules/tests/jvm/src/it/scala/coursier/test/HttpHttpsRedirectionTests.scala
+++ b/modules/tests/jvm/src/it/scala/coursier/test/HttpHttpsRedirectionTests.scala
@@ -1,0 +1,45 @@
+package coursier.test
+
+import coursier.{Dependency, moduleString}
+import coursier.maven.MavenRepository
+import utest._
+
+object HttpHttpsRedirectionTests extends TestSuite {
+
+  val tests = Tests {
+
+    val testRepo = sys.env.getOrElse("TEST_REDIRECT_REPOSITORY", sys.error("TEST_REDIRECT_REPOSITORY not set"))
+    val deps = Set(Dependency(mod"com.chuusai:shapeless_2.12", "2.3.2"))
+
+    * - {
+      // no redirections -> should fail
+
+      val failed = try {
+        CacheFetchTests.check(
+          MavenRepository(testRepo),
+          addCentral = false,
+          deps = deps
+        )
+
+        false
+      } catch {
+        case _: Throwable =>
+          true
+      }
+
+      assert(failed)
+    }
+
+    * - {
+      // with redirection -> should work
+
+      CacheFetchTests.check(
+        MavenRepository(testRepo),
+        addCentral = false,
+        deps = deps,
+        followHttpToHttpsRedirections = true
+      )
+    }
+  }
+
+}

--- a/modules/tests/jvm/src/it/scala/coursier/test/HttpHttpsRedirectionTests.scala
+++ b/modules/tests/jvm/src/it/scala/coursier/test/HttpHttpsRedirectionTests.scala
@@ -11,34 +11,45 @@ object HttpHttpsRedirectionTests extends TestSuite {
     val testRepo = sys.env.getOrElse("TEST_REDIRECT_REPOSITORY", sys.error("TEST_REDIRECT_REPOSITORY not set"))
     val deps = Set(Dependency(mod"com.chuusai:shapeless_2.12", "2.3.2"))
 
+    // typer error in 2.11.12 if we make that a lazy val
+    def enabled: Boolean = {
+      val enabled0 = testRepo != "disabled"
+      if (!enabled0)
+        System.err.println("HttpHttpsRedirectionTests disabled (TEST_REDIRECT_REPOSITORY=disabled)")
+      enabled0
+    }
+
     * - {
       // no redirections -> should fail
 
-      val failed = try {
-        CacheFetchTests.check(
-          MavenRepository(testRepo),
-          addCentral = false,
-          deps = deps
-        )
+      if (enabled) {
+        val failed = try {
+          CacheFetchTests.check(
+            MavenRepository(testRepo),
+            addCentral = false,
+            deps = deps
+          )
 
-        false
-      } catch {
-        case _: Throwable =>
-          true
+          false
+        } catch {
+          case _: Throwable =>
+            true
+        }
+
+        assert(failed)
       }
-
-      assert(failed)
     }
 
     * - {
       // with redirection -> should work
 
-      CacheFetchTests.check(
-        MavenRepository(testRepo),
-        addCentral = false,
-        deps = deps,
-        followHttpToHttpsRedirections = true
-      )
+      if (enabled)
+        CacheFetchTests.check(
+          MavenRepository(testRepo),
+          addCentral = false,
+          deps = deps,
+          followHttpToHttpsRedirections = true
+        )
     }
   }
 

--- a/scripts/redirect-server.sc
+++ b/scripts/redirect-server.sc
@@ -1,0 +1,39 @@
+#!/usr/bin/env amm
+
+import $ivy.`org.http4s::http4s-blaze-server:0.17.5`
+import $ivy.`org.http4s::http4s-dsl:0.17.5`
+import $ivy.`org.http4s::http4s-server:0.17.5`
+
+import org.http4s._
+import org.http4s.dsl._
+import org.http4s.headers._
+import org.http4s.server.blaze.BlazeBuilder
+
+
+val host = sys.env("SERVER_HOST")
+val port = sys.env("SERVER_PORT").toInt
+
+val redirectTo = Uri.unsafeFromString(sys.env("REDIRECT_TO"))
+
+def service(host: String, port: Int, redirectTo: Uri) = HttpService {
+  case (method @ (GET | HEAD)) -> Path(path @ _*) =>
+    println(s"${method.name} ${path.mkString("/")}")
+    TemporaryRedirect(path.foldLeft(redirectTo)(_ / _))
+}
+
+val server = BlazeBuilder
+  .bindHttp(port, host)
+  .mountService(service(host, port, redirectTo))
+  .start
+  .unsafeRun()
+
+println(s"Listening on http://$host:$port")
+
+if (System.console() == null)
+  while (true) Thread.sleep(60000L)
+else {
+  println("Press Ctrl+D to exit")
+  while (System.in.read() != -1) {}
+}
+
+server.shutdown.unsafeRun()

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -37,7 +37,9 @@ runJvmTests() {
     IT="jvm/it:test"
   fi
 
-  ./modules/tests/handmade-metadata/scripts/with-test-repo.sh sbt scalaFromEnv jvm/test $IT
+  ./scripts/with-redirect-server.sh \
+    ./modules/tests/handmade-metadata/scripts/with-test-repo.sh \
+    sbt scalaFromEnv jvm/test $IT
 }
 
 checkBinaryCompatibility() {

--- a/scripts/with-redirect-server.sh
+++ b/scripts/with-redirect-server.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -eu
+
+DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+export SERVER_HOST="${SERVER_HOST:-"localhost"}"
+export SERVER_PORT="${SERVER_PORT:-10002}"
+export REDIRECT_TO="${REDIRECT_TO:-"https://repo1.maven.org/maven2"}"
+
+export TEST_REDIRECT_REPOSITORY="http://$SERVER_HOST:$SERVER_PORT"
+
+
+SERVER_PID=""
+
+cleanup() {
+  if [ ! -z "$SERVER_PID" ]; then
+    echo "Terminating background HTTP redirect server"
+    kill -15 "$SERVER_PID"
+    while kill -0 "$SERVER_PID" >/dev/null 2>&1; do
+      echo "Redirect server still running"
+      sleep 1
+      kill -15 "$SERVER_PID" >/dev/null 2>&1 || true
+    done
+    echo "Redirect server terminated"
+  fi
+}
+
+trap cleanup EXIT INT TERM
+
+
+# see https://unix.stackexchange.com/questions/90244/bash-run-command-in-background-and-capture-pid
+runServerBg() {
+  coursier launch \
+    com.lihaoyi:ammonite_2.12.7:1.4.4 \
+    -M ammonite.Main \
+    -- \
+      "$DIR/redirect-server.sc" &
+  SERVER_PID="$!"
+}
+
+runServerBg
+
+"$@"


### PR DESCRIPTION
Disabled by default in the API, not to run into possible security issues (https://stackoverflow.com/a/1884427/3714539). Pass `followHttpToHttpsRedirections = true` to `Cache.fetch` and `Cache.file` to enable it.

Enabled by default in the command-line (less likely a custom authenticator was set up there).