### PR TITLE
tweak Version ordering

### DIFF
--- a/modules/core/shared/src/main/scala/coursier/core/Parse.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Parse.scala
@@ -20,11 +20,11 @@ object Parse {
       case latestSubRevision(prefix, delim) =>
         for {
           from <- version(prefix)
-          if from.rawItems.nonEmpty
+          if from.items.nonEmpty
           max = (if (delim.isEmpty) "." else delim) + "max"
           to <- version(prefix + max)
           // the contrary would mean something went wrong in the loose substitution above
-          if from.rawItems.init == to.rawItems.dropRight(1).init
+          if from.items.init == to.items.dropRight(1).init
         } yield VersionInterval(Some(from), Some(to), fromIncluded = true, toIncluded = true)
       case _ =>
         None

--- a/modules/core/shared/src/main/scala/coursier/core/Version.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Version.scala
@@ -199,53 +199,15 @@ object Version {
     }
   }
 
-  def postProcess(item: Item, tokens0: Stream[(Tokenizer.Separator, Item)]): Stream[Item] = {
+  // def isNumeric(item: Item) = item match { case _: Numeric => true; case _ => false }
 
-    val tokens =
-      // drop some '.0' under some conditions ???
-      if (isNumeric(item)) {
-        val nextNonDotZero = tokens0.dropWhile{case (Tokenizer.Dot, n: Numeric) => n.isEmpty; case _ => false }
-        if (nextNonDotZero.headOption.forall { case (sep, t) => sep != Tokenizer.Plus && !isMinMax(t) && !isNumeric(t) })
-          nextNonDotZero
-        else
-          tokens0
-      } else
-        tokens0
-
-    def ifFollowedByNumberElse(ifFollowedByNumber: Item, default: Item) = {
-      val followedByNumber = tokens.headOption
-        .exists{ case (Tokenizer.None, num: Numeric) if !num.isEmpty => true; case _ => false }
-
-      if (followedByNumber) ifFollowedByNumber
-      else default
-    }
-
-    val nextItem = item match {
-      case Tag("min") => Min
-      case Tag("max") => Max
-      case Tag("a") => ifFollowedByNumberElse(alphaQualifier, item)
-      case Tag("b") => ifFollowedByNumberElse(betaQualifier, item)
-      case Tag("m") => ifFollowedByNumberElse(milestoneQualifier, item)
-      case _ => item
-    }
-
-    def next =
-      if (tokens.isEmpty) Stream()
-      else postProcess(tokens.head._2, tokens.tail)
-
-    nextItem #:: next
-  }
-
-  def isNumeric(item: Item) = item match { case _: Numeric => true; case _ => false }
-
-  def isMinMax(item: Item) = {
-    (item eq Min) || (item eq Max) || item == Tag("min") || item == Tag("max")
-  }
+  // def isMinMax(item: Item) = {
+  //   (item eq Min) || (item eq Max) || item == Tag("min") || item == Tag("max")
+  // }
 
   def items(repr: String): List[Item] = {
     val (first, tokens) = Tokenizer(repr)
-
-    postProcess(first, tokens).toList
+    first :: tokens.toList.map(_._2)
   }
 
   @tailrec

--- a/modules/core/shared/src/main/scala/coursier/core/Version.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Version.scala
@@ -9,11 +9,7 @@ import coursier.core.compatibility._
  *  Same kind of ordering as aether-util/src/main/java/org/eclipse/aether/util/version/GenericVersion.java
  */
 final case class Version(repr: String) extends Ordered[Version] {
-  lazy val items = Version.items(repr)
-  lazy val rawItems: Seq[Version.Item] = {
-    val (first, tokens) = Version.Tokenizer(repr)
-    first +: tokens.toVector.map { case (_, item) => item }
-  }
+  lazy val items: List[Version.Item] = Version.items(repr)
   def compare(other: Version) = Version.listCompare(items, other.items)
   def isEmpty = items.forall(_.isEmpty)
 }
