### PR TITLE
Filter dependency tree using module regex

### DIFF
--- a/modules/cli/src/main/scala-2.12/coursier/cli/params/ResolveParams.scala
+++ b/modules/cli/src/main/scala-2.12/coursier/cli/params/ResolveParams.scala
@@ -19,7 +19,7 @@ final case class ResolveParams(
   benchmarkCache: Boolean,
   tree: Boolean,
   reverseTree: Boolean,
-  whatDependsOn: Set[ModuleMatcher],
+  whatDependsOn: Seq[ModuleMatcher],
   conflicts: Boolean
 ) {
   def anyTree: Boolean =
@@ -81,7 +81,7 @@ object ResolveParams {
           benchmarkCache,
           tree,
           reverseTree,
-          whatDependsOn.map(m => ModuleMatcher(m)).toSet,
+          whatDependsOn.map(m => ModuleMatcher(m)),
           conflicts
         )
     }

--- a/modules/cli/src/main/scala-2.12/coursier/cli/params/ResolveParams.scala
+++ b/modules/cli/src/main/scala-2.12/coursier/cli/params/ResolveParams.scala
@@ -7,6 +7,7 @@ import coursier.cli.params.shared.{DependencyParams, OutputParams, RepositoryPar
 import coursier.core.{Module, Repository}
 import coursier.params.{CacheParams, ResolutionParams}
 import coursier.parse.ModuleParser
+import coursier.util.ModuleMatcher
 
 final case class ResolveParams(
   cache: CacheParams,
@@ -18,7 +19,7 @@ final case class ResolveParams(
   benchmarkCache: Boolean,
   tree: Boolean,
   reverseTree: Boolean,
-  whatDependsOn: Set[Module],
+  whatDependsOn: Set[ModuleMatcher],
   conflicts: Boolean
 ) {
   def anyTree: Boolean =
@@ -80,7 +81,7 @@ object ResolveParams {
           benchmarkCache,
           tree,
           reverseTree,
-          whatDependsOn.toSet,
+          whatDependsOn.map(m => ModuleMatcher(m)).toSet,
           conflicts
         )
     }

--- a/modules/cli/src/main/scala-2.12/coursier/cli/resolve/Output.scala
+++ b/modules/cli/src/main/scala-2.12/coursier/cli/resolve/Output.scala
@@ -7,7 +7,7 @@ import coursier.cli.params.shared.OutputParams
 import coursier.core.{Dependency, Resolution}
 import coursier.graph.Conflict
 import coursier.params.ResolutionParams
-import coursier.util.Print
+import coursier.util.{ModuleMatcher, Print}
 
 object Output {
 
@@ -55,7 +55,7 @@ object Output {
         if (params.whatDependsOn.nonEmpty)
           Print.dependencyTree(
             res,
-            roots = res.minDependencies.filter(f => params.whatDependsOn(f.module)).toSeq,
+            roots = res.minDependencies.filter(f => params.whatDependsOn.exists(m => m.matches(f.module))).toSeq,
             printExclusions = withExclusions,
             reverse = true,
             colors = colors

--- a/modules/cli/src/main/scala-2.12/coursier/cli/resolve/Output.scala
+++ b/modules/cli/src/main/scala-2.12/coursier/cli/resolve/Output.scala
@@ -7,7 +7,7 @@ import coursier.cli.params.shared.OutputParams
 import coursier.core.{Dependency, Resolution}
 import coursier.graph.Conflict
 import coursier.params.ResolutionParams
-import coursier.util.{ModuleMatcher, Print}
+import coursier.util.Print
 
 object Output {
 

--- a/modules/cli/src/test/scala-2.12/coursier/cli/ResolveTests.scala
+++ b/modules/cli/src/test/scala-2.12/coursier/cli/ResolveTests.scala
@@ -68,6 +68,39 @@ class ResolveTests extends FlatSpec with BeforeAndAfterAll {
     assert(output === expectedOutput)
   }
 
+  it should "print what depends on with regex" in {
+    val options = ResolveOptions(
+      whatDependsOn = List("*:htrace-*")
+    )
+    val args = RemainingArgs(Seq("org.apache.spark:spark-sql_2.12:2.4.0"), Nil)
+
+    val stdout = new ByteArrayOutputStream
+
+    val params = paramsOrThrow(options)
+
+    Resolve.task(params, pool, new PrintStream(stdout, true, "UTF-8"), System.err, args.all)
+      .unsafeRun()(ec)
+
+    val output = new String(stdout.toByteArray, "UTF-8")
+    val expectedOutput =
+      """└─ org.htrace:htrace-core:3.0.4
+        |   ├─ org.apache.hadoop:hadoop-common:2.6.5
+        |   │  └─ org.apache.hadoop:hadoop-client:2.6.5
+        |   │     └─ org.apache.spark:spark-core_2.12:2.4.0
+        |   │        ├─ org.apache.spark:spark-catalyst_2.12:2.4.0
+        |   │        │  └─ org.apache.spark:spark-sql_2.12:2.4.0
+        |   │        └─ org.apache.spark:spark-sql_2.12:2.4.0
+        |   └─ org.apache.hadoop:hadoop-hdfs:2.6.5
+        |      └─ org.apache.hadoop:hadoop-client:2.6.5
+        |         └─ org.apache.spark:spark-core_2.12:2.4.0
+        |            ├─ org.apache.spark:spark-catalyst_2.12:2.4.0
+        |            │  └─ org.apache.spark:spark-sql_2.12:2.4.0
+        |            └─ org.apache.spark:spark-sql_2.12:2.4.0
+        |""".stripMargin
+
+    assert(output === expectedOutput)
+  }
+
   it should "print results anyway" in {
     val options = ResolveOptions(
       outputOptions = OutputOptions(


### PR DESCRIPTION
Just supporting something similar to what maven dependency tree plugin does over here https://maven.apache.org/plugins/maven-dependency-plugin/examples/filtering-the-dependency-tree.html

`coursier` already comes with a `ModuleMatcher` , I naively made use of that when resolving dependencies using the `--what-depends-on` option.

also added a test because test are always nice to have.