### PR TITLE
Accept metadata-specific pattern for Ivy repos on the command-line

### DIFF
--- a/modules/coursier/shared/src/main/scala/coursier/internal/SharedRepositoryParser.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/internal/SharedRepositoryParser.scala
@@ -24,9 +24,17 @@ object SharedRepositoryParser {
       Right(Repositories.sbtMaven(s.stripPrefix("sbt-maven:")))
     else if (s.startsWith("sbt-plugin:"))
       Right(Repositories.sbtPlugin(s.stripPrefix("sbt-plugin:")))
-    else if (s.startsWith("ivy:"))
-      IvyRepository.parse(s.stripPrefix("ivy:"))
-    else if (s == "jitpack")
+    else if (s.startsWith("ivy:")) {
+      val s0 = s.stripPrefix("ivy:")
+      val sepIdx = s0.indexOf('|')
+      if (sepIdx < 0)
+        IvyRepository.parse(s0)
+      else {
+        val mainPart = s0.substring(0, sepIdx)
+        val metadataPart = s0.substring(sepIdx + 1)
+        IvyRepository.parse(mainPart, Some(metadataPart))
+      }
+    } else if (s == "jitpack")
       Right(Repositories.jitpack)
     else
       Right(MavenRepository(s))

--- a/modules/coursier/shared/src/test/scala/coursier/parse/RepositoryParserTests.scala
+++ b/modules/coursier/shared/src/test/scala/coursier/parse/RepositoryParserTests.scala
@@ -47,6 +47,20 @@ object RepositoryParserTests extends TestSuite {
       val res = RepositoryParser.repository("jitpack")
       assert(res.right.exists(isMavenRepo))
     }
+
+    "ivy with metadata" - {
+      val mainPattern =
+        "http://repo/cache/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[organisation]/[module]/[type]s/[artifact]-[revision](-[classifier]).[ext]"
+      val metadataPattern =
+        "http://repo/cache/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[organisation]/[module]/[type]-[revision](-[classifier]).[ext]"
+
+      val repo = s"ivy:$mainPattern|$metadataPattern"
+
+      val expected = IvyRepository.parse(mainPattern, Some(metadataPattern)).right.get
+
+      val res = RepositoryParser.repository(repo)
+      assert(res == Right(expected))
+    }
   }
 
 }


### PR DESCRIPTION
Fixes https://github.com/coursier/coursier/issues/755.

Use like
```
$ coursier resolve -r ivy:https://repo.com/ivy/[defaultPattern]|https://repo.com/ivy/[custom]/[metadata-pattern]
```