### PR TITLE
Remove spark-submit command from the default command list

### DIFF
--- a/modules/cli/src/main/scala/coursier/cli/Coursier.scala
+++ b/modules/cli/src/main/scala/coursier/cli/Coursier.scala
@@ -17,7 +17,6 @@ import coursier.cli.publish.Publish
 import coursier.cli.publish.sonatype.Sonatype
 import coursier.cli.resolve.Resolve
 import coursier.cli.setup.{Setup, SetupOptions}
-import coursier.cli.spark.SparkSubmit
 import coursier.core.Version
 import coursier.launcher.internal.{FileUtil, Windows}
 import io.github.alexarchambault.windowsansi.WindowsAnsi
@@ -116,13 +115,11 @@ object Coursier extends CommandAppPreA(Parser[LauncherOptions], Help[LauncherOpt
         Setup.run(setupOptions, args)
       case Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inl(sonatypeOptions))))))))))) =>
         Sonatype.run(sonatypeOptions, args)
-      case Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inl(sparkSubmitOptions)))))))))))) =>
-        SparkSubmit.run(sparkSubmitOptions, args)
-      case Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inl(uninstallOptions))))))))))))) =>
+      case Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inl(uninstallOptions)))))))))))) =>
         Uninstall.run(uninstallOptions, args)
-      case Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inl(updateOptions)))))))))))))) =>
+      case Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inl(updateOptions))))))))))))) =>
         Update.run(updateOptions, args)
-      case Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(cnil)))))))))))))) =>
+      case Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(cnil))))))))))))) =>
         cnil.impossible
     }
 

--- a/modules/cli/src/main/scala/coursier/cli/Coursier.scala
+++ b/modules/cli/src/main/scala/coursier/cli/Coursier.scala
@@ -14,7 +14,6 @@ import coursier.cli.install.{Install, Uninstall, Update}
 import coursier.cli.jvm.{Java, JavaHome}
 import coursier.cli.launch.Launch
 import coursier.cli.publish.Publish
-import coursier.cli.publish.sonatype.Sonatype
 import coursier.cli.resolve.Resolve
 import coursier.cli.setup.{Setup, SetupOptions}
 import coursier.core.Version
@@ -113,13 +112,11 @@ object Coursier extends CommandAppPreA(Parser[LauncherOptions], Help[LauncherOpt
         Resolve.run(resolveOptions, args)
       case Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inl(setupOptions)))))))))) =>
         Setup.run(setupOptions, args)
-      case Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inl(sonatypeOptions))))))))))) =>
-        Sonatype.run(sonatypeOptions, args)
-      case Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inl(uninstallOptions)))))))))))) =>
+      case Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inl(uninstallOptions))))))))))) =>
         Uninstall.run(uninstallOptions, args)
-      case Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inl(updateOptions))))))))))))) =>
+      case Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inl(updateOptions)))))))))))) =>
         Update.run(updateOptions, args)
-      case Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(cnil))))))))))))) =>
+      case Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(cnil)))))))))))) =>
         cnil.impossible
     }
 

--- a/modules/cli/src/main/scala/coursier/cli/CoursierCommand.scala
+++ b/modules/cli/src/main/scala/coursier/cli/CoursierCommand.scala
@@ -9,7 +9,6 @@ import coursier.cli.install.{Install, Uninstall, Update}
 import coursier.cli.jvm.{Java, JavaHome}
 import coursier.cli.launch.Launch
 import coursier.cli.publish.Publish
-import coursier.cli.publish.sonatype.Sonatype
 import coursier.cli.resolve.Resolve
 import coursier.cli.setup.Setup
 
@@ -27,7 +26,6 @@ object CoursierCommand {
       .add(Publish)
       .add(Resolve)
       .add(Setup)
-      .add(Sonatype, "sonatype")
       .add(Uninstall)
       .add(Update)
       .reverse
@@ -44,7 +42,6 @@ object CoursierCommand {
       .add(Publish)
       .add(Resolve)
       .add(Setup)
-      .add(Sonatype, "sonatype")
       .add(Uninstall)
       .add(Update)
       .reverse

--- a/modules/cli/src/main/scala/coursier/cli/CoursierCommand.scala
+++ b/modules/cli/src/main/scala/coursier/cli/CoursierCommand.scala
@@ -12,7 +12,6 @@ import coursier.cli.publish.Publish
 import coursier.cli.publish.sonatype.Sonatype
 import coursier.cli.resolve.Resolve
 import coursier.cli.setup.Setup
-import coursier.cli.spark.SparkSubmit
 
 object CoursierCommand {
 
@@ -29,7 +28,6 @@ object CoursierCommand {
       .add(Resolve)
       .add(Setup)
       .add(Sonatype, "sonatype")
-      .add(SparkSubmit)
       .add(Uninstall)
       .add(Update)
       .reverse
@@ -47,7 +45,6 @@ object CoursierCommand {
       .add(Resolve)
       .add(Setup)
       .add(Sonatype, "sonatype")
-      .add(SparkSubmit)
       .add(Uninstall)
       .add(Update)
       .reverse


### PR DESCRIPTION
It can still be run like
```
$ cs launch io.get-coursier::coursier-cli:2.0.0-RC6-6 -r typesafe:ivy-releases \
    -M coursier.cli.spark.SparkSubmit -- \
      spark-submit-options…
```