### PR TITLE
Fix ignored conflict

### DIFF
--- a/modules/core/shared/src/main/scala/coursier/core/Versions.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Versions.scala
@@ -88,8 +88,14 @@ final case class VersionConstraint(
   interval: VersionInterval,
   preferred: Seq[Version]
 ) {
+  def isValid: Boolean =
+    interval.isValid && preferred.forall { v =>
+      interval.contains(v) ||
+        interval.to.forall(v.compare(_) <= 0)
+    }
+
   def blend: Option[Either[VersionInterval, Version]] =
-    if (interval.isValid) {
+    if (isValid) {
       val preferredInInterval = preferred.filter(interval.contains)
 
       if (preferredInInterval.isEmpty)

--- a/modules/tests/shared/src/test/scala/coursier/test/CentralTests.scala
+++ b/modules/tests/shared/src/test/scala/coursier/test/CentralTests.scala
@@ -129,7 +129,8 @@ abstract class CentralTests extends TestSuite {
         * - runner.resolutionCheck(
           mod,
           version,
-          extraRepos = extraRepos
+          extraRepos = extraRepos,
+          forceVersions = Map(mod"commons-codec:commons-codec" -> "1.6")
         )
       }
     }


### PR DESCRIPTION
For example, depending on both `2.12+` (equivalent to `[2.12,2.12-max]`) and `2.13.0` wasn't resulting in a conflict. It does with this PR from now on.