### PR TITLE
fix TLS error when bootstrap pants with pip

### DIFF
--- a/modules/pants
+++ b/modules/pants
@@ -86,6 +86,7 @@ function bootstrap_pants {
       staging_dir=$(tempdir "${PANTS_BOOTSTRAP}") && \
       "${PYTHON}" "${venv_path}/virtualenv.py" --no-setuptools --no-download \
         "${staging_dir}/install" && \
+      curl https://bootstrap.pypa.io/get-pip.py | "${staging_dir}/install/bin/python" && \
       "${staging_dir}/install/bin/python" \
         "${staging_dir}/install/bin/pip" install \
           "${SETUPTOOLS_REQUIREMENT}" && \


### PR DESCRIPTION
Upgrade pip to latest version will fix:
```
Collecting setuptools==5.4.1
  Could not fetch URL https://pypi.python.org/simple/setuptools/: There was a problem confirming the ssl certificate: [SSL: TLSV1_ALERT_PROTOCOL_VERSION] tlsv1 alert protocol version (_ssl.c:590) - skipping
```
Edit: This issue exists on OS X