### PR TITLE
FileUtils: avoid Integer Boxing

### DIFF
--- a/modules/cache/jvm/src/main/scala/coursier/cache/FileCache.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/FileCache.scala
@@ -685,7 +685,7 @@ import dataclass.data
                 var is: FileInputStream = null
                 try {
                   is = new FileInputStream(localFile0)
-                  FileUtil.withContent(is, new FileContent.UpdateDigest(md))
+                  FileUtil.withContent(is, new FileUtil.UpdateDigest(md))
                 } finally is.close()
 
                 val digest = md.digest()

--- a/modules/cache/jvm/src/main/scala/coursier/cache/FileCache.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/FileCache.scala
@@ -685,7 +685,7 @@ import dataclass.data
                 var is: FileInputStream = null
                 try {
                   is = new FileInputStream(localFile0)
-                  FileUtil.withContent(is, md.update(_, 0, _))
+                  FileUtil.withContent(is, new FileContent.UpdateDigest(md))
                 } finally is.close()
 
                 val digest = md.digest()

--- a/modules/cache/jvm/src/main/scala/coursier/cache/internal/FileUtil.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/internal/FileUtil.scala
@@ -33,7 +33,7 @@ object FileUtil {
     }
   }
 
-  def withContent(is: InputStream, f: (Array[Byte], Int) => Unit, bufferSize: Int = 16384): Unit = {
+  def withContent(is: InputStream, f: WithContent, bufferSize: Int = 16384): Unit = {
     val data = Array.ofDim[Byte](bufferSize)
 
     var nRead = is.read(data, 0, data.length)
@@ -41,6 +41,14 @@ object FileUtil {
       f(data, nRead)
       nRead = is.read(data, 0, data.length)
     }
+  }
+
+  trait WithContent {
+    def apply(arr: Array[Byte], z: Int): Unit
+  }
+
+  class UpdateDigest(md: java.security.MessageDigest) extends FileUtil.WithContent {
+    def apply(arr: Array[Byte], z: Int): Unit = md.update(arr, 0, z)
   }
 
 }

--- a/modules/install/src/main/scala/coursier/cli/app/AppGenerator.scala
+++ b/modules/install/src/main/scala/coursier/cli/app/AppGenerator.scala
@@ -28,7 +28,7 @@ object AppGenerator {
     var is: FileInputStream = null
     try {
       is = new FileInputStream(f)
-      FileUtil.withContent(is, md.update(_, 0, _))
+      FileUtil.withContent(is, new FileContent.UpdateDigest(md))
     } finally is.close()
 
     val b = md.digest()

--- a/modules/install/src/main/scala/coursier/cli/app/AppGenerator.scala
+++ b/modules/install/src/main/scala/coursier/cli/app/AppGenerator.scala
@@ -28,7 +28,7 @@ object AppGenerator {
     var is: FileInputStream = null
     try {
       is = new FileInputStream(f)
-      FileUtil.withContent(is, new FileContent.UpdateDigest(md))
+      FileUtil.withContent(is, new FileUtil.UpdateDigest(md))
     } finally is.close()
 
     val b = md.digest()


### PR DESCRIPTION
The function `withContent` was defined to take a `Function2` object, in which the second item was an integer. Sadly, this means that those Int values need to be boxed, so this is a source of allocations.