### PR TITLE
Delete lockfile explicitly

### DIFF
--- a/modules/cache/jvm/src/main/scala/coursier/cache/CacheLocks.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/CacheLocks.scala
@@ -41,8 +41,7 @@ object CacheLocks {
       channel = FileChannel.open(
         lockFile,
         StandardOpenOption.CREATE,
-        StandardOpenOption.WRITE,
-        StandardOpenOption.DELETE_ON_CLOSE
+        StandardOpenOption.WRITE
       )
     }
 
@@ -62,6 +61,7 @@ object CacheLocks {
               lock = null
               channel.close()
               channel = null
+              Files.deleteIfExists(lockFile)
             }
         }
         catch {


### PR DESCRIPTION
This partially reverts the changes introduced in 344f6e73c10cf161c25a5878d6db9cce470e02b0 (between 2.0.0-RC6-1 and 2.0.0-RC6-2). Specifically, it reverts back to explicitly deleting lockfiles from caches, rather than relying on the DELETE_ON_CLOSE channel option.

It solves a concurrent download bug in mill and unblocks this PR https://github.com/lihaoyi/mill/pull/858. I'm not exactly sure why this change fixes the issue, but this is what I found after many hours of bisecting. Note that it is not sufficient to explicitly delete the file in the finally block, but that the DELETE_ON_CLOSE must not be used as it somehow interferes.