### PR TITLE
Improve footer

### DIFF
--- a/doc/website/core/Footer.js
+++ b/doc/website/core/Footer.js
@@ -28,7 +28,7 @@ class Footer extends React.Component {
             </a>
           </h2>
           <div>
-            <h5><a href={this.docUrl('overview')}>Docs</h5></h5>
+            <h5><a href={this.docUrl('overview')}>Docs</a></h5>
             <a href={this.docUrl('overview')}>Overview</a>
             <a href={this.docUrl('cli-overview')}>Install CLI</a>
             <a href={this.docUrl('sbt-coursier')}>Setup sbt</a>

--- a/doc/website/core/Footer.js
+++ b/doc/website/core/Footer.js
@@ -36,11 +36,11 @@ class Footer extends React.Component {
           </div>
           <div>
             <h5>Community</h5>
-            <a href="https://github.com/coursier/coursier" target="_blank">
-              <img src="https://img.shields.io/github/stars/coursier/coursier.svg?color=%23087e8b&label=stars&logo=github&style=social" />
-            </a>
             <a href="https://gitter.im/coursier/coursier" target="_blank">
               <img src="https://img.shields.io/gitter/room/coursier/coursier.svg?logo=gitter&style=social" />
+            </a>
+            <a href="https://github.com/coursier/coursier" target="_blank">
+              <img src="https://img.shields.io/github/stars/coursier/coursier.svg?color=%23087e8b&label=stars&logo=github&style=social" />
             </a>
           </div>
         </section>

--- a/doc/website/core/Footer.js
+++ b/doc/website/core/Footer.js
@@ -28,14 +28,14 @@ class Footer extends React.Component {
             </a>
           </h2>
           <div>
-            <h5>Docs</h5>
+            <h5><a href={this.docUrl('overview')}>Docs</h5></h5>
             <a href={this.docUrl('overview')}>Overview</a>
             <a href={this.docUrl('cli-overview')}>Install CLI</a>
             <a href={this.docUrl('sbt-coursier')}>Setup sbt</a>
             <a href={this.docUrl('api')}>Use the API</a>
           </div>
           <div>
-            <h5>Community</h5>
+            <h5><a href="https://gitter.im/coursier/coursier" target="_blank">Community</a></h5>
             <a href="https://gitter.im/coursier/coursier" target="_blank">
               <img src="https://img.shields.io/gitter/room/coursier/coursier.svg?logo=gitter&style=social" />
             </a>


### PR DESCRIPTION
The most prominent elements of the footer w/o this change are **Docs** and **Community**; but clicking them does nothing.

**Docs** is used at the top of the page w/ a similar style to link to **Docs** -- this change makes it link to that same place.

In order to avoid leaving **Community** as the only very visible text without a link, I've decided to link it to *Gitter*, which is indeed a community, and the best way to have that consistent w/ **Docs** is by swapping the order.