### PR TITLE
Don't automatically lookup in Scaladex anymore

### DIFF
--- a/modules/cli/src/main/scala-2.12/coursier/cli/Helper.scala
+++ b/modules/cli/src/main/scala-2.12/coursier/cli/Helper.scala
@@ -136,11 +136,8 @@ class Helper(
   val loggerFallbackMode =
     !common.outputOptions.progress && TermDisplay.defaultFallbackMode
 
-  val (scaladexRawDependencies, otherRawDependencies) =
-    rawDependencies.partition(s => s.contains("/") || !s.contains(":"))
-
   val scaladexDepsWithExtraParams: List[(Dependency, Map[String, String])] =
-    if (scaladexRawDependencies.isEmpty)
+    if (common.dependencyOptions.scaladex.isEmpty)
       Nil
     else {
       val logger =
@@ -166,7 +163,7 @@ class Helper(
 
       val scaladex = Scaladex.withCache(fetch)
 
-      val res = Gather[Task].gather(scaladexRawDependencies.map { s =>
+      val res = Gather[Task].gather(common.dependencyOptions.scaladex.map { s =>
         val deps = scaladex.dependencies(
           s,
           common.dependencyOptions.scalaVersion,
@@ -277,7 +274,7 @@ class Helper(
   val moduleReq = ModuleRequirements(globalExcludes, localExcludeMap, common.dependencyOptions.defaultConfiguration0)
 
   val (modVerCfgErrors: Seq[String], normalDepsWithExtraParams: Seq[(Dependency, Map[String, String])]) =
-    Parse.moduleVersionConfigs(otherRawDependencies, moduleReq, transitive=true, common.dependencyOptions.scalaVersion)
+    Parse.moduleVersionConfigs(rawDependencies, moduleReq, transitive=true, common.dependencyOptions.scalaVersion)
 
   val (intransitiveModVerCfgErrors: Seq[String], intransitiveDepsWithExtraParams: Seq[(Dependency, Map[String, String])]) =
     Parse.moduleVersionConfigs(common.dependencyOptions.intransitive, moduleReq, transitive=false, common.dependencyOptions.scalaVersion)

--- a/modules/cli/src/main/scala-2.12/coursier/cli/options/shared/DependencyOptions.scala
+++ b/modules/cli/src/main/scala-2.12/coursier/cli/options/shared/DependencyOptions.scala
@@ -1,7 +1,7 @@
 package coursier.cli.options.shared
 
 import caseapp.{ExtraName => Short, HelpMessage => Help, ValueDescription => Value, _}
-import coursier.core.{Configuration, ResolutionProcess}
+import coursier.core.Configuration
 
 final case class DependencyOptions(
 
@@ -33,6 +33,9 @@ final case class DependencyOptions(
 
   @Help("Add sbt plugin dependencies")
     sbtPlugin: List[String] = Nil,
+
+  @Help("Add dependencies via Scaladex lookups")
+    scaladex: List[String] = Nil,
 
   @Help("Default configuration (default(compile) by default)")
   @Value("configuration")

--- a/modules/cli/src/main/scala-2.12/coursier/cli/params/shared/DependencyParams.scala
+++ b/modules/cli/src/main/scala-2.12/coursier/cli/params/shared/DependencyParams.scala
@@ -15,6 +15,7 @@ final case class DependencyParams(
   scalaVersion: String,
   intransitiveDependencies: Seq[(Dependency, Map[String, String])],
   sbtPluginDependencies: Seq[(Dependency, Map[String, String])],
+  scaladexLookups: Seq[String],
   defaultConfiguration: Configuration
 )
 
@@ -152,6 +153,11 @@ object DependencyParams {
 
     val defaultConfiguration = Configuration(options.defaultConfiguration)
 
+    val scaladexLookups = options
+      .scaladex
+      .map(_.trim)
+      .filter(_.nonEmpty)
+
     (excludeV, perModuleExcludeV, intransitiveDependenciesV, sbtPluginDependenciesV).mapN {
       (exclude, perModuleExclude, intransitiveDependencies, sbtPluginDependencies) =>
         DependencyParams(
@@ -160,6 +166,7 @@ object DependencyParams {
           scalaVersion,
           intransitiveDependencies,
           sbtPluginDependencies,
+          scaladexLookups,
           defaultConfiguration
         )
     }


### PR DESCRIPTION
Previously, things not recognized as dependencies were assumed to be Scaladex queries, and were looked into it, like
```bash
$ coursier launch ammonite
```
(which currently resolves the spurious `com.simianquant:ammonite-kernel_2.12:0.4.2`…)

Scaladex lookups now have to be passed via `--scaladex`, like
```bash
$ coursier launch --scaladex ammonite
```
(still spurious lookup though…)