### PR TITLE
Accept --jep option in launch command

### DIFF
--- a/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapParams.scala
+++ b/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapParams.scala
@@ -10,7 +10,10 @@ final case class BootstrapParams(
   sharedLaunch: SharedLaunchParams,
   nativeBootstrap: NativeLauncherParams,
   specific: BootstrapSpecificParams
-)
+) {
+  lazy val fork: Boolean =
+    sharedLaunch.fork.getOrElse(SharedLaunchParams.defaultFork)
+}
 
 object BootstrapParams {
   def apply(options: BootstrapOptions): ValidatedNel[String, BootstrapParams] = {

--- a/modules/cli/src/main/scala/coursier/cli/launch/Launch.scala
+++ b/modules/cli/src/main/scala/coursier/cli/launch/Launch.scala
@@ -237,12 +237,6 @@ object Launch extends CaseApp[LaunchOptions] {
           s"$name.version" -> v
         }
 
-        val jcp =
-          if (params.shared.sharedLoader.loaderNames.isEmpty)
-            Seq("java.class.path" -> files.map(_._2.getAbsolutePath).mkString(File.pathSeparator))
-          else
-            Nil
-
         opt.toSeq ++ params.shared.properties
       }
       f <- Task.fromEither {

--- a/modules/cli/src/main/scala/coursier/cli/launch/Launch.scala
+++ b/modules/cli/src/main/scala/coursier/cli/launch/Launch.scala
@@ -14,6 +14,7 @@ import coursier.cli.params.{ArtifactParams, SharedLoaderParams}
 import coursier.cli.resolve.{Resolve, ResolveException}
 import coursier.core.Resolution
 import coursier.parse.{DependencyParser, JavaOrScalaDependency, JavaOrScalaModule}
+import coursier.paths.Jep
 import coursier.util.{Artifact, Sync, Task}
 
 import scala.annotation.tailrec
@@ -241,6 +242,22 @@ object Launch extends CaseApp[LaunchOptions] {
       }
       f <- Task.fromEither {
 
+        val (jlp, jepExtraJar) =
+          if (params.jep) {
+            val jepLocation = Jep.location()
+            if (params.shared.resolve.output.verbosity >= 1)
+              System.err.println(s"Found jep location: $jepLocation")
+            val jepJar = Jep.jar(jepLocation)
+            if (params.shared.resolve.output.verbosity >= 1)
+              System.err.println(s"Found jep JAR: $jepJar")
+            val props = Seq(
+              "java.library.path" -> jepLocation.getAbsolutePath
+            )
+
+            (props, Some(jepJar))
+          } else
+            (Nil, None)
+
         val hierarchy = loaderHierarchy(
           res,
           files,
@@ -248,7 +265,7 @@ object Launch extends CaseApp[LaunchOptions] {
           platformOpt,
           params.shared.sharedLoader,
           params.shared.artifact,
-          params.shared.extraJars.map(_.toFile),
+          params.shared.extraJars.map(_.toFile) ++ jepExtraJar.toSeq,
           params.shared.resolve.classpathOrder
         )
 
@@ -265,11 +282,11 @@ object Launch extends CaseApp[LaunchOptions] {
         val properties0 = {
           val m = new java.util.LinkedHashMap[String, String]
           // order matters - jcp first, so that it can be referenced from subsequent variables before expansion
-          for ((k, v) <- jcp.iterator ++ props.iterator)
+          for ((k, v) <- jcp.iterator ++ jlp.iterator ++ props.iterator)
             m.put(k, v)
           val m0 = coursier.paths.Util.expandProperties(m)
           // don't unnecessarily inject java.class.path - passing -cp to the Java invocation is enough
-          if (params.shared.fork && props.forall(_._1 != "java.class.path"))
+          if (params.fork && props.forall(_._1 != "java.class.path"))
             m0.remove("java.class.path")
           val b = new ListBuffer[(String, String)]
           m0.forEach(
@@ -281,7 +298,7 @@ object Launch extends CaseApp[LaunchOptions] {
           b.result()
         }
 
-        if (params.shared.fork)
+        if (params.fork)
           launchFork(hierarchy, mainClass, userArgs, properties0, params.shared.resolve.output.verbosity)
             .right.map(f => () => Some(f()))
         else

--- a/modules/cli/src/main/scala/coursier/cli/launch/LaunchOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/launch/LaunchOptions.scala
@@ -10,7 +10,9 @@ final case class LaunchOptions(
   @Recurse
     sharedOptions: SharedLaunchOptions = SharedLaunchOptions(),
 
-  json: Boolean = false // move to SharedLaunchOptions? (and handle it from the other commands too)
+  json: Boolean = false, // move to SharedLaunchOptions? (and handle it from the other commands too)
+
+  jep: Boolean = false
 ) {
   def addApp(app: RawAppDescriptor): LaunchOptions =
     copy(

--- a/modules/cli/src/main/scala/coursier/cli/launch/LaunchParams.scala
+++ b/modules/cli/src/main/scala/coursier/cli/launch/LaunchParams.scala
@@ -4,8 +4,12 @@ import cats.data.ValidatedNel
 import coursier.cli.params.SharedLaunchParams
 
 final case class LaunchParams(
-  shared: SharedLaunchParams
-)
+  shared: SharedLaunchParams,
+  jep: Boolean
+) {
+  lazy val fork: Boolean =
+    shared.fork.getOrElse(jep || SharedLaunchParams.defaultFork)
+}
 
 object LaunchParams {
   def apply(options: LaunchOptions): ValidatedNel[String, LaunchParams] = {
@@ -13,7 +17,10 @@ object LaunchParams {
     val sharedV = SharedLaunchParams(options.sharedOptions)
 
     sharedV.map { shared =>
-      LaunchParams(shared)
+      LaunchParams(
+        shared,
+        options.jep
+      )
     }
   }
 }

--- a/modules/cli/src/main/scala/coursier/cli/params/SharedLaunchParams.scala
+++ b/modules/cli/src/main/scala/coursier/cli/params/SharedLaunchParams.scala
@@ -15,7 +15,7 @@ final case class SharedLaunchParams(
   mainClassOpt: Option[String],
   properties: Seq[(String, String)],
   extraJars: Seq[Path],
-  fork: Boolean
+  fork: Option[Boolean]
 ) {
   def fetch: FetchParams =
     FetchParams(
@@ -28,7 +28,7 @@ final case class SharedLaunchParams(
 
 object SharedLaunchParams {
 
-  private def defaultFork: Boolean =
+  def defaultFork: Boolean =
     sys.props
       .get("org.graalvm.nativeimage.imagecode")
       .contains("runtime")
@@ -59,8 +59,6 @@ object SharedLaunchParams {
       Paths.get(p)
     }
 
-    val fork = options.fork.getOrElse(defaultFork)
-
     (resolveV, artifactV, sharedLoaderV, propertiesV).mapN {
       (resolve, artifact, sharedLoader, properties) =>
         SharedLaunchParams(
@@ -70,7 +68,7 @@ object SharedLaunchParams {
           mainClassOpt,
           properties,
           extraJars,
-          fork
+          options.fork
         )
     }
   }

--- a/modules/paths/src/main/java/coursier/paths/Jep.java
+++ b/modules/paths/src/main/java/coursier/paths/Jep.java
@@ -1,0 +1,121 @@
+package coursier.paths;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+public class Jep {
+
+  private static boolean existsInPath(String exec) {
+    // https://stackoverflow.com/questions/934191/how-to-check-existence-of-a-program-in-the-path/23539220#23539220
+    return Stream.of(System.getenv("PATH").split(Pattern.quote(File.pathSeparator)))
+      .map(Paths::get)
+      .anyMatch(path -> Files.exists(path.resolve(exec)));
+  }
+
+  // https://stackoverflow.com/questions/309424/how-do-i-read-convert-an-inputstream-into-a-string-in-java/309718#309718
+  private static String readFully(final InputStream is, final Charset charset, final int bufferSize) throws IOException {
+     final char[] buffer = new char[bufferSize];
+     final StringBuilder out = new StringBuilder();
+     try (Reader in = new InputStreamReader(is, charset)) {
+         for (;;) {
+             int rsz = in.read(buffer, 0, buffer.length);
+             if (rsz < 0)
+                 break;
+             out.append(buffer, 0, rsz);
+         }
+     }
+     return out.toString();
+  }
+
+  public static class JepException extends Exception {
+    public JepException(String message) {
+      super(message);
+    }
+  }
+
+  private final static String locationLinePrefix = "Location: ";
+
+  public static File location() throws Exception {
+
+    String fromEnv = System.getenv("JEP_LOCATION");
+    if (fromEnv != null && !fromEnv.isEmpty())
+      return new File(fromEnv);
+
+    String fromProps = System.getProperty("jep.location");
+    if (fromProps != null && !fromProps.isEmpty())
+      return new File(fromProps);
+
+    String pip = "pip";
+    if (existsInPath("pip3"))
+      pip = "pip3";
+
+    ProcessBuilder b = new ProcessBuilder(pip, "show", "jep")
+      .redirectInput(ProcessBuilder.Redirect.PIPE)
+      .redirectOutput(ProcessBuilder.Redirect.PIPE)
+      .redirectError(ProcessBuilder.Redirect.INHERIT);
+    Process p = b.start();
+    p.getOutputStream().close(); // close sub-process stdin
+
+    String output = readFully(p.getInputStream(), Charset.defaultCharset(), 1024);
+    int retValue = p.waitFor();
+    if (retValue != 0) {
+      if (!output.isEmpty())
+        output = "\n" + output;
+      throw new JepException("Error running " + pip + " show jep (return code: " + retValue + ")" + output);
+    }
+
+    Optional<String> locationOpt = Stream.of(output.split(System.getProperty("line.separator")))
+      .filter(line -> line.startsWith(locationLinePrefix))
+      .findFirst();
+    if (!locationOpt.isPresent()) {
+      throw new JepException("No location found in " + pip + " show jep output:" + output);
+    }
+
+    File base = new File(locationOpt.get().substring(locationLinePrefix.length()));
+
+    return new File(base, "jep");
+  }
+
+  private final static String prefix = "jep-";
+  private final static String suffix = ".jar";
+
+  public static File jar(File jepDirectory) throws JepException {
+    File[] jars = jepDirectory.listFiles(f -> f.isFile() && f.getName().startsWith(prefix) && f.getName().endsWith(suffix));
+    if (jars == null || jars.length == 0)
+      return null;
+    else if (jars.length == 1)
+      return jars[0];
+    else {
+      StringBuilder b = new StringBuilder("Found too many jars in " + jepDirectory + ": ");
+      boolean isFirst = true;
+      for (File f: jars) {
+        if (isFirst)
+          isFirst = false;
+        else
+          b.append(", ");
+        b.append(f.getName());
+      }
+      throw new JepException(b.toString());
+    }
+  }
+
+  public static String version(File jepJar) throws JepException {
+    String name = jepJar.getName();
+    if (!name.startsWith(prefix))
+      throw new JepException("Invalid jep jar name: " + jepJar);
+    if (!name.endsWith(suffix))
+      throw new JepException("Invalid jep jar name: " + jepJar);
+    String version = name.substring(prefix.length(), name.length() - suffix.length());
+    return version;
+  }
+
+}

--- a/modules/paths/src/main/java/coursier/paths/Mirror.java
+++ b/modules/paths/src/main/java/coursier/paths/Mirror.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
+import java.util.regex.Pattern;
 
 public class Mirror {
 
@@ -23,12 +24,12 @@ public class Mirror {
   public static File defaultConfigFile() throws IOException {
 
     String fromEnv = System.getenv("COURSIER_MIRRORS");
-    if (fromEnv != null) {
+    if (fromEnv != null && !fromEnv.isEmpty()) {
       return new File(fromEnv);
     }
 
     String fromProps = System.getProperty("coursier.mirrors");
-    if (fromProps != null) {
+    if (fromProps != null && !fromProps.isEmpty()) {
       return new File(fromProps);
     }
 
@@ -109,8 +110,8 @@ public class Mirror {
         throw new MirrorPropertiesException("Property " + prefix + ".from not found");
       }
 
-      List<String> froms = new ArrayList<>(Arrays.asList(rawFrom.split(";")));
-      for (String rawFrom0: rawFrom.split(";")) {
+      List<String> froms = new ArrayList<>();
+      for (String rawFrom0: rawFrom.split(Pattern.quote(";"))) {
         if (!rawFrom0.isEmpty()) {
           if (rawFrom0.charAt(rawFrom0.length() - 1) == '/')
             froms.add(rawFrom0.substring(0, rawFrom0.length() - 1));


### PR DESCRIPTION
Allowing e.g. to start Ammonite with jep already set up,
```
$ cs launch ammonite --jep
Welcome to the Ammonite Repl 1.8.1
(Scala 2.12.10 Java 1.8.0_121)
@ import $ivy.`me.shadaj::scalapy-core:0.3.0`
import $ivy.$

@ import me.shadaj.scalapy.py
import me.shadaj.scalapy.py

@ val listLengthPython = py.global.len(List(1, 2, 3))
listLengthPython: py.Any = 3
```