### PR TITLE
Better output when strict rule doesn't pass

### DIFF
--- a/modules/core/js/src/main/scala/coursier/core/compatibility/package.scala
+++ b/modules/core/js/src/main/scala/coursier/core/compatibility/package.scala
@@ -132,4 +132,7 @@ package object compatibility {
 
   def regexLookbehind: String = ":"
 
+  def hasConsole: Boolean =
+    true // no System.console in Scala.JS
+
 }

--- a/modules/core/jvm/src/main/scala/coursier/core/compatibility/package.scala
+++ b/modules/core/jvm/src/main/scala/coursier/core/compatibility/package.scala
@@ -180,4 +180,7 @@ package object compatibility {
 
   def regexLookbehind: String = "<="
 
+  def hasConsole: Boolean =
+    System.console() != null
+
 }

--- a/modules/coursier/shared/src/main/scala/coursier/error/ResolutionError.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/error/ResolutionError.scala
@@ -76,7 +76,7 @@ object ResolutionError {
     val rule: Rule,
     val conflict: UnsatisfiedRule,
     message: String
-  ) extends Simple(resolution, s"Unsatisfiable rule $rule: $message", conflict)
+  ) extends Simple(resolution, message, conflict)
 
 
 }

--- a/modules/coursier/shared/src/main/scala/coursier/error/conflict/UnsatisfiedRule.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/error/conflict/UnsatisfiedRule.scala
@@ -6,4 +6,4 @@ abstract class UnsatisfiedRule(
   val rule: Rule,
   message: String,
   cause: Throwable = null
-) extends Exception(s"Unsatisfied rule $rule: $message", cause)
+) extends Exception(s"Unsatisfied rule ${rule.repr}: $message", cause)

--- a/modules/coursier/shared/src/main/scala/coursier/params/rule/Rule.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/params/rule/Rule.scala
@@ -26,4 +26,7 @@ abstract class Rule extends Product with Serializable {
               .right.map(r => Right(Some(r)))
         }
     }
+
+  def repr: String =
+    toString
 }

--- a/modules/coursier/shared/src/test/scala/coursier/ResolveRulesTests.scala
+++ b/modules/coursier/shared/src/test/scala/coursier/ResolveRulesTests.scala
@@ -207,7 +207,7 @@ object ResolveRulesTests extends TestSuite {
             assert(f.rule == rule)
             assert(f.conflict.isInstanceOf[Strict.EvictedDependencies])
             f.conflict match {
-              case e: Strict.EvictedDependencies => e.evicted
+              case e: Strict.EvictedDependencies => e.evicted.map(_.conflict)
               case _ => ???
             }
           case _ =>
@@ -250,7 +250,7 @@ object ResolveRulesTests extends TestSuite {
             assert(f.rule == rule)
             assert(f.conflict.isInstanceOf[Strict.EvictedDependencies])
             f.conflict match {
-              case e: Strict.EvictedDependencies => e.evicted
+              case e: Strict.EvictedDependencies => e.evicted.map(_.conflict)
               case _ => ???
             }
           case _ =>
@@ -324,7 +324,7 @@ object ResolveRulesTests extends TestSuite {
               assert(f.rule == rule)
               assert(f.conflict.isInstanceOf[Strict.EvictedDependencies])
               f.conflict match {
-                case e: Strict.EvictedDependencies => e.evicted
+                case e: Strict.EvictedDependencies => e.evicted.map(_.conflict)
                 case _ => ???
               }
             case _ =>


### PR DESCRIPTION
This prints the part of the dependency graph bringing the dependencies not passing the strict rule, in particular.