### PR TITLE
Ensure artifacts of dependencies with classifier or type are non optional

### DIFF
--- a/modules/core/shared/src/main/scala/coursier/core/Definitions.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Definitions.scala
@@ -317,6 +317,8 @@ object Info {
   classifier: Classifier
 ) {
   def attributes: Attributes = Attributes(`type`, classifier)
+  def isEmpty: Boolean =
+    name.isEmpty && `type`.isEmpty && ext.isEmpty && classifier.isEmpty
 }
 
 object Publication {

--- a/modules/coursier/shared/src/test/scala/coursier/ResolveTests.scala
+++ b/modules/coursier/shared/src/test/scala/coursier/ResolveTests.scala
@@ -864,5 +864,21 @@ object ResolveTests extends TestSuite {
 
       assert(urls == expectedUrls)
     }
+
+    "Artifacts with classifier are non optional" - async {
+      val dep = dep"io.netty:netty-transport-native-epoll:4.1.44.Final,classifier=woops"
+      val res = await {
+        resolve.addDependencies(dep).future()
+      }
+
+      await(validateDependencies(res))
+
+      val artifacts = res.dependencyArtifacts()
+      val expectedUrl = "https://repo1.maven.org/maven2/io/netty/netty-transport-native-epoll/4.1.44.Final/netty-transport-native-epoll-4.1.44.Final-woops.jar"
+      val (_, _, woopsArtifact) = artifacts.find(_._3.url == expectedUrl).getOrElse {
+        sys.error(s"Expected artifact with URL $expectedUrl")
+      }
+      assert(!woopsArtifact.optional)
+    }
   }
 }

--- a/modules/tests/shared/src/test/resources/artifacts/com.splicemachine/splice_spark/2.8.0.1915-SNAPSHOT
+++ b/modules/tests/shared/src/test/resources/artifacts/com.splicemachine/splice_spark/2.8.0.1915-SNAPSHOT
@@ -223,6 +223,7 @@ https://repo1.maven.org/maven2/xml-apis/xml-apis/1.3.04/xml-apis-1.3.04.jar
 http://repository.mapr.com/maven/org/apache/hadoop/hadoop-yarn-server-nodemanager/2.7.0-mapr-1808/hadoop-yarn-server-nodemanager-2.7.0-mapr-1808.jar
 http://repository.splicemachine.com/nexus/content/groups/public/com/splicemachine/splice_encoding/2.8.0.1915-SNAPSHOT/splice_encoding-2.8.0.1915-20190427.010754-1.jar
 https://repo1.maven.org/maven2/software/amazon/ion/ion-java/1.0.1/ion-java-1.0.1.jar
+https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.6.7.1/jackson-databind-2.6.7.1.jar
 https://repo1.maven.org/maven2/com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.6.6/jackson-dataformat-cbor-2.6.6.jar
 https://repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.11.0/scala-compiler-2.11.0.jar
 https://repo1.maven.org/maven2/org/apache/lucene/lucene-core/4.3.1/lucene-core-4.3.1.jar

--- a/modules/tests/shared/src/test/resources/resolutions/io.netty/netty-transport-native-epoll/4.1.44.Final_dep7de51034e184d143081b12b308cb34a00c611b87
+++ b/modules/tests/shared/src/test/resources/resolutions/io.netty/netty-transport-native-epoll/4.1.44.Final_dep7de51034e184d143081b12b308cb34a00c611b87
@@ -1,0 +1,6 @@
+io.netty:netty-transport-native-epoll:4.1.44.Final:default
+io.netty:netty-common:4.1.44.Final:default
+io.netty:netty-buffer:4.1.44.Final:default
+io.netty:netty-transport:4.1.44.Final:default
+io.netty:netty-transport-native-unix-common:4.1.44.Final:default
+io.netty:netty-resolver:4.1.44.Final:default

--- a/modules/tests/shared/src/test/scala/coursier/test/CentralTests.scala
+++ b/modules/tests/shared/src/test/scala/coursier/test/CentralTests.scala
@@ -662,13 +662,13 @@ abstract class CentralTests extends TestSuite {
 
       * - runner.resolutionCheck(mod, ver)
 
-      * - runner.withArtifacts(mod, ver, Attributes(Type.jar)) { artifacts =>
+      * - runner.withArtifacts(mod, ver) { artifacts =>
         val mainArtifactOpt = artifacts.find(_.url == mainUrl)
         assert(mainArtifactOpt.nonEmpty)
         assert(mainArtifactOpt.forall(_.optional))
       }
 
-      * - runner.withArtifacts(Module(org"com.lihaoyi", name"scalatags_2.12"), "0.6.2", Attributes(Type.jar), transitive = true) { artifacts =>
+      * - runner.withArtifacts(Module(org"com.lihaoyi", name"scalatags_2.12"), "0.6.2", transitive = true) { artifacts =>
 
         val urls = artifacts.map(_.url).toSet
 


### PR DESCRIPTION
Fixes https://github.com/coursier/coursier/issues/1469. Only applies to dependencies pulled from Maven repositories. The ones from Ivy repositories should already be fine.