### PR TITLE
Have strict conflict manager ignore conflicts for forced versions

### DIFF
--- a/modules/coursier/shared/src/main/scala/coursier/params/rule/Strict.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/params/rule/Strict.scala
@@ -7,7 +7,8 @@ import coursier.util.ModuleMatcher
 
 final case class Strict(
   include: Set[ModuleMatcher] = Set(ModuleMatcher.all),
-  exclude: Set[ModuleMatcher] = Set.empty
+  exclude: Set[ModuleMatcher] = Set.empty,
+  ignoreIfForcedVersion: Boolean = true
 ) extends Rule {
 
   import Strict._
@@ -17,7 +18,9 @@ final case class Strict(
   def check(res: Resolution): Option[EvictedDependencies] = {
 
     val conflicts = coursier.graph.Conflict(res).filter { c =>
-      include.exists(_.matches(c.module)) &&
+      val ignore = ignoreIfForcedVersion && res.forceVersions.get(c.module).contains(c.version)
+      !ignore &&
+        include.exists(_.matches(c.module)) &&
         !exclude.exists(_.matches(c.module))
     }
 

--- a/modules/tests/shared/src/test/resources/resolutions/com.github.alexarchambault/argonaut-shapeless_6.2_2.12/1.2.0-M4_depc7dd6de1636ac652de44565a82e3cbe2511cba3_params95fe1bd55fbf0c7a6dba14107b08dbb8eccd8687
+++ b/modules/tests/shared/src/test/resources/resolutions/com.github.alexarchambault/argonaut-shapeless_6.2_2.12/1.2.0-M4_depc7dd6de1636ac652de44565a82e3cbe2511cba3_params95fe1bd55fbf0c7a6dba14107b08dbb8eccd8687
@@ -1,0 +1,6 @@
+com.chuusai:shapeless_2.12:2.3.3:compile
+com.github.alexarchambault:argonaut-shapeless_6.2_2.12:1.2.0-M4:compile
+io.argonaut:argonaut_2.12:6.2-RC2:compile
+org.scala-lang:scala-library:2.12.4:compile
+org.scala-lang:scala-reflect:2.12.0:compile
+org.typelevel:macro-compat_2.12:1.1.1:compile


### PR DESCRIPTION
By default, previous behavior can still be recovered