### PR TITLE
Scm.Info's fields should be optional.

### DIFF
--- a/modules/core/shared/src/main/scala/coursier/core/Definitions.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Definitions.scala
@@ -271,9 +271,9 @@ object Info {
   )
 
   final case class Scm(
-    url: String,
-    connection: String,
-    developerConnection: String
+    url: Option[String],
+    connection: Option[String],
+    developerConnection: Option[String]
   )
 
   val empty = Info("", "", Nil, Nil, None, None)

--- a/modules/core/shared/src/main/scala/coursier/maven/Pom.scala
+++ b/modules/core/shared/src/main/scala/coursier/maven/Pom.scala
@@ -283,15 +283,12 @@ object Pom {
 
       val scm = pom.children
         .find(_.label == "scm")
-        .map { n =>
-          for {
-            url <- text(n, "url", "A publicly browsable repository").right
-            connection <- text(n, "connection", "Requires read access").right
-            devCon <- text(n, "developerConnection", "Requires write access").right
-          } yield Info.Scm(url, connection, devCon)
-        }
-        .collect {
-          case Right(d) => d
+        .flatMap { n =>
+          Option(Info.Scm(
+            text(n, "url", "A publicly browsable repository").right.toOption,
+            text(n, "connection", "Requires read access").right.toOption,
+            text(n, "developerConnection", "Requires write access").right.toOption
+          )).filter(scm => scm.url.isDefined || scm.connection.isDefined || scm.developerConnection.isDefined)
         }
 
       val finalProjModule = projModule.copy(organization = groupId)

--- a/modules/tests/shared/src/test/scala/coursier/test/PomParsingTests.scala
+++ b/modules/tests/shared/src/test/scala/coursier/test/PomParsingTests.scala
@@ -284,7 +284,6 @@ object PomParsingTests extends TestSuite {
        |    <scm>
        |      <url>https://github.com/coursier/coursier</url>
        |      <connection>scm:git:git@github.com:coursier/coursier.git</connection>
-       |      <developerConnection>scm:git:git@github.com:coursier/coursier_DEV.git</developerConnection>
        |    </scm>
        |</project>""".stripMargin
 
@@ -298,9 +297,9 @@ object PomParsingTests extends TestSuite {
         developers = Seq.empty,
         publication = None,
         scm = Some(Info.Scm(
-          url = "https://github.com/coursier/coursier",
-          connection = "scm:git:git@github.com:coursier/coursier.git",
-          developerConnection = "scm:git:git@github.com:coursier/coursier_DEV.git"
+          url = Some("https://github.com/coursier/coursier"),
+          connection = Some("scm:git:git@github.com:coursier/coursier.git"),
+          developerConnection = None
         )
       ))))
 


### PR DESCRIPTION
Follow-up of #1291

Current implementation fails to parse `<scm>` if not all fields are provided.
According to http://maven.apache.org/xsd/maven-4.0.0.xsd, `<scm>`'s fields should be optional.

cc: @fthomas
https://github.com/coursier/coursier/pull/1291#issuecomment-521518104