### PR TITLE
Switch to scala 2.13.0-RC1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,7 @@ lazy val tests = crossProject("tests")(JSPlatform, JVMPlatform)
     dontPublish,
     hasITs,
     coursierPrefix,
-    libs += Deps.scalaAsync,
+    libs += Deps.scalaAsync.value,
     utest,
     sharedTestResources
   )
@@ -87,7 +87,7 @@ lazy val `proxy-tests` = project("proxy-tests")
     coursierPrefix,
     libs ++= Seq(
       Deps.dockerClient,
-      Deps.scalaAsync,
+      Deps.scalaAsync.value,
       Deps.slf4JNop
     ),
     utest,
@@ -119,7 +119,7 @@ lazy val cache = crossProject("cache")(JSPlatform, JVMPlatform)
             "org.http4s" %% "http4s-blaze-server" % "0.18.17" % Test,
             "org.http4s" %% "http4s-dsl" % "0.18.17" % Test,
             "ch.qos.logback" % "logback-classic" % "1.2.3" % Test,
-            Deps.scalaAsync % Test
+            Deps.scalaAsync.value % Test
           )
         case _ =>
           Nil
@@ -163,7 +163,8 @@ lazy val cats = crossProject("interop", "cats")(JSPlatform, JVMPlatform)
     utest,
     Mima.previousArtifacts,
     coursierPrefix,
-    libs += CrossDeps.catsEffect.value
+    libs += CrossDeps.catsEffect.value,
+    onlyIn("2.11", "2.12"), // not there yet for 2.13.0-RC1
   )
 
 lazy val catsJvm = cats.jvm
@@ -333,7 +334,7 @@ lazy val coursier = crossProject("coursier")(JSPlatform, JVMPlatform)
     publishGeneratedSources,
     utest,
     libs ++= Seq(
-      Deps.scalaAsync % Test,
+      Deps.scalaAsync.value % Test,
       CrossDeps.argonautShapeless.value
     )
   )

