### PR TITLE
Remove HEAD argument from brew install

### DIFF
--- a/doc/docs/cli-overview.md
+++ b/doc/docs/cli-overview.md
@@ -43,7 +43,7 @@ the launcher is available as an asset on the GitHub release page, e.g.
 Alternatively on OS X, install it via homebrew, that puts the `coursier` launcher directly in your PATH,
 ```bash
 $ brew tap coursier/formulas
-$ brew install --HEAD coursier/formulas/coursier
+$ brew install coursier/formulas/coursier
 ```
 
 ### Arch Linux


### PR DESCRIPTION
Due to the replacement of head with an explicit version in https://github.com/coursier/homebrew-formulas/commit/5c0b71234d143c8de816f662d7c16fd6d9ee6de9, the `--HEAD` option doesn't work anymore.