### PR TITLE
Fix dependency parser

### DIFF
--- a/modules/cli/src/main/scala-2.12/coursier/cli/params/shared/SharedLoaderParams.scala
+++ b/modules/cli/src/main/scala-2.12/coursier/cli/params/shared/SharedLoaderParams.scala
@@ -5,6 +5,7 @@ import cats.implicits._
 import coursier.cli.options.shared.SharedLoaderOptions
 import coursier.cli.resolve.Dependencies
 import coursier.core.{Configuration, Dependency}
+import coursier.parse.DependencyParser
 
 final case class SharedLoaderParams(
   loaderNames: Seq[String],
@@ -34,7 +35,7 @@ object SharedLoaderParams {
       .traverse { d =>
         d.split(":", 2) match {
           case Array(target, dep) =>
-            Dependencies.parseSimpleDependency(dep, scalaVersion, defaultConfiguration) match {
+            DependencyParser.dependencyParams(dep, scalaVersion, defaultConfiguration) match {
               case Left(err) =>
                 Validated.invalidNel(s"$d: $err")
               case Right((dep0, params)) =>

--- a/modules/cli/src/main/scala-2.12/coursier/cli/resolve/Dependencies.scala
+++ b/modules/cli/src/main/scala-2.12/coursier/cli/resolve/Dependencies.scala
@@ -12,20 +12,6 @@ import coursier.util.{InMemoryRepository, Task}
 object Dependencies {
 
   /**
-    * Parses a simple dependency, like "org.typelevel:cats-core_2.12:1.1.0".
-    */
-  def parseSimpleDependency(
-    rawDependency: String,
-    scalaVersion: String,
-    defaultConfiguration: Configuration
-  ): Either[String, (Dependency, Map[String, String])] =
-    DependencyParser.dependencyParams(
-      rawDependency,
-      scalaVersion,
-      defaultConfiguration
-    )
-
-  /**
     * Tries to get a dependency, like "scalafmt", via a Scala Index lookup.
     */
   def handleScaladexDependency(
@@ -78,12 +64,11 @@ object Dependencies {
   ): ValidatedNel[String, List[(Dependency, Map[String, String])]] =
     rawDependencies
       .map { s =>
-        val e = parseSimpleDependency(
+        DependencyParser.dependencyParams(
           s,
           scalaVersion,
           defaultConfiguration
-        )
-        e match {
+        ) match {
           case Left(error) => Validated.invalidNel(error)
           case Right(d) => Validated.validNel(List(d))
         }

--- a/modules/coursier/shared/src/test/scala/coursier/parse/DependencyParserTests.scala
+++ b/modules/coursier/shared/src/test/scala/coursier/parse/DependencyParserTests.scala
@@ -23,7 +23,7 @@ object DependencyParserTests extends TestSuite {
       }
     }
 
-    "org:name:version:conifg" - {
+    "org:name:version:config" - {
       DependencyParser.dependencyParams("org.apache.avro:avro:1.7.4:runtime", "2.11.11") match {
         case Left(err) => assert(false)
         case Right((dep, _)) =>


### PR DESCRIPTION
So that one can specify version intervals on the command-line again, in particular.