--- a/modules/cache/jvm/src/main/scala/coursier/cache/internal/Terminal.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/internal/Terminal.scala
@@ -39,7 +39,7 @@ object Terminal {
       throw new Exception("TTY not available")
 
   implicit class Ansi(val output: Writer) extends AnyVal {
-    private def control(n: Int, c: Char) = output.write(s"\033[" + n + c)
+    private def control(n: Int, c: Char) = output.write(s"\u001b[" + n + c)
 
     /**
       * Move up `n` squares

--- a/modules/tests/jvm/src/test/scala/coursier/test/compatibility/package.scala
+++ b/modules/tests/jvm/src/test/scala/coursier/test/compatibility/package.scala
@@ -33,7 +33,7 @@ package object compatibility {
     dir
   }
 
-  private val fillChunks = sys.env.get("FILL_CHUNKS").exists(s => s == "1" || s == "true")
+  private val fillChunks = sys.env.get("FETCH_MOCK_DATA").exists(s => s == "1" || s == "true")
 
   def artifact[F[_]: Sync]: Repository.Fetch[F] =
     MockCache.create[F](baseRepo, fillChunks).fetch

--- a/modules/tests/shared/src/test/resources/resolutions/io.get-coursier/coursier-core_2.12/0.1.2-publish-local
+++ b/modules/tests/shared/src/test/resources/resolutions/io.get-coursier/coursier-core_2.12/0.1.2-publish-local
@@ -1,3 +1,3 @@
 io.get-coursier:coursier-core_2.12:0.1.2-publish-local:compile
 org.scala-lang:scala-library:2.12.8:default
-org.scala-lang.modules:scala-xml_2.12:1.1.1:default
+org.scala-lang.modules:scala-xml_2.12:1.2.0:default

--- a/project/CrossDeps.scala
+++ b/project/CrossDeps.scala
@@ -11,18 +11,12 @@ object CrossDeps {
   // The setting / .value hoop-and-loop is necessary because of the expansion of the %%% macro, which references
   // other settings.
 
-  def argonautShapeless = setting("com.github.alexarchambault" %%% "argonaut-shapeless_6.2" % "1.2.0-M10")
+  def argonautShapeless = setting("com.github.alexarchambault" %%% "argonaut-shapeless_6.2" % SharedVersions.argonautShapeless)
   def catsEffect = setting("org.typelevel" %%% "cats-effect" % "1.2.0")
   def fastParse = setting("com.lihaoyi" %%% "fastparse" % SharedVersions.fastParse)
   def scalazCore = setting("org.scalaz" %%% "scalaz-core" % SharedVersions.scalaz)
   def scalaJsDom = setting("org.scala-js" %%% "scalajs-dom" % "0.9.6")
-  def utest = setting {
-    val is213 = scalaVersion.value.startsWith("2.13")
-    val ver =
-      if (is213) "0.6.6"
-      else "0.6.7"
-    "com.lihaoyi" %%% "utest" % ver
-  }
+  def utest = setting("com.lihaoyi" %%% "utest" % "0.6.7")
   def scalaJsJquery = setting("be.doeraene" %%% "scalajs-jquery" % "0.9.4")
   def scalaJsReact = setting("com.github.japgolly.scalajs-react" %%% "core" % "1.3.1")
 }

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -10,11 +10,11 @@ object Deps {
   def quasiQuotes = "org.scalamacros" %% "quasiquotes" % "2.1.0"
   def fastParse = "com.lihaoyi" %% "fastparse" % SharedVersions.fastParse
   def jsoup = "org.jsoup" % "jsoup" % "1.11.3"
-  def scalaXml = "org.scala-lang.modules" %% "scala-xml" % "1.1.1"
+  def scalaXml = "org.scala-lang.modules" %% "scala-xml" % "1.2.0"
   def scalazConcurrent = "org.scalaz" %% "scalaz-concurrent" % SharedVersions.scalaz
   def caseApp = "com.github.alexarchambault" %% "case-app" % "2.0.0-M6"
   def okhttpUrlConnection = "com.squareup.okhttp" % "okhttp-urlconnection" % "2.7.5"
-  def argonautShapeless = "com.github.alexarchambault" %% "argonaut-shapeless_6.2" % "1.2.0-M10"
+  def argonautShapeless = "com.github.alexarchambault" %% "argonaut-shapeless_6.2" % SharedVersions.argonautShapeless
   def scalatest = "org.scalatest" %% "scalatest" % "3.0.7"
   def junit = "junit" % "junit" % "4.12"
   def dockerClient = "com.spotify" % "docker-client" % "8.15.2"
@@ -26,7 +26,13 @@ object Deps {
     sbtPluginExtra("com.jsuereth" % "sbt-pgp" % ver, sbtv, sv)
   }
 
-  def scalaAsync = "org.scala-lang.modules" %% "scala-async" % "0.9.7"
+  def scalaAsync = Def.setting {
+    val sv = scalaVersion.value
+    val ver =
+      if (sv.startsWith("2.11.")) "0.9.7"
+      else "0.10.0"
+    "org.scala-lang.modules" %% "scala-async" % ver
+  }
 
   def jarjar = "io.get-coursier.jarjar" % "jarjar-core" % "1.0.1-coursier-1"
 

--- a/project/ScalaVersion.scala
+++ b/project/ScalaVersion.scala
@@ -1,7 +1,7 @@
 
 object ScalaVersion {
 
-  def scala213 = "2.13.0-M5"
+  def scala213 = "2.13.0-RC1"
   def scala212 = "2.12.8"
   def scala211 = "2.11.12"
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -404,4 +404,33 @@ object Settings {
     }
   )
 
+  def onlyIn(sbv: String*) = {
+
+    val sbv0 = sbv.toSet
+    val ok = Def.setting {
+      CrossVersion.partialVersion(scalaBinaryVersion.value)
+        .map { case (maj, min) => s"$maj.$min" }
+        .exists(sbv0)
+    }
+
+    Seq(
+      baseDirectory := {
+        val baseDir = baseDirectory.value
+
+        if (ok.value)
+          baseDir
+        else
+          baseDir / "target" / "dummy"
+      },
+      libraryDependencies := {
+        val deps = libraryDependencies.value
+        if (ok.value)
+          deps
+        else
+          Nil
+      },
+      publishArtifact := ok.value
+    )
+  }
+
 }

--- a/project/SharedVersions.scala
+++ b/project/SharedVersions.scala
@@ -1,8 +1,9 @@
 
 object SharedVersions {
 
+  def argonautShapeless = "1.2.0-M11"
   def asm = "5.2"
-  def fastParse = "2.1.0"
+  def fastParse = "2.1.2"
   def proguard = "6.0.3"
   def scalaNative = "0.3.8"
   def scalaz = "7.2.27"


### PR DESCRIPTION
Blocked (at least) by
- [x] [scala-js-dom](https://github.com/scala-js/scala-js-dom)
- [x] [fastparse](https://github.com/lihaoyi/fastparse) (needs release)