@@ -105,7 +101,7 @@ object Version {
   }
   final case class BuildMetadata(value: String) extends Item {
     val order = 1
-    override def compareToEmpty = if (value.isEmpty) 0 else 1
+    override def compareToEmpty = 0
   }
 
   val empty = Number(0)
@@ -122,8 +118,8 @@ object Version {
     case object Plus extends Separator
     case object None extends Separator
 
-    def apply(s: String): (Item, Stream[(Separator, Item)]) = {
-      def parseItem(s: Stream[Char]): (Item, Stream[Char]) = {
+    def apply(str: String): (Item, Stream[(Separator, Item)]) = {
+      def parseItem(s: Stream[Char], prev: Option[Separator]): (Item, Stream[Char]) = {
         if (s.isEmpty) (empty, s)
         else if (s.head.isDigit) {
           def digits(b: StringBuilder, s: Stream[Char]): (String, Stream[Char]) =
@@ -145,6 +141,7 @@ object Version {
 
           val (letters0, rem) = letters(new StringBuilder, s)
           val item = letters0 match {
+            case "x" if prev == Some(Dot) => Max
             case "min" => Min
             case "max" => Max
             case _     => Tag(letters0)
@@ -152,18 +149,22 @@ object Version {
           (item, rem)
         } else {
           val (sep, _) = parseSeparator(s)
-          if (sep == None) {
-            def other(b: StringBuilder, s: Stream[Char]): (String, Stream[Char]) =
-              if (s.isEmpty || s.head.isLetterOrDigit || parseSeparator(s)._1 != None)
-                (b.result().toLowerCase, s)  // not specifying a Locale (error with scala js)
-              else
-                other(b += s.head, s.tail)
+          (prev, sep) match {
+            case (_, None) =>
+              def other(b: StringBuilder, s: Stream[Char]): (String, Stream[Char]) =
+                if (s.isEmpty || s.head.isLetterOrDigit || parseSeparator(s)._1 != None)
+                  (b.result().toLowerCase, s)  // not specifying a Locale (error with scala js)
+                else
+                  other(b += s.head, s.tail)
 
-            val (item, rem0) = other(new StringBuilder, s)
-
-            (Tag(item), rem0)
-          } else
-            (empty, s)
+              val (item, rem0) = other(new StringBuilder, s)
+              // treat .* as .max
+              if (prev == Some(Dot) && item == "*") (Max, rem0)
+              else (Tag(item), rem0)
+            // treat .+ as .max
+            case (Some(Dot), Plus) => (Max, s)
+            case _                 => (empty, s)
+          }
         }
       }
 
@@ -187,13 +188,13 @@ object Version {
             case Plus =>
               Stream((sep, BuildMetadata(rem0.mkString)))
             case _ =>
-              val (item, rem) = parseItem(rem0)
+              val (item, rem) = parseItem(rem0, Some(sep))
               (sep, item) #:: helper(rem)
           }
         }
       }
 
-      val (first, rem) = parseItem(s.toStream)
+      val (first, rem) = parseItem(str.toStream, scala.None)
       (first, helper(rem))
     }
   }

--- a/modules/core/shared/src/main/scala/coursier/maven/MavenRepository.scala
+++ b/modules/core/shared/src/main/scala/coursier/maven/MavenRepository.scala
@@ -294,7 +294,7 @@ final class MavenRepository private (
         else {
           val parsedVersions = rawVersions.map(Version(_))
           val nonPreVersions = parsedVersions.filter(_.items.forall {
-            case q: Version.Qualifier => q.level >= 0
+            case t: Version.Tag => !t.isPreRelease
             case _ => true
           })
 

--- a/modules/coursier/shared/src/test/scala/coursier/ResolveTests.scala
+++ b/modules/coursier/shared/src/test/scala/coursier/ResolveTests.scala
@@ -372,41 +372,6 @@ object ResolveTests extends TestSuite {
       }
     }
 
-    'conflicts - {
-      * - async {
-
-        // hopefully, that's a legit conflict (not one that ought to go away after possible fixes in Resolution)
-
-        val res = await {
-          resolve
-            .addDependencies(dep"org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.3.0")
-            .io
-            .attempt
-            .future()
-        }
-
-        val isLeft = res.isLeft
-        assert(isLeft)
-
-        val error = res.left.get
-
-        error match {
-          case c: ResolutionError.ConflictingDependencies =>
-            val expectedModules = Set(mod"io.netty:netty-codec-http2", mod"io.grpc:grpc-core")
-            val modules = c.dependencies.map(_.module)
-            assert(modules == expectedModules)
-            val expectedVersions = Map(
-              mod"io.netty:netty-codec-http2" -> Set("[4.1.8.Final]", "[4.1.16.Final]"),
-              mod"io.grpc:grpc-core" -> Set("1.2.0", "1.5.0", "1.6.1", "1.7.0", "[1.2.0]", "[1.7.0]")
-            )
-            val versions = c.dependencies.groupBy(_.module).mapValues(_.map(_.version)).iterator.toMap
-            assert(versions == expectedVersions)
-          case _ =>
-            ???
-        }
-      }
-    }
-
     "parent / import scope" - {
       * - async {
 

--- a/modules/tests/shared/src/test/scala/coursier/test/VersionTests.scala
+++ b/modules/tests/shared/src/test/scala/coursier/test/VersionTests.scala
@@ -45,7 +45,9 @@ object VersionTests extends TestSuite {
 
     'buildMetadata - {
       * - {
-        assert(compare("1.2", "1.2+foo") < 0)
+        assert(compare("1.2", "1.2+foo") == 0)
+        assert(compare("2.0", "2.0+20130313144700") == 0)
+        assert(compare("2.0+20130313144700", "2.0.2") < 0)
 
         // Semver § 10: two versions that differ only in the build metadata, have the same precedence
         assert(compare("1.2+bar", "1.2+foo") == 0)
@@ -118,7 +120,6 @@ object VersionTests extends TestSuite {
       assert(compare("1.0", "1.0.0" ) == 0)
     }
 
-
     'trailingZerosBeforeQualifierAreSemanticallyIrrelevant - {
       assert(compare("1.0-ga", "1.0.0-ga" ) == 0)
       assert(compare("1.0.ga", "1.0.0.ga" ) == 0)
@@ -142,40 +143,13 @@ object VersionTests extends TestSuite {
       assert(compare("4.1.0-173", "4.1.1-178") < 0)
     }
 
-
-    'trailingDelimitersAreSemanticallyIrrelevant - {
-      assert(compare("1", "1............." ) == 0)
-      assert(compare("1", "1-------------" ) == 0)
-      assert(compare("1.0", "1............." ) == 0)
-      assert(compare("1.0", "1-------------" ) == 0)
-    }
-
-
-    'initialDelimiters - {
-      assert(compare("0.1", ".1" ) == 0)
-      assert(compare("0.0.1", "..1" ) == 0)
-      assert(compare("0.1", "-1" ) == 0)
-      assert(compare("0.0.1", "--1" ) == 0)
-    }
-
-
-    'consecutiveDelimiters - {
-      assert(compare("1.0.1", "1..1" ) == 0)
-      assert(compare("1.0.0.1", "1...1" ) == 0)
-      assert(compare("1.0.1", "1--1" ) == 0)
-      assert(compare("1.0.0.1", "1---1" ) == 0)
-    }
-
-
     'unlimitedNumberOfVersionComponents - {
       assert(compare("1.0.1.2.3.4.5.6.7.8.9.0.1.2.10", "1.0.1.2.3.4.5.6.7.8.9.0.1.2.3" ) > 0)
     }
 
-
     'unlimitedNumberOfDigitsInNumericComponent - {
       assert(compare("1.1234567890123456789012345678901", "1.123456789012345678901234567891" ) > 0)
     }
-
 
     'transitionFromDigitToLetterAndViceVersaIsEqualivantToDelimiter - {
       assert(compare("1alpha10", "1.alpha.10" ) == 0)
@@ -185,14 +159,11 @@ object VersionTests extends TestSuite {
       assert(compare("10alpha", "1alpha" ) > 0)
     }
 
-
     'wellKnownQualifierOrdering - {
+      assert(compare("1-dev1", "1-alpha1" ) < 0)
       assert(compare("1-alpha1", "1-a1" ) == 0)
       assert(compare("1-alpha", "1-beta" ) < 0)
       assert(compare("1-beta1", "1-b1" ) == 0)
-      assert(compare("1-beta", "1-milestone" ) < 0)
-      assert(compare("1-milestone1", "1-m1" ) == 0)
-      assert(compare("1-milestone", "1-rc" ) < 0)
       assert(compare("1-rc", "1-cr" ) == 0)
       assert(compare("1-rc", "1-snapshot" ) < 0)
       assert(compare("1-snapshot", "1" ) < 0)
@@ -206,6 +177,8 @@ object VersionTests extends TestSuite {
       assert(compare("1", "1-final" ) == 0)
       assert(compare("1", "1-sp" ) < 0)
 
+      assert(compare("2.12.4-bin-typelevel-4", "2.12.4" ) > 0)
+
       assert(compare("A.rc.1", "A.ga.1" ) < 0)
       assert(compare("A.sp.1", "A.ga.1" ) > 0)
       assert(compare("A.rc.x", "A.ga.x" ) < 0)
@@ -214,43 +187,57 @@ object VersionTests extends TestSuite {
 
 
     'wellKnownQualifierVersusUnknownQualifierOrdering - {
-      assert(compare("1-abc", "1-alpha" ) > 0)
-      assert(compare("1-abc", "1-beta" ) > 0)
-      assert(compare("1-abc", "1-milestone" ) > 0)
-      assert(compare("1-abc", "1-rc" ) > 0)
-      assert(compare("1-abc", "1-snapshot" ) > 0)
-      assert(compare("1-abc", "1" ) > 0)
-      assert(compare("1-abc", "1-sp" ) > 0)
+      assert(compare("1-milestone", "1-rc" ) < 0)
+      assert(compare("1-milestone", "1-beta" ) < 0)
+      assert(compare("1-M1", "1-rc1" ) < 0)
+
+      assert(compare("1-abc", "1-alpha" ) < 0)
+      assert(compare("1-abc", "1-beta" ) < 0)
+      assert(compare("1-abc", "1-milestone" ) < 0)
+      assert(compare("1-abc", "1-rc" ) < 0)
+      assert(compare("1-abc", "1-snapshot" ) < 0)
+      assert(compare("1-abc", "1" ) < 0)
+      assert(compare("1-abc", "1-sp" ) < 0)
+
+      assert(compare("1.0m", "1.0" ) < 0)
+      assert(compare("1.0-m", "1.0" ) < 0)
+      assert(compare("1.0.m", "1.0" ) < 0)
+
+      assert(compare("1.0m1", "1.0" ) < 0)
+      assert(compare("1.0-m1", "1.0" ) < 0)
+      assert(compare("1.0.m1", "1.0" ) < 0)
+      assert(compare("1.0m.1", "1.0" ) < 0)
+      assert(compare("1.0m-1", "1.0" ) < 0)
+
+      assert(compare("1.0.1-MF", "1.0.0" ) > 0)
+      assert(compare("1.0.1-MF", "1.0.1" ) < 0)
+      assert(compare("1.0.1-MF", "1.0.2" ) < 0)
+      assert(compare("1.0.1-X20", "1.0.0" ) > 0)
+      assert(compare("1.0.1-X20", "1.0.1" ) < 0)
+      assert(compare("1.0.1-X20", "1.0.2" ) < 0)
+      assert(compare("1.0.1-SNAP12", "1.0.0" ) > 0)
+      assert(compare("1.0.1-SNAP12", "1.0.1" ) < 0)
+      assert(compare("1.0.1-SNAP12", "1.0.2" ) < 0)
     }
 
 
     'wellKnownSingleCharQualifiersOnlyRecognizedIfImmediatelyFollowedByNumber - {
-      assert(compare("1.0a", "1.0" ) > 0)
-      assert(compare("1.0-a", "1.0" ) > 0)
-      assert(compare("1.0.a", "1.0" ) > 0)
-      assert(compare("1.0b", "1.0" ) > 0)
-      assert(compare("1.0-b", "1.0" ) > 0)
-      assert(compare("1.0.b", "1.0" ) > 0)
-      assert(compare("1.0m", "1.0" ) > 0)
-      assert(compare("1.0-m", "1.0" ) > 0)
-      assert(compare("1.0.m", "1.0" ) > 0)
-
+      assert(compare("1.0a", "1.0" ) < 0)
+      assert(compare("1.0-a", "1.0" ) < 0)
+      assert(compare("1.0.a", "1.0" ) < 0)
+      assert(compare("1.0b", "1.0" ) < 0)
+      assert(compare("1.0-b", "1.0" ) < 0)
+      assert(compare("1.0.b", "1.0" ) < 0)
       assert(compare("1.0a1", "1.0" ) < 0)
       assert(compare("1.0-a1", "1.0" ) < 0)
       assert(compare("1.0.a1", "1.0" ) < 0)
       assert(compare("1.0b1", "1.0" ) < 0)
       assert(compare("1.0-b1", "1.0" ) < 0)
       assert(compare("1.0.b1", "1.0" ) < 0)
-      assert(compare("1.0m1", "1.0" ) < 0)
-      assert(compare("1.0-m1", "1.0" ) < 0)
-      assert(compare("1.0.m1", "1.0" ) < 0)
-
-      assert(compare("1.0a.1", "1.0" ) > 0)
-      assert(compare("1.0a-1", "1.0" ) > 0)
-      assert(compare("1.0b.1", "1.0" ) > 0)
-      assert(compare("1.0b-1", "1.0" ) > 0)
-      assert(compare("1.0m.1", "1.0" ) > 0)
-      assert(compare("1.0m-1", "1.0" ) > 0)
+      assert(compare("1.0a.1", "1.0" ) < 0)
+      assert(compare("1.0a-1", "1.0" ) < 0)
+      assert(compare("1.0b.1", "1.0" ) < 0)
+      assert(compare("1.0b-1", "1.0" ) < 0)
     }
 
 
@@ -331,7 +318,9 @@ object VersionTests extends TestSuite {
       assert(compare("1.max", "1.0-SNAPSHOT" ) > 0)
       assert(compare("1.max", "1.0" ) > 0)
       assert(compare("1.max", "1.9999999999" ) > 0)
-
+      assert(compare("1.*", "1.9999999999" ) > 0)
+      assert(compare("1.+", "1.9999999999" ) > 0)
+      assert(compare("1.x", "1.9999999999" ) > 0)
       assert(compare("1.max", "1.MAX" ) == 0)
 
       assert(compare("1.max", "2.0-alpha-1" ) < 0)
@@ -353,8 +342,13 @@ object VersionTests extends TestSuite {
       assert(increasing( "1.0.alpha", "1.0", "1.0-1" ))
       assert(increasing( "1.0-alpha", "1.0", "1.0.1" ))
       assert(increasing( "1.0.alpha", "1.0", "1.0.1" ))
+
+      assert(increasing( "1.0-M1", "1.0-MF", "1.0-X1", "1.0-alpha1", "1.0-RC1", "1.0", "2.0", "2.0.2"))
+      assert(increasing( "1.0-MF", "1.0-X1", "1.0a", "1.0-RC1", "1.0", "2.0", "2.0.2"))
     }
 
+    def sortVersionsCoursier(versions: String*): List[String] =
+      versions.toList.map(Version.apply).sorted.map(_.repr)
 
 //    'caseInsensitiveOrderingOfQualifiersIsLocaleIndependent - {
 //      import java.util.Locale
@@ -370,7 +364,7 @@ object VersionTests extends TestSuite {
 
     'specialStartChar - {
       val items = Version("[1.2.0]").items
-      val expectedItems = Seq(Version.Literal("["), Version.Number(1), Version.Number(2), Version.Literal("]"))
+      val expectedItems = Seq(Version.Tag("["), Version.Number(1), Version.Number(2), Version.Number(0), Version.Tag("]"))
       assert(items == expectedItems)
     }
 

--- a/modules/tests/shared/src/test/scala/coursier/test/VersionTests.scala
+++ b/modules/tests/shared/src/test/scala/coursier/test/VersionTests.scala
@@ -332,8 +332,7 @@ object VersionTests extends TestSuite {
       assert(increasing( "0.9.9-SNAPSHOT", "0.9.9", "0.9.10-SNAPSHOT", "0.9.10", "1.0-alpha-2-SNAPSHOT", "1.0-alpha-2",
         "1.0-alpha-10-SNAPSHOT", "1.0-alpha-10", "1.0-beta-1-SNAPSHOT", "1.0-beta-1",
         "1.0-rc-1-SNAPSHOT", "1.0-rc-1", "1.0-SNAPSHOT", "1.0", "1.0-sp-1-SNAPSHOT", "1.0-sp-1"))
-      // FIXME Should pass?
-      // assert(compare("1.0-sp-1", "1.0.1-alpha-1-SNAPSHOT") < 0)
+      assert(compare("1.0-sp-1", "1.0.1-alpha-1-SNAPSHOT") < 0)
       assert(increasing("1.0.1-alpha-1-SNAPSHOT",
       "1.0.1-alpha-1", "1.0.1-beta-1-SNAPSHOT", "1.0.1-beta-1",
         "1.0.1-rc-1-SNAPSHOT", "1.0.1-rc-1", "1.0.1-SNAPSHOT", "1.0.1", "1.1-SNAPSHOT", "1.1" ))

--- a/modules/tests/shared/src/test/scala/coursier/test/VersionTests.scala
+++ b/modules/tests/shared/src/test/scala/coursier/test/VersionTests.scala
@@ -368,6 +368,12 @@ object VersionTests extends TestSuite {
       assert(items == expectedItems)
     }
 
+
+    'xhandling - {
+      val items = Version("1.x.0-alpha").items
+      val expectedItems = Seq(Version.Number(1), Version.Max, Version.Number(0), Version.Tag("alpha"))
+      assert(items == expectedItems)
+    }
   }
 
 }


### PR DESCRIPTION
Fixes #1313
Ref #420

This changes the version ordering similar to that of Apache Ivy.

Specifically, milestone qualifiers are treated as unknown, and they are sorted together with other unknown qualifiers such as `-X1` and `-MF`, all lower than the final `1.0.0`.

In addition, this adds a few other means of writing `1.max`:
- `1.x`
- `1.+`
- `1.*`

### before

Here's how Coursier 2.0.0-RC2-6 orders versions

- 1.0-alpha
- 1.0-M1
- 1.0-RC1
- 1.0
- 1.+
- 1.0-X1
- 1.0-MF
- 2.0
- 2.0.2
- 2.0+20130313144700

### after 

- 1.0-M1
- 1.0-MF
- 1.0-X1
- 1.0-alpha1
- 1.0-RC1
- 1.0
- 1.+
- 2.0
- 2.0+20130313144700
- 2.0.2
