### PR TITLE
Use Relaxed reconciliation by default

### DIFF
--- a/modules/cli/src/main/scala/coursier/cli/options/ResolutionOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/ResolutionOptions.scala
@@ -48,7 +48,7 @@ final case class ResolutionOptions(
     rules: List[String] = Nil,
 
   @Help("Choose reconciliation strategy")
-  @Value("organization:name:(basic|relaxed)")
+  @Value("organization:name:(relaxed|check-intervals)")
     reconciliation: List[String] = Nil,
 
   strict: Option[Boolean] = None,

--- a/modules/core/shared/src/main/scala/coursier/core/Reconciliation.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Reconciliation.scala
@@ -43,7 +43,9 @@ object Reconciliation {
       Some(retained)
     }
 
-  case object Default extends Reconciliation {
+  def Default: Reconciliation = Relaxed
+
+  case object CheckIntervals extends Reconciliation {
     def apply(versions: Seq[String]): Option[String] = {
       if (versions.isEmpty)
         None

--- a/modules/coursier/shared/src/main/scala/coursier/parse/ReconciliationParser.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/parse/ReconciliationParser.scala
@@ -18,9 +18,9 @@ object ReconciliationParser {
       if (module.organization == Organization("*") && module.name == ModuleName("*")) ModuleMatchers.all
       else ModuleMatchers(exclude = Set(ModuleMatcher.all), include = Set(ModuleMatcher(module)))
     v match {
-      case "default" => Right(m -> Reconciliation.Default)
-      case "relaxed" => Right(m -> Reconciliation.Relaxed)
-      case _         => Left(s"Unknown reconciliation '$v'")
+      case "check-intervals" => Right(m -> Reconciliation.CheckIntervals)
+      case "relaxed"         => Right(m -> Reconciliation.Relaxed)
+      case _                 => Left(s"Unknown reconciliation '$v'")
     }
   }
 }

--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -173,6 +173,7 @@ object Mima {
         // https://github.com/coursier/coursier/pull/1293
         ProblemFilters.exclude[DirectMissingMethodProblem]("coursier.core.Resolution.merge"),
         ProblemFilters.exclude[DirectMissingMethodProblem]("coursier.core.Resolution.mergeVersions"),
+        ProblemFilters.exclude[MissingClassProblem]("coursier.core.Reconciliation$Default$"),
       )
     }
   }


### PR DESCRIPTION
Fixes #1312
Ref #1293 / #1284

This switches the default reconciliation to use the relaxed one that picks the latest version interval given multiple non-mergable ones.