### PR TITLE
Remove possibly corrupt checksum files

### DIFF
--- a/modules/cache/jvm/src/main/scala/coursier/cache/FileCache.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/FileCache.scala
@@ -579,7 +579,7 @@ final class FileCache[F[_]](private val params: FileCache.Params[F]) extends Cac
 
   def validateChecksum(
     artifact: Artifact,
-                       sumType: String
+    sumType: String
   ): EitherT[F, ArtifactError, Unit] = {
 
     val localFile0 = localFile(artifact.url, artifact.authentication.map(_.user))
@@ -707,21 +707,21 @@ final class FileCache[F[_]](private val params: FileCache.Params[F]) extends Cac
         validateChecksum(artifact, c).map(_ => f)
     }.leftFlatMap {
       case err: ArtifactError.WrongChecksum =>
-        if (retry <= 0) {
+        if (retry <= 0)
           EitherT(S.point(Left(err)))
-        }
-        else {
+        else
           EitherT {
             S.schedule[Either[ArtifactError, Unit]](pool) {
               val badFile = localFile(artifact.url, artifact.authentication.map(_.user))
+              val badChecksumFile = new File(err.sumFile)
               badFile.delete()
+              badChecksumFile.delete()
               logger.removedCorruptFile(artifact.url, Some(err.describe))
               Right(())
             }
           }.flatMap { _ =>
             filePerPolicy0(artifact, policy, retry - 1)
           }
-        }
       case err =>
         EitherT(S.point(Left(err)))
     }

--- a/modules/cache/jvm/src/test/scala-2.12/coursier/cache/TestUtil.scala
+++ b/modules/cache/jvm/src/test/scala-2.12/coursier/cache/TestUtil.scala
@@ -130,9 +130,16 @@ object TestUtil {
 
   def withTmpDir[T](f: Path => T): T = {
     val dir = Files.createTempDirectory("coursier-test")
+    val shutdownHook: Thread =
+      new Thread {
+        override def run() =
+          deleteRecursive(dir.toFile)
+      }
+    Runtime.getRuntime.addShutdownHook(shutdownHook)
     try f(dir)
     finally {
       deleteRecursive(dir.toFile)
+      Runtime.getRuntime.removeShutdownHook(shutdownHook)
     }
   }
 


### PR DESCRIPTION
The file we compute a checksum for was already removed since #797. This removes the (possibly faulty) checksum file too.