### PR TITLE
Add support for mirrors to Versions

### DIFF
--- a/modules/coursier/js/src/main/scala/coursier/PlatformResolve.scala
+++ b/modules/coursier/js/src/main/scala/coursier/PlatformResolve.scala
@@ -4,7 +4,7 @@ import coursier.params.MirrorConfFile
 
 abstract class PlatformResolve {
 
-  protected def defaultMirrorConfFiles: Seq[MirrorConfFile] =
+  def defaultMirrorConfFiles: Seq[MirrorConfFile] =
     Nil
 
   val defaultRepositories: Seq[Repository] =

--- a/modules/coursier/jvm/src/main/scala/coursier/PlatformResolve.scala
+++ b/modules/coursier/jvm/src/main/scala/coursier/PlatformResolve.scala
@@ -7,7 +7,7 @@ import coursier.parse.RepositoryParser
 
 abstract class PlatformResolve {
 
-  protected def defaultMirrorConfFiles = {
+  def defaultMirrorConfFiles = {
     val files = Seq(coursier.paths.Mirror.defaultConfigFile()) ++
       Option(coursier.paths.Mirror.extraConfigFile()).toSeq
     files.map { f =>

--- a/modules/coursier/jvm/src/main/scala/coursier/PlatformResolve.scala
+++ b/modules/coursier/jvm/src/main/scala/coursier/PlatformResolve.scala
@@ -7,7 +7,7 @@ import coursier.parse.RepositoryParser
 
 abstract class PlatformResolve {
 
-  def defaultMirrorConfFiles = {
+  def defaultMirrorConfFiles: Seq[MirrorConfFile] = {
     val files = Seq(coursier.paths.Mirror.defaultConfigFile()) ++
       Option(coursier.paths.Mirror.extraConfigFile()).toSeq
     files.map { f =>

--- a/modules/coursier/shared/src/main/scala/coursier/Resolve.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/Resolve.scala
@@ -21,7 +21,7 @@ import dataclass.{data, since}
   cache: Cache[F],
   dependencies: Seq[Dependency] = Nil,
   repositories: Seq[Repository] = Resolve.defaultRepositories,
-  mirrorConfFiles: Seq[MirrorConfFile] = Resolve.defaultMirrorConfFiles0,
+  mirrorConfFiles: Seq[MirrorConfFile] = Resolve.defaultMirrorConfFiles,
   mirrors: Seq[Mirror] = Nil,
   resolutionParams: ResolutionParams = ResolutionParams(),
   throughOpt: Option[F[Resolution] => F[Resolution]] = None,
@@ -187,7 +187,6 @@ import dataclass.{data, since}
 }
 
 object Resolve extends PlatformResolve {
-  private def defaultMirrorConfFiles0 = defaultMirrorConfFiles
 
   def apply(): Resolve[Task] =
     Resolve(Cache.default)

--- a/modules/coursier/shared/src/main/scala/coursier/Resolve.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/Resolve.scala
@@ -53,19 +53,7 @@ import dataclass.{data, since}
   }
 
   def finalRepositories: F[Seq[Repository]] =
-    S.map(allMirrors) { mirrors0 =>
-      repositories
-        .map { repo =>
-          val it = mirrors0
-            .iterator
-            .flatMap(_.matches(repo).iterator)
-          if (it.hasNext)
-            it.next()
-          else
-            repo
-        }
-        .distinct
-    }
+    S.map(allMirrors)(Mirror.replace(repositories, _))
 
   def addDependencies(dependencies: Dependency*): Resolve[F] =
     withDependencies(this.dependencies ++ dependencies)

--- a/modules/coursier/shared/src/main/scala/coursier/Versions.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/Versions.scala
@@ -37,19 +37,7 @@ import dataclass.data
     F.map(result())(_.versions)
 
   def finalRepositories: F[Seq[Repository]] =
-    F.map(allMirrors) { mirrors0 =>
-      repositories
-        .map { repo =>
-          val it = mirrors0
-            .iterator
-            .flatMap(_.matches(repo).iterator)
-          if (it.hasNext)
-            it.next()
-          else
-            repo
-        }
-        .distinct
-    }
+    F.map(allMirrors)(Mirror.replace(repositories, _))
 
   private def allMirrors0 =
     mirrors ++ mirrorConfFiles.flatMap(_.mirrors())

--- a/modules/coursier/shared/src/main/scala/coursier/Versions.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/Versions.scala
@@ -4,12 +4,13 @@ import coursier.cache.Cache
 import coursier.core.Version
 import coursier.params.{Mirror, MirrorConfFile}
 import coursier.util.{Sync, Task}
-import dataclass.data
+import dataclass._
 
 @data class Versions[F[_]](
   cache: Cache[F],
   moduleOpt: Option[Module] = None,
   repositories: Seq[Repository] = Resolve.defaultRepositories,
+  @since
   mirrorConfFiles: Seq[MirrorConfFile] = Resolve.defaultMirrorConfFiles,
   mirrors: Seq[Mirror] = Nil
 )(implicit

--- a/modules/coursier/shared/src/main/scala/coursier/Versions.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/Versions.scala
@@ -88,6 +88,7 @@ import dataclass.data
 }
 
 object Versions {
+
   def apply(): Versions[Task] =
     Versions(Cache.default)
 

--- a/modules/coursier/shared/src/main/scala/coursier/params/Mirror.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/params/Mirror.scala
@@ -5,3 +5,18 @@ import coursier.core.Repository
 abstract class Mirror extends Serializable {
   def matches(repo: Repository): Option[Repository]
 }
+
+object Mirror {
+  def replace(repositories: Seq[Repository], mirrors: Seq[Mirror]): Seq[Repository] =
+    repositories
+      .map { repo =>
+        val it = mirrors
+          .iterator
+          .flatMap(_.matches(repo).iterator)
+        if (it.hasNext)
+          it.next()
+        else
+          repo
+      }
+      .distinct
+}

--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -99,7 +99,9 @@ object Mima {
 
       Seq(
         // ignore shaded-stuff related errors
-        (pb: Problem) => pb.matchName.forall(!_.startsWith("coursier.internal.shaded."))
+        (pb: Problem) => pb.matchName.forall(!_.startsWith("coursier.internal.shaded.")),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("coursier.Versions.apply"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("coursier.Versions.this")
       )
     }
   }

--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -99,9 +99,7 @@ object Mima {
 
       Seq(
         // ignore shaded-stuff related errors
-        (pb: Problem) => pb.matchName.forall(!_.startsWith("coursier.internal.shaded.")),
-        ProblemFilters.exclude[DirectMissingMethodProblem]("coursier.Versions.apply"),
-        ProblemFilters.exclude[DirectMissingMethodProblem]("coursier.Versions.this")
+        (pb: Problem) => pb.matchName.forall(!_.startsWith("coursier.internal.shaded."))
       )
     }
   }


### PR DESCRIPTION
This adds support for mirrors to `Versions` by mimicking the API in `Resolve`.