### PR TITLE
Optimizations

### DIFF
--- a/modules/cache/jvm/src/main/scala/coursier/cache/loggers/RefreshLogger.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/loggers/RefreshLogger.scala
@@ -39,7 +39,7 @@ object RefreshLogger {
     new RefreshLogger(writer, display)
 
 
-  def defaultFallbackMode: Boolean = {
+  lazy val defaultFallbackMode: Boolean = {
     val env0 = sys.env.get("COURSIER_PROGRESS").map(_.toLowerCase).collect {
       case "true"  | "enable"  | "1" => true
       case "false" | "disable" | "0" => false

--- a/modules/core/jvm/src/main/scala/coursier/core/compatibility/Entities.scala
+++ b/modules/core/jvm/src/main/scala/coursier/core/compatibility/Entities.scala
@@ -96,4 +96,6 @@ object Entities {
     ("&thorn;", "&#254;"),
     ("&yuml;", "&#255;")
   )
+
+  lazy val map = entities.toMap
 }

--- a/modules/core/shared/src/main/scala/coursier/core/Dependency.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Dependency.scala
@@ -127,6 +127,9 @@ final class Dependency private (
     copy0(optional = optional)
   def withTransitive(transitive: Boolean): Dependency =
     copy0(transitive = transitive)
+
+  lazy val clearExclusions: Dependency =
+    withExclusions(Set.empty)
 }
 
 object Dependency {

--- a/modules/core/shared/src/main/scala/coursier/core/DependencySet.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/DependencySet.scala
@@ -1,0 +1,148 @@
+package coursier.core
+
+import coursier.core.DependencySet.Sets
+
+import scala.collection.immutable.TreeMap
+import scala.collection.mutable
+
+final case class DependencySet(
+  set: Set[Dependency],
+  grouped: Map[Dependency, Sets[Dependency]]
+) {
+
+  assert(grouped.iterator.map(_._2.size).sum == set.size, s"${grouped.iterator.map(_._2.size).sum} != ${set.size}")
+  assert(grouped.forall { case (dep, l) => l.forall(_.moduleVersion == dep.moduleVersion) })
+
+  lazy val minimizedSet: Set[Dependency] =
+    grouped.iterator.flatMap(_._2.children.keysIterator).toSet
+
+  def add(dependency: Dependency): DependencySet =
+    add(Seq(dependency))
+
+  def add(dependency: Iterable[Dependency]): DependencySet =
+    addNoCheck(dependency.filter(!set(_)))
+
+  private def addNoCheck(dependencies: Iterable[Dependency]): DependencySet =
+    if (dependencies.isEmpty)
+      this
+    else {
+      val m = new mutable.HashMap[Dependency, Sets[Dependency]]
+      m ++= grouped
+      for (dep <- dependencies) {
+        val dep0 = dep.clearExclusions
+        val l = m.getOrElse(dep0, Sets.empty[Dependency]).add(dep, _.exclusions.size, (a, b) => a.exclusions.subsetOf(b.exclusions))
+        m(dep0) = l
+      }
+      DependencySet(set ++ dependencies, m.toMap)
+    }
+
+  def remove(dependencies: Iterable[Dependency]): DependencySet =
+    removeNoCheck(dependencies.filter(set))
+
+  private def removeNoCheck(dependencies: Iterable[Dependency]): DependencySet =
+    if (dependencies.isEmpty)
+      this
+    else {
+      val m = new mutable.HashMap[Dependency, Sets[Dependency]]
+      m ++= grouped
+      for (dep <- dependencies) {
+        val dep0 = dep.clearExclusions
+        val prev = m.getOrElse(dep0, Sets.empty) // getOrElse useful if we're passed duplicated stuff in dependencies
+        if (prev.contains(dep)) {
+          if (prev.size <= 1) {
+            m -= dep0
+          } else {
+            val l = prev.remove(dep, _.exclusions.size, (a, b) => a.exclusions.subsetOf(b.exclusions))
+            m += ((dep0, l))
+          }
+        }
+      }
+
+      DependencySet(set -- dependencies, m.toMap)
+    }
+
+  def setValues(newSet: Set[Dependency]): DependencySet = {
+    val toAdd = newSet -- set
+    val toRemove = set -- newSet
+    addNoCheck(toAdd)
+      .removeNoCheck(toRemove)
+  }
+
+}
+
+object DependencySet {
+  val empty = DependencySet(Set.empty, Map.empty)
+
+
+  object Sets {
+    def empty[T]: Sets[T] = Sets(TreeMap.empty, Map.empty, Map.empty)
+  }
+
+  final case class Sets[T](
+    required: TreeMap[Int, Set[T]],
+    children: Map[T, Set[T]],
+    parents: Map[T, T]
+  ) {
+
+    def size: Int = parents.size + children.size
+
+    def forall(f: T => Boolean): Boolean =
+      (parents.keysIterator ++ children.keysIterator)
+        .forall(f)
+
+    def contains(t: T): Boolean =
+      parents.contains(t) || children.contains(t)
+
+    private def forceAdd(s: T, size: T => Int, subsetOf: (T, T) => Boolean): Sets[T] = {
+
+      val n = size(s)
+
+      val subsetOpt = required.filterKeys(_ <= n).iterator.flatMap(_._2.iterator).find {
+        s0 => subsetOf(s0, s)
+      }
+
+      subsetOpt match {
+        case None =>
+          val required0 = required + (n -> (required.getOrElse(n, Set.empty) + s))
+          val children0 = children + (s -> Set.empty[T])
+          Sets(required0, children0, parents)
+        case Some(subset) =>
+          val children0 = children + (subset -> (children.getOrElse(subset, Set.empty) + s))
+          val parents0 = parents + (s -> subset)
+          Sets(required, children0, parents0)
+      }
+    }
+
+    def add(s: T, size: T => Int, subsetOf: (T, T) => Boolean): Sets[T] =
+      if (children.contains(s) || parents.contains(s))
+        this
+      else
+        forceAdd(s, size, subsetOf)
+
+    def remove(s: T, size: T => Int, subsetOf: (T, T) => Boolean): Sets[T] =
+      children.get(s) match {
+        case Some(children0) =>
+          val required0 = {
+            val elem = required.getOrElse(size(s), Set.empty) - s
+            if (elem.isEmpty)
+              required - size(s)
+            else
+              required + (size(s) -> elem)
+          }
+          val before = this.size
+          val parents0 = parents -- children0
+          val sets0 = Sets(required0, children - s, parents0)
+          val r = children0.foldLeft(sets0)(_.forceAdd(_, size, subsetOf))
+          val after = r.size
+          assert(before - after == 1, s"after: $after, before: $before, right before: ${sets0.size}, removing $s, adding back $children0")
+          r
+        case None =>
+          parents.get(s) match {
+            case Some(parent) =>
+              Sets(required, children + (parent -> (children.getOrElse(parent, Set.empty) - s)), parents - s)
+            case None =>
+              sys.error(s"Couldn't remove $s")
+          }
+      }
+  }
+}

--- a/modules/core/shared/src/main/scala/coursier/core/Resolution.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Resolution.scala
@@ -621,14 +621,13 @@ object Resolution {
  *
  * Done if method `isDone` returns `true`.
  *
- * @param dependencies: current set of dependencies
  * @param conflicts: conflicting dependencies
  * @param projectCache: cache of known projects
  * @param errorCache: keeps track of the modules whose project definition could not be found
  */
 final case class Resolution(
   rootDependencies: Seq[Dependency],
-  dependencies: Set[Dependency],
+  dependencySet: DependencySet,
   forceVersions: Map[Module, String],
   conflicts: Set[Dependency],
   projectCache: Map[Resolution.ModuleVersion, (Artifact.Source, Project)],
@@ -643,6 +642,9 @@ final case class Resolution(
   forceProperties: Map[String, String] // FIXME Make that a seq too?
 ) {
 
+  lazy val dependencies: Set[Dependency] =
+    dependencySet.set
+
   override lazy val hashCode: Int = {
     var code = 17 + "coursier.core.Resolution".##
     code = 37 * code + Resolution.unapply(this).get.##
@@ -656,7 +658,7 @@ final case class Resolution(
 
   private def copyWithCache(
     rootDependencies: Seq[Dependency] = rootDependencies,
-    dependencies: Set[Dependency] = dependencies,
+    dependencySet: DependencySet = dependencySet,
     conflicts: Set[Dependency] = conflicts,
     errorCache: Map[Resolution.ModuleVersion, Seq[String]] = errorCache
     // don't allow changing mapDependencies here - that would invalidate finalDependenciesCache
@@ -664,7 +666,7 @@ final case class Resolution(
   ): Resolution =
     copy(
       rootDependencies,
-      dependencies,
+      dependencySet,
       forceVersions,
       conflicts,
       projectCache,
@@ -735,7 +737,7 @@ final case class Resolution(
    * No attempt is made to solve version conflicts here.
    */
   lazy val transitiveDependencies: Seq[Dependency] =
-    (dependencies -- conflicts)
+    (dependencySet.minimizedSet -- conflicts)
       .toVector
       .flatMap(finalDependencies0)
 
@@ -753,7 +755,7 @@ final case class Resolution(
   lazy val nextDependenciesAndConflicts: (Seq[Dependency], Seq[Dependency], Map[Module, String]) =
     // TODO Provide the modules whose version was forced by dependency overrides too
     merge(
-      rootDependencies.map(withDefaultConfig) ++ dependencies ++ transitiveDependencies,
+      rootDependencies.map(withDefaultConfig) ++ dependencySet.minimizedSet ++ transitiveDependencies,
       forceVersions
     )
 
@@ -871,7 +873,7 @@ final case class Resolution(
     val (newConflicts, _, _) = nextDependenciesAndConflicts
 
     copyWithCache(
-      dependencies = newDependencies ++ newConflicts,
+      dependencySet = dependencySet.setValues(newDependencies ++ newConflicts),
       conflicts = newConflicts.toSet
     )
   }
@@ -1232,7 +1234,7 @@ final case class Resolution(
 
     copyWithCache(
       rootDependencies = dependencies,
-      dependencies = helper(dependencies.map(updateVersion).toSet)
+      dependencySet = dependencySet.setValues(helper(dependencies.map(updateVersion).toSet))
       // don't know if something should be done about conflicts
     )
   }

--- a/modules/core/shared/src/main/scala/coursier/core/Resolution.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Resolution.scala
@@ -846,7 +846,7 @@ final case class Resolution(
               broughtBy
                 .filter(x => remaining.contains(x) || rootDependencies0(x))
             )
-            .toVector
+            .iterator
             .toMap
         )
     }

--- a/modules/core/shared/src/main/scala/coursier/maven/MavenRepository.scala
+++ b/modules/core/shared/src/main/scala/coursier/maven/MavenRepository.scala
@@ -125,13 +125,25 @@ final case class MavenRepository(
   private def moduleVersionPath(module: Module, version: String): Seq[String] =
     modulePath(module) :+ toBaseVersion(version)
 
-  private[maven] def urlFor(path: Seq[String], isDir: Boolean = false): String =
-    root0 + {
+  private[maven] def urlFor(path: Seq[String], isDir: Boolean = false): String = {
+    val b = new StringBuilder(root0)
+
+    val it = path.iterator
+    var isFirst = true
+    while (it.hasNext) {
+      if (!isDir) {
+        if (isFirst)
+          isFirst = false
+        else
+          b += '/'
+      }
+      b ++= it.next()
       if (isDir)
-        path.map(encodeURIComponent).map(_ + "/").mkString
-      else
-        path.map(encodeURIComponent).mkString("/")
+        b += '/'
     }
+
+    b.result()
+  }
 
   def projectArtifact(
     module: Module,

--- a/modules/coursier/shared/src/main/scala/coursier/Resolve.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/Resolve.scala
@@ -1,7 +1,7 @@
 package coursier
 
 import coursier.cache.{Cache, CacheLogger}
-import coursier.core.Exclusions
+import coursier.core.{Activation, DependencySet, Exclusions}
 import coursier.error.ResolutionError
 import coursier.error.conflict.UnsatisfiedRule
 import coursier.internal.Typelevel
@@ -12,7 +12,6 @@ import coursier.util._
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.language.higherKinds
-import coursier.core.Activation
 
 final class Resolve[F[_]] private[coursier] (private val params: Resolve.Params[F]) {
 
@@ -161,7 +160,7 @@ final class Resolve[F[_]] private[coursier] (private val params: Resolve.Params[
             case Right(Right(None)) =>
               recurseOnRules(res, t)
             case Right(Right(Some(newRes))) =>
-              S.bind(S.bind(run(newRes.copy(dependencies = Set.empty)))(validate0)) { res0 =>
+              S.bind(S.bind(run(newRes.copy(dependencySet = DependencySet.empty)))(validate0)) { res0 =>
                 // FIXME check that the rule passes after it tried to address itself
                 recurseOnRules(res0, t)
               }
@@ -309,7 +308,7 @@ object Resolve extends PlatformResolve {
 
     coursier.core.Resolution(
       rootDependencies = dependencies,
-      dependencies = Set.empty,
+      dependencySet = DependencySet.empty,
       forceVersions = params.forceVersion ++ forceScalaVersions,
       conflicts = Set.empty,
       projectCache = Map.empty,

--- a/modules/coursier/shared/src/main/scala/coursier/package.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/package.scala
@@ -104,7 +104,7 @@ package object coursier {
     ): Resolution =
       core.Resolution(
         rootDependencies,
-        dependencies,
+        DependencySet.empty.add(dependencies),
         forceVersions,
         conflicts,
         projectCache,

--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -65,6 +65,11 @@ object Mima {
       import com.typesafe.tools.mima.core._
 
       Seq(
+        // things that are going to change more before 2.0 final
+        ProblemFilters.exclude[IncompatibleResultTypeProblem]("coursier.core.Resolution.copy$default$2"),
+        ProblemFilters.exclude[IncompatibleMethTypeProblem]("coursier.core.Resolution.copy"),
+        ProblemFilters.exclude[IncompatibleMethTypeProblem]("coursier.core.Resolution.this"),
+        ProblemFilters.exclude[IncompatibleMethTypeProblem]("coursier.core.Resolution.apply"),
         // should have been private
         ProblemFilters.exclude[DirectMissingMethodProblem]("coursier.core.Resolution#DepMgmt.add"),
         // things that were supposed to be private

--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -65,6 +65,8 @@ object Mima {
       import com.typesafe.tools.mima.core._
 
       Seq(
+        // should have been private
+        ProblemFilters.exclude[DirectMissingMethodProblem]("coursier.core.Resolution#DepMgmt.add"),
         // things that were supposed to be private
         ProblemFilters.exclude[IncompatibleResultTypeProblem]("coursier.core.Resolution#DepMgmt.key"),
         ProblemFilters.exclude[IncompatibleResultTypeProblem]("coursier.core.Resolution#DepMgmt.key"),


### PR DESCRIPTION
This optimizes hot paths and costly methods seen when profiling resolutions with async-profiler (with commands like `profiler.sh -e wall -t -f flamegraph.svg PID` / `coursier resolve org:name:ver --parallel 1 --benchmark 1000`)

The contributions of each commit are probabaly unequal… "Optimized dependency set" should be the one bringing the most gains. It tries to avoid costly calculations (post-processing of `Dependency`: taking into account dependency management, properties, exclusions, …) by ignoring dependencies that can be ignored (because other dependencies bring the same artifacts and transitive dependencies) from the dependency set of `Resolution`.

[This notebook](https://nbviewer.jupyter.org/gist/alexarchambault/c1380873a6bded4d7a02883bf336855e) shows before / after resolution times (ms), for spark-sql and spark-repl.

This optimizes things on warm JVMs. Gains are probably more modest on cold ones. But these ought to be there from the graalvm native launcher.