### PR TITLE
Use cs instead of coursier in CLI examples in docs

### DIFF
--- a/doc/docs/cli-bootstrap.md
+++ b/doc/docs/cli-bootstrap.md
@@ -215,7 +215,7 @@ sources is an option for you.
 `bootstrap` can generate
 [Scala Native](https://www.scala-native.org)-based native launchers:
 ```bash
-$ coursier bootstrap echo-native -o echo --native
+$ cs bootstrap echo-native -o echo --native
 [info] Linking (1457 ms)
 [info] Discovered 614 classes and 4200 methods
 [info] Optimizing (debug mode) (2157 ms)

--- a/doc/docs/cli-installation.md
+++ b/doc/docs/cli-installation.md
@@ -4,9 +4,6 @@ title: Installation
 
 ## Native launcher
 
-> The commands below install the native launcher as `cs`, which can be
-substituted to `coursier` in the various examples on this website.
-
 ### Linux
 
 On Linux, download and run the coursier launcher with
@@ -46,6 +43,9 @@ On Windows, use
 
 In case you run into any issue with the [native launcher](#native-launcher),
 a JAR-based launcher is available.
+
+> The commands below install the JAR-based launcher as `coursier`, which can be
+substituted to `cs` in the various examples on this website.
 
 ### Linux / macOS
 

--- a/doc/docs/cli-launch.md
+++ b/doc/docs/cli-launch.md
@@ -19,7 +19,7 @@ Usage: scalafmt [options] [<file>...]
 Pass arguments to the launched program, by adding `--` after the coursier
 arguments, like
 ```bash
-$ coursier launch org.scalameta::scalafmt-cli:2.4.2 -- --version
+$ cs launch org.scalameta::scalafmt-cli:2.4.2 -- --version
 ```
 
 ## Main class

--- a/doc/docs/extra.md
+++ b/doc/docs/extra.md
@@ -8,7 +8,7 @@ title: Extra
 
 E.g. to print the dependency tree of `io.circe:circe-core:0.4.1`,
 ```
-$ coursier resolve -t io.circe:circe-core_2.11:0.4.1
+$ cs resolve -t io.circe:circe-core_2.11:0.4.1
   Result:
 └─ io.circe:circe-core_2.11:0.4.1
    ├─ io.circe:circe-numbers_2.11:0.4.1
@@ -48,7 +48,7 @@ They highlight in red version bumps that may not be binary compatible, changing 
 
 The `coursier bootstrap` command generates tiny bootstrap launchers (~30 kB). These are able to download their dependencies upon first launch, then launch the corresponding application. E.g. to generate a launcher for scalafmt,
 ```
-$ coursier bootstrap com.geirsson:scalafmt-cli_2.11:0.2.3 -o scalafmt
+$ cs bootstrap com.geirsson:scalafmt-cli_2.11:0.2.3 -o scalafmt
 ```
 
 This generates a `scalafmt` file, which is a tiny JAR, corresponding to the `bootstrap` sub-project of coursier. It contains resource files, with the URLs of the various dependencies of scalafmt. On first launch, these are downloaded under `~/.coursier/bootstrap/com.geirsson/scalafmt-cli_2.11` (following the organization and name of the first dependency - note that this directory can be changed with the `-D` option). Nothing needs to be downloaded once all the dependencies are there, and the application is then launched straightaway.
@@ -57,7 +57,7 @@ This generates a `scalafmt` file, which is a tiny JAR, corresponding to the `boo
 
 To use artifacts from repositories requiring credentials, pass the user and password via the repository URL, like
 ```
-$ coursier fetch -r https://user:pass@company.com/repo com.company:lib:0.1.0
+$ cs fetch -r https://user:pass@company.com/repo com.company:lib:0.1.0
 ```
 
 From sbt, add the setting `coursierUseSbtCredentials := true` for sbt-coursier to use the credentials set via the `credentials` key. This manual step was added in order for the `credentials` setting not to be checked if not needed, as it seems to acquire some (good ol') global lock when checked, which sbt-coursier aims at avoiding.

--- a/doc/docs/other-credentials.md
+++ b/doc/docs/other-credentials.md
@@ -18,7 +18,7 @@ $ export COURSIER_CREDENTIALS="
     artifacts.foo.com(the realm) alex:my-pass
     oss.sonatype.org alex-sonatype:aLeXsOnAtYpE
 "
-$ coursier fetch -r https://artifacts.foo.com/maven …
+$ cs fetch -r https://artifacts.foo.com/maven …
 ```
 
 It should contain lines like
@@ -34,7 +34,7 @@ are ignored too.
 From the CLI, you can also pass those explicitly via the `--credentials` option,
 like
 ```bash
-$ coursier fetch -r https://artifacts.foo.com/maven \
+$ cs fetch -r https://artifacts.foo.com/maven \
     --credentials "artifacts.foo.com(the realm) alex:my-pass" \
     --credentials "oss.sonatype.org alex-sonatype:aLeXsOnAtYpE" \
     …
@@ -94,7 +94,7 @@ if that's a possibility.
 
 The CLI still accepts credentials passed along specific repositories, like
 ```bash
-$ coursier fetch -r https://user:password@artifacts.foo.com/maven …
+$ cs fetch -r https://user:password@artifacts.foo.com/maven …
 ```
 
 The API accept those too, when creating a repository, for example,

--- a/doc/docs/other-repositories.md
+++ b/doc/docs/other-repositories.md
@@ -18,13 +18,13 @@ $ export COURSIER_REPOSITORIES="ivy2Local|central|sonatype:releases|jitpack|http
 From the CLI, one can add extra repositories to a particular command with the
 `-r` option, like
 ```bash
-$ coursier fetch -r jitpack sh.almond:scala-kernel_2.12.8:0.2.2
+$ cs fetch -r jitpack sh.almond:scala-kernel_2.12.8:0.2.2
 ```
 
 One can ignore the default repositories above or the ones from
 `COURSIER_REPOSITORIES` by passing `--no-default`, like
 ```bash
-$ coursier fetch --no-default \
+$ cs fetch --no-default \
   -r central -r sonatype:snapshots \
   org.scalameta:scalafmt-cli_2.12:2.0.0-RC4+29-f2154330-SNAPSHOT
 ```


### PR DESCRIPTION
Only remaining 'coursier' use: proxy setup, which requires the JVM launcher…