### PR TITLE
Install 'sbt' rather than 'sbt-launcher'

### DIFF
--- a/modules/cli/src/main/scala/coursier/cli/setup/DefaultAppList.scala
+++ b/modules/cli/src/main/scala/coursier/cli/setup/DefaultAppList.scala
@@ -9,7 +9,7 @@ object DefaultAppList {
       "coursier",
       "scala",
       "scalac",
-      "sbt-launcher",
+      "sbt",
       "scalafmt"
     )
 


### PR DESCRIPTION
The former relies on the offical sbt launcher (sbt/launcher), rather than on the coursier one (coursier/sbt-launcher).

Fixes https://github.com/coursier/coursier/issues/1714.