### PR TITLE
Support multiple searchpaths for ld in LDFLAGS

### DIFF
--- a/modules/extra/src/main/scala-2.12/coursier/extra/Native.scala
+++ b/modules/extra/src/main/scala-2.12/coursier/extra/Native.scala
@@ -45,7 +45,7 @@ object Native {
   }
 
   private def linkingOptions(): Seq[String] = sn.Discover.linkingOptions() ++
-    sys.env.get("LDFLAGS").toSeq
+    sys.env.get("LDFLAGS").toSeq.flatMap(_.split(","))
 
   def deleteRecursive(f: File): Unit = {
     if (f.isDirectory) {

--- a/modules/extra/src/main/scala-2.12/coursier/extra/Native.scala
+++ b/modules/extra/src/main/scala-2.12/coursier/extra/Native.scala
@@ -45,7 +45,7 @@ object Native {
   }
 
   private def linkingOptions(): Seq[String] = sn.Discover.linkingOptions() ++
-    sys.env.get("LDFLAGS").toSeq.flatMap(_.split(","))
+    sys.env.get("LDFLAGS").toSeq.flatMap(_.split("\\s+"))
 
   def deleteRecursive(f: File): Unit = {
     if (f.isDirectory) {


### PR DESCRIPTION
This was a stupid mistake in https://github.com/coursier/coursier/pull/981. `ld` supports multiple library paths by passing the same option multiple times (see https://linux.die.net/man/1/ld, search for `--library-path` to get to the correct part of the man page).

Makes sense to support multiple options to `ld` anyway. Users might want to pass other flags than `-L` when creating native bootstraps with coursier.

Not sure what upstream branch to target.