### PR TITLE
Shade stuff under different namespaces

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ inThisBuild(List(
 lazy val core = crossProject("core")(JSPlatform, JVMPlatform)
   .jvmConfigure(_.enablePlugins(ShadingPlugin))
   .jvmSettings(
-    shading,
+    shading("coursier.util.shaded"),
     utest,
     libs ++= Seq(
       Deps.fastParse % "shaded",
@@ -317,7 +317,7 @@ lazy val okhttp = project("okhttp")
 lazy val coursier = crossProject("coursier")(JSPlatform, JVMPlatform)
   .jvmConfigure(_.enablePlugins(ShadingPlugin))
   .jvmSettings(
-    shading,
+    shading("coursier.internal.shaded"),
     // TODO shade those
     libs += Deps.fastParse % "shaded"
   )

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -219,13 +219,13 @@ object Settings {
       )
     )
 
-  lazy val shading =
+  def shading(namespace: String) =
     inConfig(_root_.coursier.ShadingPlugin.Shading)(PgpSettings.projectSettings) ++
        // Why does this have to be repeated here?
        // Can't figure out why configuration gets lost without this in particular...
       _root_.coursier.ShadingPlugin.projectSettings ++
       Seq(
-        shadingNamespace := "coursier.shaded",
+        shadingNamespace := namespace,
         publish := publish.in(Shading).value,
         publishLocal := publishLocal.in(Shading).value,
         PgpKeys.publishSigned := PgpKeys.publishSigned.in(Shading).value,


### PR DESCRIPTION
So that things don't collide when we merge the core and coursier module again (in the interface project, for example, where they are proguarded together).