### PR TITLE
Allow forks to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,10 +82,10 @@ jobs:
         - npm install
         - export PATH="$PATH:$(pwd)/node_modules/bower/bin"
         - amm website.sc updateWebsite
-branches:
-  only:
-  - master
-  - /^v\d+\.\d+.*$/ # tagged versions
+# Only build if: master branch, a tag, or a fork
+if: branch = master
+    OR tag IS present
+    OR repo != coursier/coursier
 cache:
   directories:
   - $HOME/.m2


### PR DESCRIPTION
* switch to `if`, which is the more powerful replacement of the "legacy"
  `branches`
* switch to `tag IS present`, which is the more direct way to determine
  a build is a tag build