### PR TITLE
Fix broken website links

### DIFF
--- a/doc/docs/cli-install.md
+++ b/doc/docs/cli-install.md
@@ -469,7 +469,7 @@ Specifies the type of launcher that should be built for this application. Can be
 - `bootstrap`: builds a bootstrap as built by the `bootstrap` command by default
 - `assembly`: builds an assembly (corresponds to the `--assembly` option of the `bootstrap` command)
 - `standalone`: builds a bootstrap embedding its JAR dependencies as resources (corresponds to the `--standalone` option of the `bootstrap` command - these JARs are similar to the ones [one-jar](http://one-jar.sourceforge.net) builds)
-- `scala-native`: builds a Scala Native application (requires the right [environment setup](https://scala-native.readthedocs.io/en/v0.3.9-docs/user/setup.html), and requires coursier to be started via its [JAR-based launcher](cli-overview.md#install-jar-based-launcher) for now)
+- `scala-native`: builds a Scala Native application (requires the right [environment setup](https://scala-native.readthedocs.io/en/v0.3.9-docs/user/setup.html), and requires coursier to be started via its [JAR-based launcher](cli-installation.md#jar-based-launcher) for now)
 - `graalvm-native-image`: builds a GraalVM native image
 
 #### `mainClass`

--- a/doc/docs/cli-overview.md
+++ b/doc/docs/cli-overview.md
@@ -11,7 +11,7 @@ The CLI of coursier has a number of commands to deal with dependencies and artif
 - `java` and `java-home` [install, run, and get the home directory of JVMs](#java),
 - `setup` [checks if your system has a JVM and the standard Scala applications](#setup), and installs them if needed.
 
-See [Installation](#cli-installation.md) for how to install the
+See [Installation](cli-installation.md) for how to install the
 CLI of coursier.
 
 This page succinctly describes each of these commands. More

--- a/doc/docs/other-credentials.md
+++ b/doc/docs/other-credentials.md
@@ -5,7 +5,7 @@ title: Credentials
 Credentials can be passed either:
 - [inline](#inline), via the `COURSIER_CREDENTIALS` environment variable or the `coursier.credentials` Java property,
 - via [a property file](#property-file), or
-- [per repository](#per-repository), the former / legacy way (which suffers some limitations).
+- [per host](#per-host), the former / legacy way (which suffers some limitations).
 
 ## Inline
 


### PR DESCRIPTION
This PR fixes links on the website. 

This fixes all warnings raised by running `sbt docs/mdoc` (except for one warning about `../demo` being an unknown link, which is a false positive).