### PR TITLE
Add strict as Reconciliation

### DIFF
--- a/modules/core/shared/src/main/scala/coursier/core/Reconciliation.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Reconciliation.scala
@@ -106,4 +106,17 @@ object Reconciliation {
       }
     }
   }
+
+  /**
+    * Strict version reconciliation.
+    *
+    * This particular instance behaves the same as [[Default]] when used by
+    * [[coursier.core.Resolution]]. Actual strict conflict manager is handled
+    * by `coursier.params.rule.Strict`, which is set up by `coursier.Resolve`
+    * when a strict reconciliation is added to it.
+    */
+  case object Strict extends Reconciliation {
+    def apply(versions: Seq[String]): Option[String] =
+      Default(versions)
+  }
 }

--- a/modules/coursier/shared/src/main/scala/coursier/Resolve.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/Resolve.scala
@@ -181,9 +181,9 @@ final class Resolve[F[_]] private[coursier] (private val params: Resolve.Params[
       }
 
     S.bind(S.bind(run(initialRes))(validate0)) { res0 =>
-      S.bind(recurseOnRules(res0, params.resolutionParams.rules)) {
+      S.bind(recurseOnRules(res0, params.resolutionParams.actualRules)) {
         case (res0, conflicts) =>
-          S.map(validateAllRules(res0, params.resolutionParams.rules)) { _ =>
+          S.map(validateAllRules(res0, params.resolutionParams.actualRules)) { _ =>
             (res0, conflicts)
           }
       }
@@ -306,15 +306,17 @@ object Resolve extends PlatformResolve {
       l.reduceOption((f, g) => dep => f(g(dep)))
     }
 
-    val reconciliation: Option[Module => Reconciliation] =
-      if (params.reconciliation.isEmpty) None
+    val reconciliation: Option[Module => Reconciliation] = {
+      val actualReconciliation = params.actualReconciliation
+      if (actualReconciliation.isEmpty) None
       else
         Some { m =>
-          params.reconciliation.find(_._1.matches(m)) match {
+          actualReconciliation.find(_._1.matches(m)) match {
             case Some((_, r)) => r
             case None         => Reconciliation.Default
           }
         }
+    }
 
     coursier.core.Resolution(
       rootDependencies = dependencies,

--- a/modules/coursier/shared/src/main/scala/coursier/params/rule/DontBumpRootDependencies.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/params/rule/DontBumpRootDependencies.scala
@@ -70,9 +70,6 @@ object DontBumpRootDependencies {
   def apply(): DontBumpRootDependencies =
     DontBumpRootDependencies(ModuleMatchers.all)
 
-  def apply(matcher: ModuleMatchers, matcher1: ModuleMatchers, matchers: ModuleMatchers*): DontBumpRootDependencies =
-    DontBumpRootDependencies(matchers.foldLeft(matcher + matcher1)(_ + _))
-
   final class BumpedRootDependencies(
     val bumpedRootDependencies: Seq[(Dependency, String)],
     override val rule: DontBumpRootDependencies

--- a/modules/coursier/shared/src/main/scala/coursier/parse/ReconciliationParser.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/parse/ReconciliationParser.scala
@@ -20,7 +20,8 @@ object ReconciliationParser {
     v match {
       case "default" => Right(m -> Reconciliation.Default)
       case "relaxed" => Right(m -> Reconciliation.Relaxed)
-      case _         => Left(s"Unknown reconciliation '$v'")
+      case "strict" => Right(m -> Reconciliation.Strict)
+      case _ => Left(s"Unknown reconciliation '$v'")
     }
   }
 }

--- a/modules/coursier/shared/src/main/scala/coursier/util/ModuleMatchers.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/util/ModuleMatchers.scala
@@ -4,16 +4,20 @@ import coursier.core.Module
 
 final case class ModuleMatchers(
   exclude: Set[ModuleMatcher],
-  include: Set[ModuleMatcher] = Set()
+  include: Set[ModuleMatcher] = Set(),
+  includeByDefault: Boolean = true
 ) {
 
-  // Modules are included by default.
+  // If modules are included by default:
   // Those matched by anything in exclude are excluded, but for those also matched by something in include.
-
-  // Maybe an extra parameter could be added to change the default (include).
+  // If modules are excluded by default:
+  // Those matched by anything in include are included, but for those also matched by something in exclude.
 
   def matches(module: Module): Boolean =
-    !exclude.exists(_.matches(module)) || include.exists(_.matches(module))
+    if (includeByDefault)
+      !exclude.exists(_.matches(module)) || include.exists(_.matches(module))
+    else
+      include.exists(_.matches(module)) && !exclude.exists(_.matches(module))
 
   def +(other: ModuleMatchers): ModuleMatchers =
     ModuleMatchers(

--- a/modules/tests/shared/src/test/resources/resolutions/com.github.alexarchambault/argonaut-shapeless_6.2_2.12/1.2.0-M4_depc7dd6de1636ac652de44565a82e3cbe2511cba3_params956181a7a9087d99a5283dc6cd92d0c7cc59180
+++ b/modules/tests/shared/src/test/resources/resolutions/com.github.alexarchambault/argonaut-shapeless_6.2_2.12/1.2.0-M4_depc7dd6de1636ac652de44565a82e3cbe2511cba3_params956181a7a9087d99a5283dc6cd92d0c7cc59180
@@ -1,0 +1,6 @@
+org.scala-lang:scala-library:2.12.4:default
+org.scala-lang:scala-reflect:2.12.0:default
+io.argonaut:argonaut_2.12:6.2-RC2:default
+org.typelevel:macro-compat_2.12:1.1.1:default
+com.chuusai:shapeless_2.12:2.3.3:default
+com.github.alexarchambault:argonaut-shapeless_6.2_2.12:1.2.0-M4:default


### PR DESCRIPTION
It feels more natural to ask for strict checks via reconciliation rather than via rules. All the more that if strict checks are enabled for some modules, other reconciliations shouldn't be enabled for them.