### PR TITLE
Try to tell people how to discover unit testable units

### DIFF
--- a/doc/DEVELOPMENT.md
+++ b/doc/DEVELOPMENT.md
@@ -25,6 +25,16 @@ $ modules/cli/target/pack/bin/coursier --help
 
 `sbt "~cli/pack"` watches the sources, and re-generates `modules/cli/target/pack` accordingly.
 
+## Unit structure
+
+To get a list of units for which there may be unit tests, you can run this:
+```sh
+perl -ne 'next unless s/(J[sv][a-z]*),$/$1/; $a=$1; $b=uc $a; s/$a/$b/;print' build.sbt |sort -u
+```
+
+The following sections talk about unit tests for `testJ*`, but you can/should/may choose/want
+to perform the same action w/ one of these other units instead.
+
 ## Run unit tests (JVM)
 
 ```


### PR DESCRIPTION
I'm not an sbt expert, but there are 763 tab completion options in `sbt` for coursier which makes that not a terribly helpful way to figure out what's testable.

This command currently yields:
```
    cacheJS
    cacheJVM
    catsJS
    catsJVM
    coreJS
    coreJVM
    coursierJS
    coursierJVM
    scalazJS
    scalazJVM
    testsJS
    testsJVM
    utilJS
    utilJVM
```

The whole list could be inlined into this doc if people are willing to commit to updating the doc.

There's probably some scala way to have the sbt file introspect itself, but I don't know how to do that...