### PR TITLE
Implement scm parsing in PomParser

### DIFF
--- a/modules/core/jvm/src/test/scala/coursier/maven/PomParserTests.scala
+++ b/modules/core/jvm/src/test/scala/coursier/maven/PomParserTests.scala
@@ -21,7 +21,7 @@ object PomParserTests extends TestSuite {
           |</project>""".stripMargin
       )
       assert(success.isRight)
-      val scm = success.getOrElse(null).info.scm
+      val scm = success.right.get.info.scm
       assert(scm.isEmpty)
     }
 
@@ -39,7 +39,7 @@ object PomParserTests extends TestSuite {
           |</project>""".stripMargin
       )
       assert(success.isRight)
-      val scm = success.getOrElse(null).info.scm
+      val scm = success.right.get.info.scm
       assert(scm.exists(_.url.isEmpty))
       assert(scm.exists(_.connection.isEmpty))
       assert(scm.exists(_.developerConnection.isEmpty))
@@ -62,7 +62,7 @@ object PomParserTests extends TestSuite {
           |</project>""".stripMargin
       )
       assert(success.isRight)
-      val scm = success.getOrElse(null).info.scm
+      val scm = success.right.get.info.scm
       assert(scm.exists(_.url.contains("https://github.com/coursier/coursier")))
       assert(scm.exists(_.connection.contains("scm:git:git@github.com:coursier/coursier.git")))
       assert(scm.exists(_.developerConnection.contains("foo")))

--- a/modules/core/jvm/src/test/scala/coursier/maven/PomParserTests.scala
+++ b/modules/core/jvm/src/test/scala/coursier/maven/PomParserTests.scala
@@ -1,0 +1,71 @@
+package coursier
+
+import coursier.core.{Classifier, Configuration}
+import coursier.core.compatibility._
+import coursier.util.Traverse.TraverseOps
+import coursier.maven.MavenRepository
+import coursier.maven.Pom
+import utest._
+
+object PomParserTests extends TestSuite {
+
+  val tests = Tests {
+    "scm filed is optional" - {
+      val success = MavenRepository.parseRawPomSax(
+        """
+          |<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+          |    <modelVersion>4.0.0</modelVersion>
+          |    <groupId>com.example</groupId>
+          |    <artifactId>awesome-project</artifactId>
+          |    <version>1.0-SNAPSHOT</version>
+          |</project>""".stripMargin
+      )
+      assert(success.isRight)
+      val scm = success.getOrElse(null).info.scm
+      assert(scm.isEmpty)
+    }
+
+    "all fields in scm is optional" - {
+      val success = MavenRepository.parseRawPomSax(
+        """
+          |<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+          |    <modelVersion>4.0.0</modelVersion>
+          |    <groupId>com.example</groupId>
+          |    <artifactId>awesome-project</artifactId>
+          |    <version>1.0-SNAPSHOT</version>
+          |
+          |    <scm>
+          |    </scm>
+          |</project>""".stripMargin
+      )
+      assert(success.isRight)
+      val scm = success.getOrElse(null).info.scm
+      assert(scm.exists(_.url.isEmpty))
+      assert(scm.exists(_.connection.isEmpty))
+      assert(scm.exists(_.developerConnection.isEmpty))
+    }
+
+    "can parse scm info" - {
+      val success = MavenRepository.parseRawPomSax(
+        """
+          |<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+          |    <modelVersion>4.0.0</modelVersion>
+          |    <groupId>com.example</groupId>
+          |    <artifactId>awesome-project</artifactId>
+          |    <version>1.0-SNAPSHOT</version>
+          |
+          |    <scm>
+          |      <url>https://github.com/coursier/coursier</url>
+          |      <connection>scm:git:git@github.com:coursier/coursier.git</connection>
+          |      <developerConnection>foo</developerConnection>
+          |    </scm>
+          |</project>""".stripMargin
+      )
+      assert(success.isRight)
+      val scm = success.getOrElse(null).info.scm
+      assert(scm.exists(_.url.contains("https://github.com/coursier/coursier")))
+      assert(scm.exists(_.connection.contains("scm:git:git@github.com:coursier/coursier.git")))
+      assert(scm.exists(_.developerConnection.contains("foo")))
+    }
+  }
+}

--- a/modules/core/shared/src/main/scala/coursier/maven/PomParser.scala
+++ b/modules/core/shared/src/main/scala/coursier/maven/PomParser.scala
@@ -95,6 +95,13 @@ object PomParser {
 
     var description = ""
     var url = ""
+    val licenses = Nil // TODO
+    val developers = Nil // TODO
+    val publication = Option.empty[Versions.DateTime] // TODO
+    var scmOpt = Option.empty[Info.Scm]
+    var scmUrl = Option.empty[String]
+    var scmConnection = Option.empty[String]
+    var scmDeveloperConnection = Option.empty[String]
 
     var packagingOpt = Option.empty[Type]
 
@@ -234,10 +241,10 @@ object PomParser {
           Info(
             description,
             url,
-            Nil, // TODO
-            Nil, // TODO
-            None,
-            None
+            licenses,
+            developers,
+            publication,
+            scmOpt
           )
         )
       }
@@ -340,6 +347,11 @@ object PomParser {
     "profile" :: "profiles" :: "project" :: Nil,
     (s, p) => {
       s.profiles += p
+    }
+  ) ++ scmHandlers(
+    "scm" :: "project" :: Nil,
+    (s, scm) => {
+      s.scmOpt = Some(scm)
     }
   )
 
@@ -547,4 +559,31 @@ object PomParser {
     }
     .toMap
 
+  private def scmHandlers(prefix: List[String], add: (State, Info.Scm) => Unit) =
+    Seq(
+      new SectionHandler(prefix) {
+        def start(state: State) = {
+        }
+        def end(state: State) = {
+          val d = Info.Scm(
+            url = state.scmUrl,
+            connection = state.scmConnection,
+            developerConnection = state.scmDeveloperConnection
+          )
+          add(state, d)
+        }
+      },
+      content("url" :: prefix) {
+        (state, content) =>
+          state.scmUrl = Some(content)
+      },
+      content("connection" :: prefix) {
+        (state, content) =>
+          state.scmConnection = Some(content)
+      },
+      content("developerConnection" :: prefix) {
+        (state, content) =>
+          state.scmDeveloperConnection = Some(content)
+      }
+    )
 }


### PR DESCRIPTION
Addresses https://github.com/fthomas/scala-steward/issues/923#issuecomment-538567839
so Scala Steward will include SCM links in pull requests for most artifacts.

Related to https://github.com/coursier/coursier/pull/1291


cc: @fthomas

I could not find a right place to add tests.
I will add tests if guidance provided 🙏 
