### PR TITLE
Allow linking flags to be passed through LDFLAGS environment variable

### DIFF
--- a/modules/extra/src/main/scala-2.12/coursier/extra/Native.scala
+++ b/modules/extra/src/main/scala-2.12/coursier/extra/Native.scala
@@ -3,6 +3,7 @@ package coursier.extra
 import java.io.File
 import java.nio.file.Path
 import scala.scalanative.{build => sn}
+import scala.util.Properties
 
 object Native {
   def create(
@@ -21,7 +22,7 @@ object Native {
     val logger    = sn.Logger(log, log, log, log)
     val clang     = sn.Discover.clang()
     val clangpp   = sn.Discover.clangpp()
-    val linkopts  = sn.Discover.linkingOptions()
+    val linkopts  = linkingOptions()
     val compopts  = sn.Discover.compileOptions()
     val triple    = sn.Discover.targetTriple(clang, workdir)
     val nativelib = sn.Discover.nativelib(classpath).get
@@ -43,6 +44,9 @@ object Native {
 
     sn.Build.build(config, outpath)
   }
+
+  private def linkingOptions(): Seq[String] = sn.Discover.linkingOptions() ++
+    Properties.envOrNone("LDFLAGS").map(Seq.apply(_)).getOrElse(Seq.empty)
 
   def deleteRecursive(f: File): Unit = {
     if (f.isDirectory) {

--- a/modules/extra/src/main/scala-2.12/coursier/extra/Native.scala
+++ b/modules/extra/src/main/scala-2.12/coursier/extra/Native.scala
@@ -46,7 +46,7 @@ object Native {
   }
 
   private def linkingOptions(): Seq[String] = sn.Discover.linkingOptions() ++
-    Properties.envOrNone("LDFLAGS").map(Seq.apply(_)).getOrElse(Seq.empty)
+    sys.env.get("LDFLAGS").toSeq
 
   def deleteRecursive(f: File): Unit = {
     if (f.isDirectory) {

--- a/modules/extra/src/main/scala-2.12/coursier/extra/Native.scala
+++ b/modules/extra/src/main/scala-2.12/coursier/extra/Native.scala
@@ -3,7 +3,6 @@ package coursier.extra
 import java.io.File
 import java.nio.file.Path
 import scala.scalanative.{build => sn}
-import scala.util.Properties
 
 object Native {
   def create(


### PR DESCRIPTION
Allow the user to specify linking flags through `LDFLAGS` when creating native bootstraps.

This allows for instance for linking applications that uses STTP for Scala Native (requires `LDFLAGS=-L/usr/local/opt/curl/lib`, see [sttp#Building & testing the scala-native backend](https://github.com/softwaremill/sttp#building--testing-the-scala-native-backend))