### PR TITLE
Basic auth is not supposed to be case sensitive

### DIFF
--- a/modules/cache/jvm/src/main/scala/coursier/cache/CacheUrl.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/CacheUrl.scala
@@ -382,6 +382,7 @@ object CacheUrl {
     }
 
   private[coursier] val BasicRealm = (
+    "(?i)" + // case-insensitive, the response might be BASIC realm=
     "^" +
       Pattern.quote("Basic realm=\"") +
       "([^" + Pattern.quote("\"") + "]*)" +

--- a/modules/cache/jvm/src/test/scala-2.12/coursier/cache/TestUtil.scala
+++ b/modules/cache/jvm/src/test/scala-2.12/coursier/cache/TestUtil.scala
@@ -99,8 +99,8 @@ object TestUtil {
     res.nonEmpty
   }
 
-  def unauth(realm: String) =
-    Unauthorized(`WWW-Authenticate`(NonEmptyList.one(Challenge("Basic", realm))))
+  def unauth(realm: String, challenge: String = "Basic") =
+    Unauthorized(`WWW-Authenticate`(NonEmptyList.one(Challenge(challenge, realm))))
 
   implicit class UserUriOps(private val uri: Uri) extends AnyVal {
     def withUser(userOpt: Option[String]): Uri =

--- a/modules/util/jvm/src/main/scala/coursier/credentials/DirectCredentials.scala
+++ b/modules/util/jvm/src/main/scala/coursier/credentials/DirectCredentials.scala
@@ -88,7 +88,7 @@ final class DirectCredentials private(
         realm.forall(realm0.contains)
     }
 
-  // Only called on initial artifact URLs, no on the ones originating from redirections
+  // Only called on initial artifact URLs, not on the ones originating from redirections
   def matches(url: String, user: String): Boolean =
     nonEmpty && {
       val uriOpt = Try(new URI(url)).toOption


### PR DESCRIPTION
I spent the day looking into this for sbt/sbt#4852

Our nexus server (and almost certainly everyone else's) responds with:
```
www-authenticate: BASIC realm="Sonatype Nexus Repository Manager"
```

The code w/o this change looks for:
`Basic realm="..."`

But HTTP headers are generally case-insensitive.

You can see that the Rust implementation is explicitly case insensitive here:
https://docs.rs/www-authenticate/0.3.0/src/www_authenticate/lib.rs.html#190

```rust
impl Header for WwwAuthenticate {
    fn header_name() -> &'static str {
        "WWW-Authenticate"
    }

    fn parse_header(raw: &Raw) -> Result<Self> {
...
                let (scheme, challenge) = match stream.challenge() {
...
                map.entry(UniCase(CowStr(Cow::Owned(scheme))))
```

You can see that mozilla occasionally uses `basic realm=...` as in:
https://dxr.mozilla.org/mozilla-central/source/browser/components/urlbar/tests/browser/authenticate.sjs#139
```js
        response.setHeader("WWW-Authenticate", "basic realm=\"" + realm + "\"", true);
```

Here's the Gecko (necko) implementation which is clearly case-insensitive:
https://dxr.mozilla.org/mozilla-central/source/netwerk/protocol/http/nsHttpChannelAuthProvider.cpp#1019
```cpp

nsresult nsHttpChannelAuthProvider::GetAuthenticator(
    const char* challenge, nsCString& authType, nsIHttpAuthenticator** auth) {
...
  GetAuthType(challenge, authType);
...
  // normalize to lowercase
  ToLowerCase(authType);
```