### PR TITLE
Allow to generate launchers relying on the classpath field of manifests

### DIFF
--- a/modules/cli/src/main/scala/coursier/cli/bootstrap/Bootstrap.scala
+++ b/modules/cli/src/main/scala/coursier/cli/bootstrap/Bootstrap.scala
@@ -343,7 +343,6 @@ object Bootstrap extends CaseApp[BootstrapOptions] {
           }
 
           Parameters.Bootstrap(content, mainClass)
-            .withJavaOpts(javaOptions)
             .withJavaProperties(params.sharedLaunch.properties)
             .withDeterministic(params.specific.deterministicOutput)
             .withPreambleOpt(

--- a/modules/cli/src/main/scala/coursier/cli/bootstrap/Bootstrap.scala
+++ b/modules/cli/src/main/scala/coursier/cli/bootstrap/Bootstrap.scala
@@ -227,7 +227,7 @@ object Bootstrap extends CaseApp[BootstrapOptions] {
     var wroteBat = false
 
     val javaOptions =
-      if (params.specific.assembly)
+      if (params.specific.assembly || params.specific.manifestJar)
         params.specific.javaOptions ++ params.sharedLaunch.properties.map { case (k, v) => s"-D$k=$v" }
       else
         params.specific.javaOptions
@@ -303,6 +303,17 @@ object Bootstrap extends CaseApp[BootstrapOptions] {
             .withFiles(files.map(_._2))
             .withMainClass(mainClass)
             .withRules(params.specific.assemblyRules)
+            .withPreambleOpt(
+              if (params.specific.withPreamble)
+                Some(
+                  coursier.launcher.Preamble()
+                    .withJavaOpts(javaOptions)
+                )
+              else
+                None
+            )
+        else if (params.specific.manifestJar)
+          Parameters.ManifestJar(files.map(_._2), mainClass)
             .withPreambleOpt(
               if (params.specific.withPreamble)
                 Some(

--- a/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapSpecificOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapSpecificOptions.scala
@@ -33,6 +33,8 @@ final case class BootstrapSpecificOptions(
   @Help("Generate an assembly rather than a bootstrap jar")
   @Short("a")
     assembly: Option[Boolean] = None,
+  @Help("Generate a JAR with the classpath as manifest rather than a bootstrap jar")
+    manifestJar: Option[Boolean] = None,
   @Help("Generate a Windows bat file along the bootstrap JAR (default: true on Windows, false else)")
     bat: Option[Boolean] = None,
   @Help("Add assembly rule")

--- a/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapSpecificParams.scala
+++ b/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapSpecificParams.scala
@@ -14,6 +14,7 @@ final case class BootstrapSpecificParams(
   embedFiles: Boolean,
   javaOptions: Seq[String],
   assembly: Boolean,
+  manifestJar: Boolean,
   createBatFile: Boolean,
   assemblyRules: Seq[MergeRule],
   withPreamble: Boolean,
@@ -52,16 +53,23 @@ object BootstrapSpecificParams {
       else
         (options.graalvmJvmOption.filter(_.nonEmpty), options.graalvmOption.filter(_.nonEmpty))
 
+    val assembly = options.assembly.getOrElse(false)
+    val manifestJar = options.manifestJar.getOrElse(false)
+    val standalone = options.standalone.getOrElse(false)
+    val hybrid = options.hybrid.getOrElse(false)
+    val nativeImage = options.nativeImage.getOrElse(graalvmVersion.nonEmpty)
+
     val validateOutputType = {
       val count = Seq(
-        options.assembly.exists(identity),
-        options.standalone.exists(identity),
-        options.hybrid.exists(identity),
-        options.nativeImage.exists(identity) || graalvmVersion.nonEmpty,
+        assembly,
+        manifestJar,
+        standalone,
+        hybrid,
+        nativeImage,
         native
       ).count(identity)
       if (count > 1)
-        Validated.invalidNel("Only one of --assembly (or -a), --standalone (or -s), --hybrid, --native-image, or --native (or -S), can be specified")
+        Validated.invalidNel("Only one of --assembly (or -a), --manifest-jar, --standalone (or -s), --hybrid, --native-image, or --native (or -S), can be specified")
       else
         Validated.validNel(())
     }
@@ -95,11 +103,6 @@ object BootstrapSpecificParams {
 
     val prependRules = if (options.defaultAssemblyRules) MergeRule.default else Nil
 
-    val assembly = options.assembly.getOrElse(false)
-    val standalone = options.standalone.getOrElse(false)
-    val hybrid = options.hybrid.getOrElse(false)
-    val nativeImage = options.nativeImage.getOrElse(graalvmVersion.nonEmpty)
-
     (validateOutputType, rulesV).mapN {
       (_, rules) =>
         val javaOptions = options.javaOpt
@@ -110,6 +113,7 @@ object BootstrapSpecificParams {
           options.embedFiles,
           javaOptions,
           assembly,
+          manifestJar,
           createBatFile,
           prependRules ++ rules,
           options.preamble,

--- a/modules/launcher/src/main/scala/coursier/launcher/Generator.scala
+++ b/modules/launcher/src/main/scala/coursier/launcher/Generator.scala
@@ -14,5 +14,6 @@ object Generator extends Generator[Parameters] {
       case n: Parameters.NativeImage => NativeImageGenerator.generate(n, output)
       case s: Parameters.ScalaNative => ScalaNativeGenerator.generate(s, output)
       case d: Parameters.DummyNative => DummyNativeGenerator.generate(d, output)
+      case m: Parameters.ManifestJar => ManifestJarGenerator.generate(m, output)
     }
 }

--- a/modules/launcher/src/main/scala/coursier/launcher/ManifestJarGenerator.scala
+++ b/modules/launcher/src/main/scala/coursier/launcher/ManifestJarGenerator.scala
@@ -1,0 +1,39 @@
+package coursier.launcher
+
+import java.io.{ByteArrayOutputStream, OutputStream}
+import java.nio.file.{Files, Path}
+import java.util.jar.{Attributes, JarOutputStream, Manifest}
+
+import coursier.launcher.internal.FileUtil
+
+object ManifestJarGenerator extends Generator[Parameters.ManifestJar] {
+
+  def generate(parameters: Parameters.ManifestJar, output: Path): Unit = {
+
+    val cp = parameters.classpath.map(_.toURI.getRawPath).mkString(" ")
+
+    val manifest = new Manifest
+    val attr = manifest.getMainAttributes
+    attr.put(Attributes.Name.MANIFEST_VERSION, "1.0")
+    attr.put(Attributes.Name.CLASS_PATH, cp)
+    attr.put(Attributes.Name.MAIN_CLASS, parameters.mainClass)
+
+    val content = {
+      val baos = new ByteArrayOutputStream
+      val jos = new JarOutputStream(baos, manifest)
+      jos.close()
+      baos.close()
+      baos.toByteArray()
+    }
+
+    FileUtil.withOutputStream(output) { os =>
+
+      for (p <- parameters.preambleOpt.map(_.value))
+        os.write(p)
+
+      os.write(content)
+    }
+
+    FileUtil.tryMakeExecutable(output)
+  }
+}

--- a/modules/launcher/src/main/scala/coursier/launcher/Parameters.scala
+++ b/modules/launcher/src/main/scala/coursier/launcher/Parameters.scala
@@ -36,7 +36,6 @@ object Parameters {
   @data class Bootstrap(
     content: Seq[ClassLoaderContent],
     mainClass: String,
-    javaOpts: Seq[String] = Nil,
     javaProperties: Seq[(String, String)] = Nil,
     bootstrapResourcePathOpt: Option[String] = None,
     deterministic: Boolean = true,

--- a/modules/launcher/src/main/scala/coursier/launcher/Parameters.scala
+++ b/modules/launcher/src/main/scala/coursier/launcher/Parameters.scala
@@ -69,6 +69,16 @@ object Parameters {
         preambleOpt
   }
 
+  @data class ManifestJar(
+    classpath: Seq[File],
+    mainClass: String,
+    preambleOpt: Option[Preamble] = Some(Preamble())
+  ) extends Parameters {
+
+    def withPreamble(preamble: Preamble): ManifestJar =
+      withPreambleOpt(Some(preamble))
+  }
+
   @data class NativeImage(
     mainClass: String,
     fetch: Seq[String] => Seq[File],

--- a/scripts/test-bootstrap.sh
+++ b/scripts/test-bootstrap.sh
@@ -160,6 +160,16 @@ spaceInMainJar() {
   fi
 }
 
+manifestJar() {
+  # FIXME We should also inspect the generated launcher to check that it's indeed based on a manifest
+  "$COURSIER" bootstrap -o cs-echo-mf io.get-coursier:echo:1.0.1 --manifest-jar
+  local OUT="$(./cs-echo-mf foo)"
+  if [ "$OUT" != foo ]; then
+    echo "Error: unexpected output from echo command manifest-jar-based launcher." 1>&2
+    exit 1
+  fi
+}
+
 hybrid() {
   # FIXME We should also inspect the generated launcher to check that it's indeed an hybrid one
   "$COURSIER" bootstrap -o cs-echo-hybrid io.get-coursier:echo:1.0.1 --hybrid
@@ -311,6 +321,7 @@ javaClassPathProp
 javaClassPathInExpansion
 javaClassPathInExpansionFromLaunch
 spaceInMainJar
+manifestJar
 hybrid
 hybridJavaClassPath
 hybridNoUrlInJavaClassPath


### PR DESCRIPTION
These launchers only contain `META-INF/MANIFEST.MF`, whose `Class-Path` field contains the actual class path (local paths of the JARs of the application, in the coursier cache).