### PR TITLE
Tweak scala version handling in CLI

### DIFF
--- a/modules/cli/src/main/scala/coursier/cli/options/ResolutionOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/ResolutionOptions.scala
@@ -145,7 +145,7 @@ final case class ResolutionOptions(
           .withProperties(extraProperties)
           .withForcedProperties(forcedProperties)
           .withProfiles(profiles)
-          .withScalaVersionOpt(scalaVersion)
+          .withScalaVersionOpt(scalaVersion.map(_.trim).filter(_.nonEmpty))
           .withForceScalaVersionOpt(forceScalaVersion)
           .withTypelevel(typelevel)
           .withRules(rules)

--- a/modules/cli/src/main/scala/coursier/cli/resolve/Resolve.scala
+++ b/modules/cli/src/main/scala/coursier/cli/resolve/Resolve.scala
@@ -206,27 +206,31 @@ object Resolve extends CaseApp[ResolveOptions] {
     lift {
 
       val (deps, repositories, scalaVersion, platformOpt) = unlift(Task.fromEither(depsAndReposOrError))
+      val params0 = params.copy(
+        resolution = params.resolution
+          .withScalaVersionOpt(params.resolution.scalaVersionOpt.map(_ => scalaVersion))
+      )
 
-      val scaladexDeps = unlift(handleScaladexDependencies(params, pool, scalaVersion))
+      val scaladexDeps = unlift(handleScaladexDependencies(params0, pool, scalaVersion))
 
       val deps0 = deps ++ scaladexDeps
 
-      Output.printDependencies(params.output, params.resolution, deps0, stdout, stderr)
+      Output.printDependencies(params0.output, params0.resolution, deps0, stdout, stderr)
 
       val (res, _, errors) = unlift {
         coursier.Resolve()
           .withDependencies(deps0)
           .withRepositories(repositories)
-          .withResolutionParams(params.resolution)
+          .withResolutionParams(params0.resolution)
           .withCache(
             cache
           )
           .transformResolution { t =>
-            if (params.benchmark == 0) t
-            else benchmark(math.abs(params.benchmark))(t)
+            if (params0.benchmark == 0) t
+            else benchmark(math.abs(params0.benchmark))(t)
           }
           .transformFetcher { f =>
-            if (params.output.verbosity >= 2) {
+            if (params0.output.verbosity >= 2) {
               modVers: Seq[(Module, String)] =>
                 val print = Task.delay {
                   Output.errPrintln(s"Getting ${modVers.length} project definition(s)")
@@ -240,7 +244,7 @@ object Resolve extends CaseApp[ResolveOptions] {
           .attempt
           .flatMap {
             case Left(ex: ResolutionError) =>
-              if (force || params.output.forcePrint)
+              if (force || params0.output.forcePrint)
                 Task.point((ex.resolution, Nil, ex.errors))
               else
                 Task.fail(new ResolveException("Resolution error: " + ex.getMessage, ex))
@@ -253,11 +257,11 @@ object Resolve extends CaseApp[ResolveOptions] {
 
       val valid = errors.isEmpty
 
-      val outputToStdout = printOutput && (valid || params.output.forcePrint)
-      if (outputToStdout || params.output.verbosity >= 2) {
+      val outputToStdout = printOutput && (valid || params0.output.forcePrint)
+      if (outputToStdout || params0.output.verbosity >= 2) {
         Output.printResolutionResult(
           printResultStdout = outputToStdout,
-          params,
+          params0,
           scalaVersion,
           platformOpt,
           res,

--- a/modules/cli/src/test/scala/coursier/cli/CliFetchIntegrationTest.scala
+++ b/modules/cli/src/test/scala/coursier/cli/CliFetchIntegrationTest.scala
@@ -1330,4 +1330,55 @@ class CliFetchIntegrationTest extends FlatSpec with CliTestLib with Matchers {
     assert(pomPath.exists())
     assert(pomSha1Path.exists())
   }
+
+  "Scala version range" should "work with fully cross-versioned dependencies" in {
+    val resolutionOpt = ResolutionOptions(
+      scalaVersion = Some("2.12.+")
+    )
+    val resolveOpt = ResolveOptions(
+      resolutionOptions = resolutionOpt
+    )
+    val options = FetchOptions(resolveOptions = resolveOpt)
+    val params = paramsOrThrow(options)
+    val (_, _, _, files) = Fetch.task(params, pool, Seq("com.lihaoyi:::ammonite:1.8.1"))
+      .unsafeRun()(ec)
+    val expectedFiles = Set(
+      "ammonite-interp-api_2.12.10-1.8.1.jar",
+      "ammonite-interp_2.12.10-1.8.1.jar",
+      "ammonite-ops_2.12-1.8.1.jar",
+      "ammonite-repl-api_2.12.10-1.8.1.jar",
+      "ammonite-repl_2.12.10-1.8.1.jar",
+      "ammonite-runtime_2.12.10-1.8.1.jar",
+      "ammonite-terminal_2.12-1.8.1.jar",
+      "ammonite-util_2.12-1.8.1.jar",
+      "ammonite_2.12.10-1.8.1.jar",
+      "fansi_2.12-0.2.7.jar",
+      "fastparse_2.12-2.1.3.jar",
+      "geny_2.12-0.1.8.jar",
+      "interface-0.0.8.jar",
+      "javaparser-core-3.2.5.jar",
+      "javassist-3.21.0-GA.jar",
+      "jline-reader-3.6.2.jar",
+      "jline-terminal-3.6.2.jar",
+      "jline-terminal-jna-3.6.2.jar",
+      "jna-4.2.2.jar",
+      "os-lib_2.12-0.4.2.jar",
+      "pprint_2.12-0.5.6.jar",
+      "requests_2.12-0.2.0.jar",
+      "scala-collection-compat_2.12-2.1.2.jar",
+      "scala-compiler-2.12.10.jar",
+      "scala-library-2.12.10.jar",
+      "scala-reflect-2.12.10.jar",
+      "scala-xml_2.12-1.2.0.jar",
+      "scalaparse_2.12-2.1.3.jar",
+      "scopt_2.12-3.7.1.jar",
+      "sourcecode_2.12-0.1.8.jar",
+      "ujson_2.12-0.8.0.jar",
+      "upack_2.12-0.8.0.jar",
+      "upickle-core_2.12-0.8.0.jar",
+      "upickle-implicits_2.12-0.8.0.jar",
+      "upickle_2.12-0.8.0.jar"
+    )
+    assert(files.map(_._2.getName).toSet.equals(expectedFiles))
+  }
 }


### PR DESCRIPTION
Some version ranges or things like '2.12.+' could end up in module names during resolution… (regression in `2.0.0-RC5`)