### PR TITLE
Support latest subrevision with literal component

### DIFF
--- a/modules/core/shared/src/main/scala/coursier/core/Parse.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Parse.scala
@@ -21,15 +21,9 @@ object Parse {
         for {
           from <- version(prefix)
           if from.rawItems.nonEmpty
-          last <- Some(from.rawItems.last).collect { case n: Version.Numeric => n }
-          // a bit loose, but should do the job
-          if from.repr.endsWith(last.repr)
-          // appending -a1 to the next version, so has not to include things like
-          // nextVersion-RC1 in the interval - nothing like nextVersion* should be included
-          to <- version(from.repr.stripSuffix(last.repr) + last.next.repr + "-a1")
+          to <- version(prefix + "-max")
           // the contrary would mean something went wrong in the loose substitution above
-          if from.rawItems.init == to.rawItems.dropRight(2).init
-          if to.rawItems.takeRight(2) == Seq(Version.Literal("a"), Version.Number(1))
+          if from.rawItems.init == to.rawItems.dropRight(1).init
         } yield VersionInterval(Some(from), Some(to), fromIncluded = true, toIncluded = false)
       case _ =>
         None

--- a/modules/core/shared/src/main/scala/coursier/core/Parse.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Parse.scala
@@ -13,18 +13,19 @@ object Parse {
   }
 
   // matches revisions with a '+' appended, e.g. "1.2.+", "1.2+" or "1.2.3-+"
-  private val latestSubRevision = "(.*[^.-])[.-]?[+]".r
+  private val latestSubRevision = "(.*[^.-])([.-]?)[+]".r
 
   def ivyLatestSubRevisionInterval(s: String): Option[VersionInterval] =
     s match {
-      case latestSubRevision(prefix) =>
+      case latestSubRevision(prefix, delim) =>
         for {
           from <- version(prefix)
           if from.rawItems.nonEmpty
-          to <- version(prefix + "-max")
+          max = (if (delim.isEmpty) "." else delim) + "max"
+          to <- version(prefix + max)
           // the contrary would mean something went wrong in the loose substitution above
           if from.rawItems.init == to.rawItems.dropRight(1).init
-        } yield VersionInterval(Some(from), Some(to), fromIncluded = true, toIncluded = false)
+        } yield VersionInterval(Some(from), Some(to), fromIncluded = true, toIncluded = true)
       case _ =>
         None
     }

--- a/modules/core/shared/src/main/scala/coursier/core/Version.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Version.scala
@@ -188,7 +188,7 @@ object Version {
 
       if (isNumeric(item)) {
         val nextNonDotZero = _tokens.dropWhile{case (Tokenizer.Dot, n: Numeric) => n.isEmpty; case _ => false }
-        if (nextNonDotZero.forall(t => t._1 == Tokenizer.Hyphen || ((t._1 == Tokenizer.Dot || t._1 == Tokenizer.None) && !isNumeric(t._2)))) { // Dot && isNumeric(t._2)
+        if (nextNonDotZero.forall(t => !isMinMax(t._2) && (t._1 == Tokenizer.Hyphen || ((t._1 == Tokenizer.Dot || t._1 == Tokenizer.None) && !isNumeric(t._2))))) { // Dot && isNumeric(t._2)
           _tokens = nextNonDotZero
         }
       }
@@ -223,6 +223,10 @@ object Version {
   }
 
   def isNumeric(item: Item) = item match { case _: Numeric => true; case _ => false }
+
+  def isMinMax(item: Item) = {
+    (item eq Min) || (item eq Max) || item == Literal("min") || item == Literal("max")
+  }
 
   def items(repr: String): List[Item] = {
     val (first, tokens) = Tokenizer(repr)

--- a/modules/tests/shared/src/test/scala/coursier/test/VersionConstraintTests.scala
+++ b/modules/tests/shared/src/test/scala/coursier/test/VersionConstraintTests.scala
@@ -21,15 +21,32 @@ object VersionConstraintTests extends TestSuite {
         assert(c0 == VersionConstraint.interval(VersionInterval(None, Some(Version("1.2")), false, true)))
       }
       'latestSubRevision{
-        val c0 = Parse.versionConstraint("1.2.3-rc+")
-        assert(c0 == VersionConstraint.interval(VersionInterval(Some(Version("1.2.3-rc")), Some(Version("1.2.3-rc-max")), true, false)))
+        val c0 = Parse.versionConstraint("1.2.3-+")
+        assert(c0 == VersionConstraint.interval(VersionInterval(Some(Version("1.2.3")), Some(Version("1.2.3-max")), true, true)))
+      }
+      'latestSubRevisionWithLiteral{
+        val c0 = Parse.versionConstraint("1.2.3-rc-+")
+        assert(c0 == VersionConstraint.interval(VersionInterval(Some(Version("1.2.3-rc")), Some(Version("1.2.3-rc-max")), true, true)))
+      }
+      'latestSubRevisionWithZero{
+        val c0 = Parse.versionConstraint("1.0.+")
+        assert(c0 == VersionConstraint.interval(VersionInterval(Some(Version("1.0")), Some(Version("1.0.max")), true, true)))
       }
     }
 
     'interval{
