### PR TITLE
Change space to newline in list output

### DIFF
--- a/modules/cli/src/main/scala/coursier/cli/install/List.scala
+++ b/modules/cli/src/main/scala/coursier/cli/install/List.scala
@@ -8,6 +8,6 @@ object List extends CaseApp[ListOptions] {
   def run(options: ListOptions, args: RemainingArgs): Unit = {
     val params = ListParams(options)
     val names = Updatable.list(params.installPath)
-    System.err.println(names.mkString(" "))
+    System.err.println(names.mkString("\n"))
   }
 }


### PR DESCRIPTION
Change the output of list to be seperated by a new line rather than a space.

New output:

```sh
❯ modules/cli/target/pack/bin/coursier list
amm
coursier
cs
mdoc
metac
metap
mill
sbt
scala
scalac
scalafmt
```