### PR TITLE
Remove support for ~/.coursier/cache cache location

### DIFF
--- a/modules/cache/jvm/src/main/scala/coursier/cache/CacheDefaults.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/CacheDefaults.scala
@@ -15,27 +15,8 @@ object CacheDefaults {
 
   lazy val location: File = CachePath.defaultCacheDirectory()
 
-  def warnLegacyCacheLocation(): Unit = {
-    val legacy = new File(new File(System.getProperty("user.home")), ".coursier/cache/v1")
-    lazy val disabled = Option(System.getenv("COURSIER_LEGACY_CACHE")).contains("dont-warn") ||
-      java.lang.Boolean.getBoolean("coursier.legacy-cache.dont-warn")
-    if (location == legacy && !disabled) {
-      val colorsEnabled = coursier.paths.Util.useColorOutput()
-      val yellow = if (colorsEnabled) Console.YELLOW else ""
-      val reset = if (colorsEnabled) Console.RESET else ""
-      System.err.println(
-       s"""${yellow}Warning${reset}: a legacy coursier cache was found at $location and is currently being used.
-          |
-          |Support for that cache location will be removed in coursier 2.0.0 final, whose release is imminent.
-          |
-          |Follow the instructions at
-          |  https://github.com/coursier/cache-migration#cache-migration
-          |in order to migrate your cache to the newer location.
-          |
-          |""".stripMargin
-      )
-    }
-  }
+  @deprecated("Legacy cache location support was dropped, this method does nothing.", "2.0.0-RC6-22")
+  def warnLegacyCacheLocation(): Unit = {}
 
   private def defaultConcurrentDownloadCount = 6
 

--- a/modules/cli/src/main/scala/coursier/cli/Coursier.scala
+++ b/modules/cli/src/main/scala/coursier/cli/Coursier.scala
@@ -73,8 +73,6 @@ object Coursier extends CommandAppPreA(Parser[LauncherOptions], Help[LauncherOpt
 
   override def main(args: Array[String]): Unit = {
 
-    coursier.cache.CacheDefaults.warnLegacyCacheLocation()
-
     if (args.nonEmpty)
       super.main(args)
     else if (Windows.isWindows && !isInstalledLauncher)

--- a/modules/cli/src/test/scala/coursier/cli/CliFetchIntegrationTest.scala
+++ b/modules/cli/src/test/scala/coursier/cli/CliFetchIntegrationTest.scala
@@ -614,9 +614,9 @@ class CliFetchIntegrationTest extends AnyFlatSpec with CliTestLib with Matchers 
 
           val urlInJsonFile2 = depNodes2.head.file.get
           val inCoursierCache =
-            urlInJsonFile2.contains("/.coursier/") || // Former cache path
-              urlInJsonFile2.contains("/coursier/") || // New cache path, Linux
-              urlInJsonFile2.contains("/Coursier/") // New cache path, OS X
+            urlInJsonFile2.contains("/coursier/") || // Linux
+              urlInJsonFile2.contains("/Coursier/") || // macOS
+              urlInJsonFile2.contains("\\Coursier\\") // Windows?
           assert(inCoursierCache && urlInJsonFile2.contains(testFile.toString))
         }
       }

--- a/modules/paths/src/main/java/coursier/paths/CoursierPaths.java
+++ b/modules/paths/src/main/java/coursier/paths/CoursierPaths.java
@@ -52,23 +52,10 @@ public final class CoursierPaths {
 
         File baseXdgDir = new File(coursierDirectories().cacheDir);
         File xdgDir = new File(baseXdgDir, dirName);
-        String xdgPath = xdgDir.getAbsolutePath();
 
-        if (baseXdgDir.isDirectory())
-            path = xdgPath;
+        Util.createDirectories(xdgDir.toPath());
 
-        if (path == null) {
-            File coursierDotFile = new File(System.getProperty("user.home") + "/.coursier");
-            if (coursierDotFile.isDirectory())
-                path = System.getProperty("user.home") + "/.coursier/cache/" + dirName + "/";
-        }
-
-        if (path == null) {
-            path = xdgPath;
-            Util.createDirectories(xdgDir.toPath());
-        }
-
-        return path;
+        return xdgDir.getAbsolutePath();
     }
 
     public static File cacheDirectory() throws IOException {


### PR DESCRIPTION
Fixes https://github.com/coursier/coursier/issues/1483.

Don't know whether I want to write some kind of migration tool to help users migrate to the new location, prior to merging that.