-      'same{
+      'checkZero{
+        val v103 = Version("1.0.3")
+        val v107 = Version("1.0.7")
+        val v112 = Version("1.1.2")
+        val c0 = VersionInterval(Some(Version("1.0")), Some(Version("1.0.max")), true, true)
+        assert(c0.contains(v103))
+        assert(c0.contains(v107))
+        assert(!c0.contains(v112))
+      }
+      'subRevision{
         val v = Version("1.2.3-rc")
-        val c0 = VersionInterval(Some(v),  Some(Version("1.2.3-rc-max")), true, false)
+        val c0 = VersionInterval(Some(v),  Some(Version("1.2.3-rc-max")), true, true)
         assert(c0.contains(v))
         assert(c0.contains(Version("1.2.3-rc-500")))
         assert(!c0.contains(Version("1.2.3-final")))

--- a/modules/tests/shared/src/test/scala/coursier/test/VersionConstraintTests.scala
+++ b/modules/tests/shared/src/test/scala/coursier/test/VersionConstraintTests.scala
@@ -21,8 +21,18 @@ object VersionConstraintTests extends TestSuite {
         assert(c0 == VersionConstraint.interval(VersionInterval(None, Some(Version("1.2")), false, true)))
       }
       'latestSubRevision{
-        val c0 = Parse.versionConstraint("1.2.3-+")
-        assert(c0 == VersionConstraint.interval(VersionInterval(Some(Version("1.2.3")), Some(Version("1.2.4-a1")), true, false)))
+        val c0 = Parse.versionConstraint("1.2.3-rc+")
+        assert(c0 == VersionConstraint.interval(VersionInterval(Some(Version("1.2.3-rc")), Some(Version("1.2.3-rc-max")), true, false)))
+      }
+    }
+
+    'interval{
+      'same{
+        val v = Version("1.2.3-rc")
+        val c0 = VersionInterval(Some(v),  Some(Version("1.2.3-rc-max")), true, false)
+        assert(c0.contains(v))
+        assert(c0.contains(Version("1.2.3-rc-500")))
+        assert(!c0.contains(Version("1.2.3-final")))
       }
     }
 


### PR DESCRIPTION
We are using versions that look like this:

* `1.2.3-release-20190218T104029`
* `1.2.3-rc-20190308T090142`
* `1.2.3-alpha-32-20190311T150837`

In our projects, we (lazily) use dynamic revisions for *internal* `libraryDependencies` (or SBT plugins) like this:
```
"de.intern" %% "project-lib" % "1.2.3-release-+"
```
This works perfectly with vanilla SBT, but fails when using coursier.

This PR is an effort to fix this. I am using the `MAX` version component which simplifies constructing a version range since one does no longer need to compute the-next-version-number.