### PR TITLE
Parse homepage attribute in ivy.xml

### DIFF
--- a/modules/core/shared/src/main/scala/coursier/ivy/IvyXml.scala
+++ b/modules/core/shared/src/main/scala/coursier/ivy/IvyXml.scala
@@ -184,10 +184,13 @@ object IvyXml {
 
       val publicationsOpt = publicationsNodeOpt.map(publications)
 
-      val description = infoNode.children
-        .find(_.label == "description")
+      val descriptionNodeOpt = infoNode.children.find(_.label == "description")
+
+      val description = descriptionNodeOpt
         .map(_.textContent.trim)
         .getOrElse("")
+
+      val homePage = descriptionNodeOpt.flatMap(_.attribute("homepage").right.toOption).getOrElse("")
 
       val licenses = infoNode.children
         .filter(_.label == "license")
@@ -229,7 +232,7 @@ object IvyXml {
         },
         Info(
           description,
-          "",
+          homePage,
           licenses,
           Nil,
           publicationDate,

--- a/modules/tests/shared/src/test/scala/coursier/test/IvyXmlParsingTests.scala
+++ b/modules/tests/shared/src/test/scala/coursier/test/IvyXmlParsingTests.scala
@@ -1,0 +1,48 @@
+package coursier
+package test
+
+import coursier.core.Versions
+import coursier.core.compatibility._
+import coursier.ivy.IvyXml
+import utest._
+
+object IvyXmlParsingTests extends TestSuite {
+  val tests = Tests {
+    'infoWithHomePage {
+      val node = """
+        <ivy-module version="2.0" xmlns:e="http://ant.apache.org/ivy/extra">
+          <info organisation="com.github.gseitz" module="sbt-release" revision="1.0.12" status="release" publication="20191016122629" e:sbtVersion="1.0" e:scalaVersion="2.12">
+            <license name="Apache-2.0" url="http://www.apache.org/licenses/LICENSE-2.0"/>
+            <description homepage="https://github.com/sbt/sbt-release">
+            sbt-release
+            </description>
+          </info>
+        </ivy-module>
+      """
+
+      val result = IvyXml.project(xmlParseDom(node).right.get).map(_.info)
+      val expected = Right(Info("sbt-release", "https://github.com/sbt/sbt-release",
+        List(("Apache-2.0", Some("http://www.apache.org/licenses/LICENSE-2.0"))), Nil,
+        Some(Versions.DateTime(2019, 10, 16, 12, 26, 29)), None))
+
+      assert(result == expected)
+    }
+
+    'infoWithoutHomePage {
+      val node = """
+        <ivy-module version="2.0" xmlns:e="http://ant.apache.org/ivy/extra">
+          <info organisation="com.github.gseitz" module="sbt-release" revision="1.0.12" status="release" e:sbtVersion="1.0" e:scalaVersion="2.12">
+            <description>
+            sbt-release
+            </description>
+          </info>
+        </ivy-module>
+      """
+
+      val result = IvyXml.project(xmlParseDom(node).right.get).map(_.info)
+      val expected = Right(Info("sbt-release", "", Nil, Nil, None, None))
+
+      assert(result == expected)
+    }
+  }
+}

--- a/modules/tests/shared/src/test/scala/coursier/test/IvyXmlParsingTests.scala
+++ b/modules/tests/shared/src/test/scala/coursier/test/IvyXmlParsingTests.scala
@@ -21,7 +21,7 @@ object IvyXmlParsingTests extends TestSuite {
         </ivy-module>
       """
 
-      val result = IvyXml.project(xmlParseDom(node).right.get).map(_.info)
+      val result = IvyXml.project(xmlParseDom(node).right.get).right.map(_.info)
       val expected = Right(Info("sbt-release", "https://github.com/sbt/sbt-release",
         List(("Apache-2.0", Some("http://www.apache.org/licenses/LICENSE-2.0"))), Nil,
         Some(Versions.DateTime(2019, 10, 16, 12, 26, 29)), None))
@@ -40,7 +40,7 @@ object IvyXmlParsingTests extends TestSuite {
         </ivy-module>
       """
 
-      val result = IvyXml.project(xmlParseDom(node).right.get).map(_.info)
+      val result = IvyXml.project(xmlParseDom(node).right.get).right.map(_.info)
       val expected = Right(Info("sbt-release", "", Nil, Nil, None, None))
 
       assert(result == expected)

--- a/modules/tests/shared/src/test/scala/coursier/test/IvyXmlParsingTests.scala
+++ b/modules/tests/shared/src/test/scala/coursier/test/IvyXmlParsingTests.scala
@@ -9,6 +9,7 @@ import utest._
 object IvyXmlParsingTests extends TestSuite {
   val tests = Tests {
     'infoWithHomePage {
+      // slice of https://dl.bintray.com/sbt/sbt-plugin-releases/com.github.gseitz/sbt-release/scala_2.12/sbt_1.0/1.0.12/ivys/ivy.xml
       val node = """
         <ivy-module version="2.0" xmlns:e="http://ant.apache.org/ivy/extra">
           <info organisation="com.github.gseitz" module="sbt-release" revision="1.0.12" status="release" publication="20191016122629" e:sbtVersion="1.0" e:scalaVersion="2.12">


### PR DESCRIPTION
This extracts the [`homepage`](https://ant.apache.org/ivy/history/latest-milestone/ivyfile/description.html) attribute from the `description` element in `ivy.xml` files and sets it as `homePage` in `Info`.

My goal is to use this in Scala Steward for linking to home pages and release notes of sbt plugins.