### PR TITLE
Add missing shaded namespaces

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -456,8 +456,12 @@ lazy val okhttp = project("okhttp")
 lazy val coursier = crossProject("coursier")(JSPlatform, JVMPlatform)
   .jvmConfigure(_.enablePlugins(ShadingPlugin))
   .jvmSettings(
-    shading("coursier.internal.shaded"),
+    shading("coursier.core.shaded"), // shading only fastparse, that core shades too, so shading things under the same namespace
     libs += Deps.fastParse.value % "shaded",
+    shadeNamespaces ++= Set(
+      "fastparse",
+      "sourcecode"
+    ),
     Mima.previousArtifacts,
     Mima.coursierFilters
   )

--- a/scripts/test-bootstrap.sh
+++ b/scripts/test-bootstrap.sh
@@ -293,6 +293,15 @@ launcherAssemblyPreambleInSource() {
 ./coursier-test.jar --help
 }
 
+resolveRules() {
+  # just checking that this doesn't crash with a ClassNotFoundException because
+  # of shading
+  ./coursier-test resolve \
+    -r jitpack \
+    sh.almond:scala-kernel_2.12.8:0.3.0 \
+    --rule 'SameVersion(com.fasterxml.jackson.core:jackson-*)'
+}
+
 nailgun
 fork
 nonStaticMainClass
@@ -317,3 +326,5 @@ launcherJavaPropsEnv
 launcherJavaPropsEnvMulti
 launcherAssembly
 launcherAssemblyPreambleInSource
+
+resolveRules


### PR DESCRIPTION
sbt-shading is broken until it can rely on https://github.com/pantsbuild/jarjar/pull/50.