### PR TITLE
Add API to list versions

### DIFF
--- a/modules/core/shared/src/main/scala/coursier/core/Versions.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Versions.scala
@@ -85,7 +85,14 @@ object Versions {
     hour: Int,
     minute: Int,
     second: Int
-  )
+  ) extends Ordered[DateTime] {
+    def compare(other: DateTime): Int = {
+      import Ordering.Implicits._
+      if (this == other) 0
+      else if (tuple < other.tuple) -1
+      else 1
+    }
+  }
 
   val empty = Versions("", "", Nil, None)
 }

--- a/modules/coursier/shared/src/main/scala/coursier/Versions.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/Versions.scala
@@ -1,0 +1,90 @@
+package coursier
+
+import coursier.cache.Cache
+import coursier.core.Version
+import coursier.util.{Sync, Task}
+import dataclass.data
+
+@data class Versions[F[_]](
+  cache: Cache[F],
+  moduleOpt: Option[Module] = None,
+  repositories: Seq[Repository] = Resolve.defaultRepositories
+)(implicit
+  sync: Sync[F]
+) {
+
+  private def F = sync
+
+  def addRepositories(repository: Repository*): Versions[F] =
+    withRepositories(repositories ++ repository)
+
+  def withModule(module: Module): Versions[F] =
+    withModuleOpt(Some(module))
+
+  def versions(): F[coursier.core.Versions] =
+    F.map(result())(_.versions)
+
+  def result(): F[Versions.Result] = {
+
+    val t = F.gather(
+      for {
+        mod <- moduleOpt.toSeq
+        repo <- repositories
+      } yield {
+        F.map(repo.versions(mod, cache.fetch).run)(repo -> _.right.map(_._1))
+      }
+    )
+
+    val t0 = cache.loggerOpt.fold(t) { logger =>
+      F.bind(F.delay(logger.init())) { _ =>
+        F.bind(F.attempt(t)) { e =>
+          F.bind(F.delay(logger.stop())) { _ =>
+            F.fromAttempt(e)
+          }
+        }
+      }
+    }
+
+    F.map(t0) { l =>
+      Versions.Result(l)
+    }
+  }
+}
+
+object Versions {
+
+  def apply(): Versions[Task] =
+    Versions(Cache.default)
+
+  private def merge(versions: Vector[coursier.core.Versions]): coursier.core.Versions =
+    if (versions.isEmpty)
+      coursier.core.Versions("", "", Nil, None)
+    else if (versions.lengthCompare(1) == 0)
+      versions.head
+    else {
+      val latest = versions.map(v => Version(v.latest)).max.repr
+      val release = versions.map(v => Version(v.release)).max.repr
+
+      val available = versions
+        .flatMap(_.available)
+        .distinct
+        .map(Version(_))
+        .sorted
+        .map(_.repr)
+        .toList
+
+      val lastUpdated = versions
+        .flatMap(_.lastUpdated.toSeq)
+        .sorted
+        .lastOption
+
+      coursier.core.Versions(latest, release, available, lastUpdated)
+    }
+
+  @data class Result(
+    results: Seq[(Repository, Either[String, coursier.core.Versions])]
+  ) {
+    def versions: coursier.core.Versions =
+      merge(results.flatMap(_._2.right.toSeq).toVector)
+  }
+}

--- a/modules/coursier/shared/src/main/scala/coursier/complete/Complete.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/complete/Complete.scala
@@ -5,6 +5,7 @@ import coursier.cache.Cache
 import coursier.core.Repository
 import coursier.util.Sync
 import dataclass.data
+import coursier.util.Task
 
 @data class Complete[F[_]](
   cache: Cache[F],
@@ -75,6 +76,9 @@ import dataclass.data
 }
 
 object Complete {
+
+  def apply(): Complete[Task] =
+    Complete(Cache.default)
 
   def scalaBinaryVersion(scalaVersion: String): String =
     if (scalaVersion.contains("-M") || scalaVersion.contains("-RC"))

--- a/modules/coursier/shared/src/test/scala/coursier/ResolveTests.scala
+++ b/modules/coursier/shared/src/test/scala/coursier/ResolveTests.scala
@@ -1,6 +1,6 @@
 package coursier
 
-import coursier.core.{Configuration, Extension, Reconciliation}
+import coursier.core.{Activation, Configuration, Extension, Reconciliation}
 import coursier.error.ResolutionError
 import coursier.ivy.IvyRepository
 import coursier.params.{MavenMirror, Mirror, ResolutionParams, TreeMirror}
@@ -8,7 +8,6 @@ import coursier.util.ModuleMatchers
 import utest._
 
 import scala.async.Async.{async, await}
-import coursier.core.Activation
 
 object ResolveTests extends TestSuite {
 

--- a/modules/coursier/shared/src/test/scala/coursier/VersionsTests.scala
+++ b/modules/coursier/shared/src/test/scala/coursier/VersionsTests.scala
@@ -1,0 +1,22 @@
+package coursier
+
+import utest._
+
+import scala.async.Async.{async, await}
+
+object VersionsTests extends TestSuite {
+
+  import TestHelpers.{ec, cache}
+
+  private val versions = Versions()
+    .withCache(cache)
+
+  val tests = Tests {
+    "simple" - async {
+      val shapelessVersions = await(versions.withModule(mod"com.chuusai:shapeless_2.12").versions().future).available
+      val expectedShapelessVersions = Seq("2.3.2", "2.3.3")
+      assert(shapelessVersions == expectedShapelessVersions)
+    }
+  }
+
+}


### PR DESCRIPTION
Use like
```scala
import scala.concurrent.ExecutionContext.Implicits.global
import coursier._
val availableVersions = Versions()
  .withModule(mod"org.scala-lang:scala-library")
  .versions()
  .unsafeRun()
  .available // Seq[String]
```