### PR TITLE
Adjust files under META-INF/services during shading

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -134,6 +134,18 @@ lazy val cache = crossProject("cache")(JSPlatform, JVMPlatform)
       Deps.jansi % "shaded",
       Deps.jlineTerminalJansi % "shaded"
     ),
+    packageBin.in(Compile) := {
+      // manually editing files under META-INF/services until sbt-shading does it automatically
+      val previous = packageBin.in(Compile).value
+      val new0 = new File(previous.getParentFile, s"${previous.getName.stripSuffix(".jar")}-edited.jar")
+      ZipUtil.addToZip(
+        previous,
+	new0,
+	Seq(
+	  "META-INF/services/org.jline.terminal.spi.JansiSupport" -> "coursier.cache.shaded.org.jline.terminal.spi.JansiSupport\n".getBytes("UTF-8"))
+      )
+      new0
+    }
   )
   .jsSettings(
     name := "fetch-js",

--- a/project/ZipUtil.scala
+++ b/project/ZipUtil.scala
@@ -44,7 +44,9 @@ object ZipUtil {
         }
       }
 
-    for ((ent, data) <- zipEntries(bootstrapZip)) {
+    val extraNames = extra.map(_._1).toSet
+
+    for ((ent, data) <- zipEntries(bootstrapZip) if !extraNames(ent.getName)) {
 
       // Same workaround as https://github.com/spring-projects/spring-boot/issues/13720
       // (https://github.com/spring-projects/spring-boot/commit/a50646b7cc3ad941e748dfb450077e3a73706205#diff-2ff64cd06c0b25857e3e0dfdb6733174R144)


### PR DESCRIPTION
Could be a problem on Windows, where we rely on jline to display progress bars. (I can't actually test it on Windows right now though…)