### PR TITLE
Pass authentication on redirect

### DIFF
--- a/modules/tests/jvm/src/it/scala/coursier/test/HttpHttpsRedirectionTests.scala
+++ b/modules/tests/jvm/src/it/scala/coursier/test/HttpHttpsRedirectionTests.scala
@@ -27,7 +27,8 @@ object HttpHttpsRedirectionTests extends TestSuite {
           CacheFetchTests.check(
             MavenRepository(testRepo),
             addCentral = false,
-            deps = deps
+            deps = deps,
+            passAuthenticationOnRedirect = false
           )
 
           false
@@ -48,7 +49,8 @@ object HttpHttpsRedirectionTests extends TestSuite {
           MavenRepository(testRepo),
           addCentral = false,
           deps = deps,
-          followHttpToHttpsRedirections = true
+          followHttpToHttpsRedirections = true,
+          passAuthenticationOnRedirect = false
         )
     }
   }

--- a/modules/tests/jvm/src/test/scala/coursier/test/CacheFetchTests.scala
+++ b/modules/tests/jvm/src/test/scala/coursier/test/CacheFetchTests.scala
@@ -18,6 +18,7 @@ object CacheFetchTests extends TestSuite {
   def check(
     extraRepo: Repository,
     followHttpToHttpsRedirections: Boolean = false,
+    passAuthenticationOnRedirect: Boolean = true,
     deps: Seq[Dependency] = Seq(Dependency(mod"com.github.alexarchambault:coursier_2.11", "1.0.0-M9-test")),
     addCentral: Boolean = true
   ): Unit = {
@@ -40,7 +41,8 @@ object CacheFetchTests extends TestSuite {
 
     val fetchs = Cache.fetchs[Task](
       tmpDir,
-      followHttpToHttpsRedirections = followHttpToHttpsRedirections
+      followHttpToHttpsRedirections = followHttpToHttpsRedirections,
+      passAuthenticationOnRedirect = passAuthenticationOnRedirect
     )
 
     val processFetch = ResolutionProcess.fetch(


### PR DESCRIPTION
This is an attempt to solve the issue described at #963 . We are having the issue at work where coursier doesn't work with lightbend enterprise credentials because the credentials are not being passed after a redirect.

An extra parameter `passAuthenticationOnRedirect` was added to the cache config whose default value is `true`. This is in the interest of getting out of the box behavior that works in the same way that Ivy works. Setting it to `false` should reinstate the old behavior (which I set in an old test).