### PR TITLE
Add in a list command to display installed apps

### DIFF
--- a/doc/docs/cli-install.md
+++ b/doc/docs/cli-install.md
@@ -30,6 +30,13 @@ $ cs update
 $ cs uninstall scala
 ```
 
+[The `list` command](#list) allows you to view all of your currently installed
+applications
+
+```bash
+$ cs list
+```
+
 ## Application descriptors
 
 The `install` command goes from an application name (`scala`, `ammonite`, `scalafmt`, etc.)
@@ -152,6 +159,18 @@ $ cs install ammonite
 $ amm
 …
 $ cs uninstall amm # ammonite is installed as "amm"
+```
+
+## List
+
+The `list` command lists all the installed applications. By default this will
+list the applications in your [default installation
+directory](#installation-directory). However, you can explicitly provide a
+different directory with the `--dir` flag if you have your install directory in
+a custom location.
+
+```bash
+$ cs list --dir /myCustomDirectory
 ```
 
 ## Default channels

--- a/modules/cli/src/main/scala/coursier/cli/Coursier.scala
+++ b/modules/cli/src/main/scala/coursier/cli/Coursier.scala
@@ -10,7 +10,7 @@ import caseapp.core.parser.Parser
 import coursier.cli.bootstrap.Bootstrap
 import coursier.cli.complete.Complete
 import coursier.cli.fetch.Fetch
-import coursier.cli.install.{Install, Uninstall, Update}
+import coursier.cli.install.{Install, List, Uninstall, Update}
 import coursier.cli.jvm.{Java, JavaHome}
 import coursier.cli.launch.Launch
 import coursier.cli.publish.Publish
@@ -106,17 +106,19 @@ object Coursier extends CommandAppPreA(Parser[LauncherOptions], Help[LauncherOpt
         JavaHome.run(javaHomeOptions, args)
       case Inr(Inr(Inr(Inr(Inr(Inr(Inl(launchOptions))))))) =>
         Launch.run(launchOptions, args)
-      case Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inl(publishOptions)))))))) =>
+      case Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inl(listOptions)))))))) =>
+        List.run(listOptions, args)
+      case Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inl(publishOptions))))))))) =>
         Publish.run(publishOptions, args)
-      case Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inl(resolveOptions))))))))) =>
+      case Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inl(resolveOptions)))))))))) =>
         Resolve.run(resolveOptions, args)
-      case Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inl(setupOptions)))))))))) =>
+      case Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inl(setupOptions))))))))))) =>
         Setup.run(setupOptions, args)
-      case Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inl(uninstallOptions))))))))))) =>
+      case Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inl(uninstallOptions)))))))))))) =>
         Uninstall.run(uninstallOptions, args)
-      case Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inl(updateOptions)))))))))))) =>
+      case Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inl(updateOptions))))))))))))) =>
         Update.run(updateOptions, args)
-      case Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(cnil)))))))))))) =>
+      case Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(Inr(cnil))))))))))))) =>
         cnil.impossible
     }
 

--- a/modules/cli/src/main/scala/coursier/cli/CoursierCommand.scala
+++ b/modules/cli/src/main/scala/coursier/cli/CoursierCommand.scala
@@ -5,7 +5,7 @@ import caseapp.core.help.CommandsHelp
 import coursier.cli.bootstrap.Bootstrap
 import coursier.cli.complete.Complete
 import coursier.cli.fetch.Fetch
-import coursier.cli.install.{Install, Uninstall, Update}
+import coursier.cli.install.{Install, List, Uninstall, Update}
 import coursier.cli.jvm.{Java, JavaHome}
 import coursier.cli.launch.Launch
 import coursier.cli.publish.Publish
@@ -23,6 +23,7 @@ object CoursierCommand {
       .add(Java)
       .add(JavaHome)
       .add(Launch)
+      .add(List)
       .add(Publish)
       .add(Resolve)
       .add(Setup)
@@ -39,6 +40,7 @@ object CoursierCommand {
       .add(Java)
       .add(JavaHome)
       .add(Launch)
+      .add(List)
       .add(Publish)
       .add(Resolve)
       .add(Setup)

--- a/modules/cli/src/main/scala/coursier/cli/install/List.scala
+++ b/modules/cli/src/main/scala/coursier/cli/install/List.scala
@@ -1,0 +1,13 @@
+package coursier.cli.install
+
+import caseapp.core.app.CaseApp
+import caseapp.core.RemainingArgs
+import coursier.install.Updatable
+
+object List extends CaseApp[ListOptions] {
+  def run(options: ListOptions, args: RemainingArgs): Unit = {
+    val params = ListParams(options)
+    val names = Updatable.list(params.installPath)
+    System.err.println(names.mkString(" "))
+  }
+}

--- a/modules/cli/src/main/scala/coursier/cli/install/ListOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/install/ListOptions.scala
@@ -1,0 +1,13 @@
+package coursier.cli.install
+
+import caseapp.{ExtraName => Short, Parser}
+
+final case class ListOptions(
+  @Short("dir")
+    installDir: Option[String] = None,
+)
+
+object ListOption {
+  implicit val parser = Parser[ListOptions]
+  implicit val help = caseapp.core.help.Help[ListOptions]
+}

--- a/modules/cli/src/main/scala/coursier/cli/install/ListParams.scala
+++ b/modules/cli/src/main/scala/coursier/cli/install/ListParams.scala
@@ -1,0 +1,17 @@
+package coursier.cli.install
+
+import java.nio.file.{Path, Paths}
+
+final case class ListParams(
+    installPath: Path
+)
+
+object ListParams {
+  def apply(options: ListOptions): ListParams = {
+    val dir = options.installDir.filter(_.nonEmpty) match {
+      case Some(d) => Paths.get(d)
+      case None    => SharedInstallParams.defaultDir
+    }
+    ListParams(dir)
+  }
+}


### PR DESCRIPTION
This pr introduces a small `cs list` command to the cli.

Here is the example output.
```sh
❯ modules/cli/target/pack/bin/coursier list
amm coursier cs mdoc metac metap sbt scala scalac scalafmt
```

The only flag that I've enabled is the `--dir`.
```sh
❯ modules/cli/target/pack/bin/coursier list --dir /Users/ckipp/Library/Application\ Support/Coursier/bin
amm coursier cs mdoc metac metap sbt scala scalac scalafmt
```
### Reasoning

I'm in the habit of issuing `list` commands for the various package management systems that I use. For example, brew and yarn both have these options to get a quick glance of what has been installed. I've attempted `cs list` multiple times, and today I figured it'd be fun to just try to implement it.

### Approach

I'll be honest I just cobbled this together by picking the related parts from the `update` command, and I only kept the `--dir` flag. I wasn't fully sure what some of the use cases would be for some of the others, and all of the defaults seemed to just offer a lot of stuff that wouldn't be useful for list. If I've missed some that are necessary, please let me know, and I'll add them in.

### Potential Improvements

I know some package management systems have the option to have more verbose output and include things like version, late date updated etc. For this pr, I just did the bare minimum to ensure the way I was approaching it was correct. If you think some of these additional options are a good idea, I can look into including them as well, but I figured this would be a good start.

### Tests

I didn't notice explicit tests for some of the other commands, was I correct in assuming there isn't?

Closes #1651