### PR TITLE
More optims around version listing / completion

### DIFF
--- a/modules/cache/jvm/src/main/scala/coursier/cache/MockCache.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/MockCache.scala
@@ -8,7 +8,7 @@ import java.util.concurrent.ExecutorService
 
 import coursier.cache.internal.MockCacheEscape
 import coursier.core.{Artifact, Repository}
-import coursier.util.{EitherT, Sync}
+import coursier.util.{EitherT, Sync, WebPage}
 
 import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success, Try}
@@ -26,15 +26,20 @@ final case class MockCache[F[_]](
 
   def fetch: Repository.Fetch[F] = { artifact =>
 
-    if (artifact.url.startsWith("http://localhost:"))
+    val (artifact0, links) =
+      if (artifact.url.endsWith("/.links")) (artifact.copy(url = artifact.url.stripSuffix(".links")), true)
+      else (artifact, false)
+
+    if (artifact0.url.startsWith("http://localhost:"))
       EitherT(MockCache.readFully(
-        CacheUrl.urlConnection(artifact.url, artifact.authentication).getInputStream
+        CacheUrl.urlConnection(artifact0.url, artifact0.authentication).getInputStream,
+        if (links) Some(artifact0.url) else None
       ))
     else
-      file(artifact)
+      file(artifact0)
         .leftMap(_.describe)
         .flatMap { f =>
-          EitherT(MockCache.readFully(new FileInputStream(f)))
+          EitherT(MockCache.readFully(new FileInputStream(f), if (links) Some(artifact0.url) else None))
         }
   }
 
@@ -135,7 +140,7 @@ object MockCache {
     buffer.toByteArray
   }
 
-  private def readFully[F[_]: Sync](is: => InputStream): F[Either[String, String]] =
+  private def readFully[F[_]: Sync](is: => InputStream, parseLinksUrl: Option[String]): F[Either[String, String]] =
     Sync[F].delay {
       val t = Try {
         val is0 = is
@@ -143,7 +148,12 @@ object MockCache {
           try readFullySync(is0)
           finally is0.close()
 
-        new String(b, StandardCharsets.UTF_8)
+        val s = new String(b, StandardCharsets.UTF_8)
+        parseLinksUrl match {
+          case None => s
+          case Some(url) =>
+            WebPage.listElements(url, s).mkString("\n")
+        }
       }
 
       t match {

--- a/modules/cli/src/main/scala/coursier/cli/install/Channels.scala
+++ b/modules/cli/src/main/scala/coursier/cli/install/Channels.scala
@@ -24,7 +24,7 @@ object Channels {
     def fromModule(channel: Channel.FromModule): Option[(Channel, String, Array[Byte])] = {
 
       val files = Fetch(cache)
-        .withDependencies(Seq(Dependency(channel.module, "latest.integration")))
+        .withDependencies(Seq(Dependency(channel.module, "latest.release")))
         .withRepositories(repositories)
         .io
         .unsafeRun()(cache.ec)

--- a/modules/core/shared/src/main/scala/coursier/core/ResolutionProcess.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/ResolutionProcess.scala
@@ -262,86 +262,119 @@ object ResolutionProcess {
       fetchs.foldLeft(fetch(a))((acc, f) => acc.leftFlatMap(_ => f(a)))
     }
 
-    def getLatest(ver: Either[VersionInterval, (Latest, Option[VersionInterval])], fetch: Repository.Fetch[F]) = {
-
-      val lookups = repositories.map(_.versions(module, f).run)
-
-      val versionOrError: F[Either[Seq[String], (Version, Repository)]] =
-        F.map(F.gather(lookups)) { results =>
-          // FIXME We're sometimes trapping errors here (left elements in results)
-          val found = results.zip(repositories)
-            .collect {
-              case (Right((v, listingUrl)), repo) =>
-                val selectedOpt = ver match {
+    def versionOrError0(results: Either[String, (Versions, String)], ver: Either[VersionInterval, (Latest, Option[VersionInterval])]): Either[String, Version] =
+      results match {
+        case Right((v, listingUrl)) =>
+          val selectedOpt = ver match {
+            case Left(itv) =>
+              v.inInterval(itv)
+            case Right((kind, _)) =>
+              v.latest(kind)
+          }
+          selectedOpt match {
+            case Some(ver0) =>
+              val selectedVer = Version(ver0)
+              ver match {
+                case Right((kind, Some(itv))) if !itv.contains(selectedVer) =>
+                  Left(
+                    v.latest(kind) match {
+                      case None =>
+                        s"No latest ${kind.name} version found in $listingUrl"
+                      case Some(v0) =>
+                        if (v0 == selectedVer.repr)
+                          s"Latest ${kind.name} $v0 from $listingUrl not in ${itv.repr}"
+                        else
+                          s"Latest ${kind.name} $v0 from $listingUrl not retained"
+                    }
+                  )
+                case _ =>
+                  Right(selectedVer)
+              }
+            case None =>
+              Left {
+                ver match {
                   case Left(itv) =>
-                    v.inInterval(itv)
+                    s"No version found for $itv in $listingUrl"
                   case Right((kind, _)) =>
-                    v.latest(kind)
+                    s"No latest ${kind.name} version found in $listingUrl"
                 }
-                (selectedOpt, repo, listingUrl)
+              }
+          }
+        case Left(e) =>
+          Left(e)
+      }
+
+    def versionOrError(results: Seq[Either[String, (Versions, String)]], ver: Either[VersionInterval, (Latest, Option[VersionInterval])]): Either[Seq[String], (Version, Repository)] = {
+      // FIXME We're sometimes trapping errors here (left elements in results)
+      val found = results.zip(repositories)
+        .collect {
+          case (Right((v, listingUrl)), repo) =>
+            val selectedOpt = ver match {
+              case Left(itv) =>
+                v.inInterval(itv)
+              case Right((kind, _)) =>
+                v.latest(kind)
             }
-            .collect {
-              case (Some(v), repo, listingUrl) =>
-                (Version(v), repo, listingUrl)
-            }
-          if (found.isEmpty)
+            (selectedOpt, repo, listingUrl)
+        }
+        .collect {
+          case (Some(v), repo, listingUrl) =>
+            (Version(v), repo, listingUrl)
+        }
+      if (found.isEmpty)
+        Left(
+          results.map {
+            case Left(e) => e
+            case Right((_, listingUrl)) =>
+              ver match {
+                case Left(itv) =>
+                  s"No version found for $itv in $listingUrl"
+                case Right((kind, _)) =>
+                  s"No latest ${kind.name} version found in $listingUrl"
+              }
+          }
+        )
+      else {
+        val (selectedVer, repo, _) = found.maxBy(_._1)
+        ver match {
+          case Right((kind, Some(itv))) if !itv.contains(selectedVer) =>
             Left(
               results.map {
                 case Left(e) => e
-                case Right((_, listingUrl)) =>
-                  ver match {
-                    case Left(itv) =>
-                      s"No version found for $itv in $listingUrl"
-                    case Right((kind, _)) =>
+                case Right((v, listingUrl)) =>
+                  v.latest(kind) match {
+                    case None =>
                       s"No latest ${kind.name} version found in $listingUrl"
+                    case Some(v0) =>
+                      if (v0 == selectedVer.repr)
+                        s"Latest ${kind.name} $v0 from $listingUrl not in ${itv.repr}"
+                      else
+                        s"Latest ${kind.name} $v0 from $listingUrl not retained"
                   }
               }
             )
-          else {
-            val (selectedVer, repo, _) = found.maxBy(_._1)
-            ver match {
-              case Left(_) =>
-                Right((selectedVer, repo))
-              case Right((kind, intervalOpt)) =>
-                intervalOpt match {
-                  case None =>
-                    Right((selectedVer, repo))
-                  case Some(itv) =>
-                    if (itv.contains(selectedVer))
-                      Right((selectedVer, repo))
-                    else
-                      Left(
-                        results.map {
-                          case Left(e) => e
-                          case Right((v, listingUrl)) =>
-                            v.latest(kind) match {
-                              case None =>
-                                s"No latest ${kind.name} version found in $listingUrl"
-                              case Some(v0) =>
-                                if (v0 == selectedVer.repr)
-                                  s"Latest ${kind.name} $v0 from $listingUrl not in ${itv.repr}"
-                                else
-                                  s"Latest ${kind.name} $v0 from $listingUrl not retained"
-                            }
-                        }
-                      )
-                }
-            }
-          }
+          case _ =>
+            Right((selectedVer, repo))
         }
-
-      EitherT(versionOrError).flatMap {
-        case (v, repo) =>
-          repo
-            .find(module, v.repr, fetch)
-            .leftMap(err => repositories.map(r => if (r == repo) err else "")) // kind of meh
       }
     }
 
-    def get(fetch: Repository.Fetch[F]) = {
+    def get(fetch: Repository.Fetch[F], intervalOpt: Option[Either[VersionInterval, (Latest, Option[VersionInterval])]] = None) = {
 
       val lookups = repositories
-        .map(repo => repo -> repo.find(module, version, fetch).run)
+        .map { repo =>
+          intervalOpt match {
+            case None =>
+              repo -> repo.find(module, version, fetch).run
+            case Some(itv) =>
+              repo -> repo.versions(module, fetch, versionsCheckHasModule = false).flatMap {
+                case (v, s) =>
+                  EitherT(F.point(versionOrError0(Right((v, s)), itv))).flatMap { retainedVer =>
+                    repo.find(module, retainedVer.repr, fetch)
+                  }
+              }.run
+          }
+        }
 
       val task0 = lookups.foldLeft[F[Either[Seq[String], (Artifact.Source, Project)]]](F.point(Left(Nil))) {
         case (acc, (_, eitherProjTask)) =>
@@ -358,7 +391,26 @@ object ResolutionProcess {
     }
 
     def getLatest0(ver: Either[VersionInterval, (Latest, Option[VersionInterval])]) = {
-      (getLatest(ver, fetch) /: fetchs) (_ orElse getLatest(ver, _))
+      val shouldParallelize = ver.right.exists(_._1 == Latest.Integration)
+      if (shouldParallelize)
+        EitherT {
+
+          val lookups = F.gather(repositories.map(_.versions(module, f).run))
+
+          def getLatest(v: Version, repo: Repository, fetch: Repository.Fetch[F]) =
+            repo
+              .find(module, v.repr, fetch)
+              .leftMap(err => repositories.map(r => if (r == repo) err else "")) // kind of meh
+
+          F.bind(lookups) { results =>
+            EitherT(F.point(versionOrError(results, ver))).flatMap {
+              case (v, repo) =>
+                (getLatest(v, repo, fetch) /: fetchs) (_ orElse getLatest(v, repo, _))
+            }.run
+          }
+        }
+      else
+        (get(fetch, intervalOpt = Some(ver)) /: fetchs)(_ orElse get(_, intervalOpt = Some(ver)))
     }
 
     if (version.contains("&")) {

--- a/modules/core/shared/src/main/scala/coursier/ivy/IvyRepository.scala
+++ b/modules/core/shared/src/main/scala/coursier/ivy/IvyRepository.scala
@@ -1,8 +1,8 @@
 package coursier.ivy
 
 import coursier.core._
-import coursier.maven.MavenAttributes
-import coursier.util.{EitherT, Monad, WebPage}
+import coursier.maven.{MavenAttributes, MavenComplete}
+import coursier.util.{EitherT, Monad}
 
 final class IvyRepository private (
   val pattern: Pattern,
@@ -289,8 +289,8 @@ final class IvyRepository private (
 
         for {
           url <- EitherT(F.point(listingUrl))
-          s <- fetch(artifactFor(url, changing = true, cacheErrors = true))
-        } yield Some((url, WebPage.listDirectories(url, s).filter(_.startsWith(prefix)).toVector))
+          s <- fetch(artifactFor(url + ".links", changing = true, cacheErrors = true))
+        } yield Some((url, MavenComplete.split0(s, '\n', prefix)))
     }
 
   private[ivy] def availableVersions[F[_]](

--- a/modules/core/shared/src/main/scala/coursier/maven/MavenComplete.scala
+++ b/modules/core/shared/src/main/scala/coursier/maven/MavenComplete.scala
@@ -1,7 +1,7 @@
 package coursier.maven
 
 import coursier.core.{Module, Organization, Repository}
-import coursier.util.{Monad, WebPage}
+import coursier.util.Monad
 
 final case class MavenComplete[F[_]](
   repo: MavenRepository,
@@ -12,14 +12,15 @@ final case class MavenComplete[F[_]](
   override def sbtAttrStub: Boolean =
     repo.sbtAttrStub
 
-  private def fromDirListing(dirUrl: String, prefix: String): F[Either[Throwable, Seq[String]]] =
-    F.map(fetch(repo.artifactFor(dirUrl, changing = true)).run) {
+  private def fromDirListing(dirUrl: String, prefix: String): F[Either[Throwable, Seq[String]]] = {
+    F.map(fetch(repo.artifactFor(dirUrl + ".links", changing = true)).run) {
       case Left(e) =>
         Left(new Exception(e))
-      case Right(rawListing) =>
-        val entries = WebPage.listDirectories(dirUrl, rawListing)
-        Right(entries.filter(_.startsWith(prefix)).toVector)
+      case Right(rawLinks) =>
+        val entries = MavenComplete.split0(rawLinks, '\n', prefix)
+        Right(entries)
     }
+  }
 
   def organization(prefix: String): F[Either[Throwable, Seq[String]]] = {
 
@@ -48,4 +49,25 @@ final case class MavenComplete[F[_]](
       case Right((v, _)) =>
         Right(v.available.filter(_.startsWith(prefix)))
     }
+}
+
+object MavenComplete {
+
+  private[coursier] def split0(s: String, sep: Char, prefix: String): Vector[String] = {
+
+    var idx = 0
+    val b = Vector.newBuilder[String]
+
+    while (idx < s.length) {
+      var nextIdx = idx
+      while (nextIdx < s.length && s.charAt(nextIdx) != sep)
+        nextIdx += 1
+      if (nextIdx - idx > prefix.length && s.regionMatches(idx, prefix, 0, prefix.length) && s.charAt(nextIdx - 1) == '/')
+        b += s.substring(idx, nextIdx - 1)
+      idx = nextIdx + 1
+    }
+
+    b.result()
+  }
+
 }


### PR DESCRIPTION
Goal of these and of https://github.com/coursier/coursier/pull/1289, is to lower the cost of the version lookups happening with commands like
```
$ cs resolve ammonite
```
compared to
```
$ cs resolve com.lihaoyi:ammonite_2.13.0:1.6.9
```
(with `cs` standing for the graalvm native image of the coursier CLI). The first command successively looks for
- the `latest.integration` of `io.get-coursier:apps` (and find the app descriptor for `ammonite` in its JAR), 
- the latest scala version for `com.lihaoyi:::ammonite` (which is `2.13.0`), 
- the `latest.stable` version of `com.lihaoyi:ammonite_2.13.0` (which is `1.6.9`).

Then it actually resolves `com.lihaoyi:ammonite_2.13.0:1.6.9`, like the second command.

These lookups rely on directory listings in particular (even the version listings, prior to https://github.com/coursier/coursier/pull/1289, where checking for the existence of some directories via directory listings), which can be costly. Looking for the versions in a version interval can be costly too, in particular when it involves looking at all repositories in parallel.

Prior to https://github.com/coursier/coursier/pull/1289, locally, with a fully populated cache, the first command was taking around 250 - 300 ms (measured with `time cs …` - the delay can be "felt" by users), whereas the second one was around 50 - 60 ms (below 100 ms, feeling "effectively instant").

After https://github.com/coursier/coursier/pull/1289, that delay was down to around 100 ms. With this PR, it's around 70 ms (on a freshly fetched cache - can be longer than that on a cache populated before these changes…), making the overhead of the app descriptors logic very low.