### PR TITLE
Sync instance for Task: override definition of Map.

### DIFF
--- a/modules/cache/shared/src/main/scala/coursier/util/TaskSync.scala
+++ b/modules/cache/shared/src/main/scala/coursier/util/TaskSync.scala
@@ -6,7 +6,7 @@ trait TaskSync extends Sync[Task] {
   def bind[A, B](elem: Task[A])(f: A => Task[B]) =
     elem.flatMap(f)
 
-  override def map[A, B](elem: Task[A])(f: A => B): F[B] =
+  override def map[A, B](elem: Task[A])(f: A => B): Task[B] =
     elem.map(f)
   def gather[A](elems: Seq[Task[A]]) =
     Task(implicit ec => Future.sequence(elems.map(_.value(ec))))

--- a/modules/cache/shared/src/main/scala/coursier/util/TaskSync.scala
+++ b/modules/cache/shared/src/main/scala/coursier/util/TaskSync.scala
@@ -6,6 +6,8 @@ trait TaskSync extends Sync[Task] {
   def bind[A, B](elem: Task[A])(f: A => Task[B]) =
     elem.flatMap(f)
 
+  override def map[A, B](elem: Task[A])(f: A => B): F[B] =
+    elem.map(f)
   def gather[A](elems: Seq[Task[A]]) =
     Task(implicit ec => Future.sequence(elems.map(_.value(ec))))
   def delay[A](a: => A) = Task.delay(a)


### PR DESCRIPTION
The default implementation of `map` in terms of `point` and `flatMap` incurs the allocation cost of a Lambda expression for any call. For `Task`, this is easily avoidable.

When profiling a compilation, this was allocating 4 MiB, which was about 1/1000th of total allocated space.