### PR TITLE
Replace all calls to `sys.env.get` by `Option(System.getenv(…))`

### DIFF
--- a/modules/cache/jvm/src/main/scala/coursier/cache/CacheDefaults.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/CacheDefaults.scala
@@ -59,7 +59,7 @@ object CacheDefaults {
       }
 
   lazy val ttl: Option[Duration] = {
-    val fromEnv = sys.env.get("COURSIER_TTL").flatMap(parseDuration(_).toOption)
+    val fromEnv = Option(System.getenv("COURSIER_TTL")).flatMap(parseDuration(_).toOption)
     def fromProps = sys.props.get("coursier.ttl").flatMap(parseDuration(_).toOption)
     def default = 24.hours
 
@@ -97,7 +97,7 @@ object CacheDefaults {
   val bufferSize = 1024 * 1024
 
   private def credentialPropOpt =
-    sys.env.get("COURSIER_CREDENTIALS")
+    Option(System.getenv("COURSIER_CREDENTIALS"))
       .orElse(sys.props.get("coursier.credentials"))
       .map(s => s.dropWhile(_.isSpaceChar))
 
@@ -169,7 +169,7 @@ object CacheDefaults {
       }
 
     val fromEnv = fromOption(
-      sys.env.get("COURSIER_MODE"),
+      Option(System.getenv("COURSIER_MODE")),
       "COURSIER_MODE environment variable"
     )
 

--- a/modules/cli/src/main/scala/coursier/cli/install/ShellUtil.scala
+++ b/modules/cli/src/main/scala/coursier/cli/install/ShellUtil.scala
@@ -3,7 +3,7 @@ package coursier.cli.install
 object ShellUtil {
 
   def rcFileOpt: Option[String] =
-    sys.env.get("SHELL").map(_.split('/').last).flatMap {
+    Option(System.getenv("SHELL")).map(_.split('/').last).flatMap {
       case "zsh" => Some("~/.zshrc")
       case "bash" => Some("~/.bashrc")
       case _ => None

--- a/modules/cli/src/main/scala/coursier/cli/native/NativeLauncherOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/native/NativeLauncherOptions.scala
@@ -62,7 +62,7 @@ final case class NativeLauncherOptions(
     val prependDefaultLinkingOptions = nativeDefaultLinkingOptions
     val linkingOptions = {
       val ldflags =
-        if (nativeUseLdflags) sys.env.get("LDFLAGS").toSeq.flatMap(_.split("\\s+"))
+        if (nativeUseLdflags) Option(System.getenv("LDFLAGS")).toSeq.flatMap(_.split("\\s+"))
         else Nil
       ldflags ++ nativeLinkingOption
     }

--- a/modules/cli/src/main/scala/coursier/cli/params/OutputParams.scala
+++ b/modules/cli/src/main/scala/coursier/cli/params/OutputParams.scala
@@ -26,7 +26,7 @@ final case class OutputParams(
         else
           RefreshLogger.defaultDisplay(
             loggerFallbackMode,
-            quiet = verbosity == -1 || sys.env.contains("CI")
+            quiet = verbosity == -1 || Option(System.getenv("CI")).nonEmpty
           )
       )
     else

--- a/modules/cli/src/main/scala/coursier/cli/publish/params/RepositoryParams.scala
+++ b/modules/cli/src/main/scala/coursier/cli/publish/params/RepositoryParams.scala
@@ -82,7 +82,7 @@ object RepositoryParams {
         ghTokenOpt match {
           case Some(token) => Validated.validNel(token)
           case None =>
-            sys.env.get("GH_TOKEN") match {
+            Option(System.getenv("GH_TOKEN")) match {
               case Some(token) => Validated.validNel(token)
               case None => Validated.invalidNel("No GitHub token specified")
             }
@@ -128,7 +128,7 @@ object RepositoryParams {
 
     val repositoryV =
       options.github.map(fromGitHub)
-        .orElse(options.bintray.map(fromBintray(_, options.bintrayApiKey.orElse(sys.env.get("BINTRAY_API_KEY")))))
+        .orElse(options.bintray.map(fromBintray(_, options.bintrayApiKey.orElse(Option(System.getenv("BINTRAY_API_KEY"))))))
         .getOrElse {
           if (sonatype)
             fromSonatype
@@ -138,11 +138,11 @@ object RepositoryParams {
 
 
     def authFromEnv(userVar: String, passVar: String) = {
-      val userV = sys.env.get(userVar) match {
+      val userV = Option(System.getenv(userVar)) match {
         case None => Validated.invalidNel(s"User environment variable $userVar not set")
         case Some(u) => Validated.validNel(u)
       }
-      val passV = sys.env.get(passVar) match {
+      val passV = Option(System.getenv(passVar)) match {
         case None => Validated.invalidNel(s"Password environment variable $passVar not set")
         case Some(u) => Validated.validNel(u)
       }
@@ -179,7 +179,7 @@ object RepositoryParams {
             }
           else {
             val varName = s.stripPrefix("env:")
-            sys.env.get(varName) match {
+            Option(System.getenv(varName)) match {
               case None =>
                 Validated.invalidNel(s"Authentication environment variable $varName not set")
               case Some(v) =>

--- a/modules/cli/src/main/scala/coursier/cli/publish/sonatype/SonatypeParams.scala
+++ b/modules/cli/src/main/scala/coursier/cli/publish/sonatype/SonatypeParams.scala
@@ -49,7 +49,7 @@ object SonatypeParams {
 
     val authV = (options.user, options.password) match {
       case (None, None) =>
-        (sys.env.get("SONATYPE_USERNAME"), sys.env.get("SONATYPE_PASSWORD")) match {
+        (Option(System.getenv("SONATYPE_USERNAME")), Option(System.getenv("SONATYPE_PASSWORD"))) match {
           case (Some(u), Some(p)) =>
             Validated.validNel(Some(Authentication(u, p)))
           case _ =>

--- a/modules/cli/src/main/scala/coursier/cli/util/Guard.scala
+++ b/modules/cli/src/main/scala/coursier/cli/util/Guard.scala
@@ -3,7 +3,7 @@ package coursier.cli.util
 object Guard {
   def apply(): Unit = {
     val experimental =
-      sys.env.get("COURSIER_EXPERIMENTAL").exists(s => s == "1" || s == "true") ||
+      Option(System.getenv("COURSIER_EXPERIMENTAL")).exists(s => s == "1" || s == "true") ||
         java.lang.Boolean.getBoolean("coursier.experimental")
     if (!experimental) {
       System.err.println(

--- a/modules/coursier/jvm/src/it/scala/coursier/AuthenticationTests.scala
+++ b/modules/coursier/jvm/src/it/scala/coursier/AuthenticationTests.scala
@@ -11,9 +11,9 @@ import utest._
 
 object AuthenticationTests extends TestSuite {
 
-  private val testRepo = sys.env.getOrElse("TEST_REPOSITORY", sys.error("TEST_REPOSITORY not set"))
-  private val user = sys.env.getOrElse("TEST_REPOSITORY_USER", sys.error("TEST_REPOSITORY_USER not set"))
-  private val password = sys.env.getOrElse("TEST_REPOSITORY_PASSWORD", sys.error("TEST_REPOSITORY_PASSWORD not set"))
+  private val testRepo = Option(System.getenv("TEST_REPOSITORY")).getOrElse(sys.error("TEST_REPOSITORY not set"))
+  private val user = Option(System.getenv("TEST_REPOSITORY_USER")).getOrElse(sys.error("TEST_REPOSITORY_USER not set"))
+  private val password = Option(System.getenv("TEST_REPOSITORY_PASSWORD")).getOrElse(sys.error("TEST_REPOSITORY_PASSWORD not set"))
 
   private val testHost = new URI(testRepo).getHost
 

--- a/modules/coursier/jvm/src/main/scala/coursier/PlatformResolve.scala
+++ b/modules/coursier/jvm/src/main/scala/coursier/PlatformResolve.scala
@@ -37,8 +37,7 @@ abstract class PlatformResolve {
       }
     }
 
-    val fromEnvOpt = sys.env
-      .get("COURSIER_REPOSITORIES")
+    val fromEnvOpt = Option(System.getenv("COURSIER_REPOSITORIES"))
       .filter(_.nonEmpty)
       .flatMap(fromString(_, "environment variable COURSIER_REPOSITORIES"))
 

--- a/modules/coursier/jvm/src/test/scala/coursier/PlatformTestHelpers.scala
+++ b/modules/coursier/jvm/src/test/scala/coursier/PlatformTestHelpers.scala
@@ -35,8 +35,7 @@ abstract class PlatformTestHelpers {
     .toASCIIString
     .stripSuffix("/") + "/"
 
-  val writeMockData = sys.env
-    .get("FETCH_MOCK_DATA")
+  val writeMockData = Option(System.getenv("FETCH_MOCK_DATA"))
     .exists(s => s == "1" || s.toLowerCase(Locale.ROOT) == "true")
 
   val cache: Cache[Task] =

--- a/modules/install/src/test/scala/coursier/install/InstallTests.scala
+++ b/modules/install/src/test/scala/coursier/install/InstallTests.scala
@@ -26,8 +26,7 @@ class InstallTests extends AnyFlatSpec with BeforeAndAfterAll {
     dir
   }
 
-  private val writeMockData = sys.env
-    .get("FETCH_MOCK_DATA")
+  private val writeMockData = Option(System.getenv("FETCH_MOCK_DATA"))
     .exists(s => s == "1" || s.toLowerCase(Locale.ROOT) == "true")
 
   private val cache: Cache[Task] =

--- a/modules/tests/jvm/src/it/scala/coursier/test/DirectoryListingTests.scala
+++ b/modules/tests/jvm/src/it/scala/coursier/test/DirectoryListingTests.scala
@@ -7,11 +7,13 @@ import utest._
 
 object DirectoryListingTests extends TestSuite {
 
-  val user = sys.env("TEST_REPOSITORY_USER")
-  val password = sys.env("TEST_REPOSITORY_PASSWORD")
+  val user = Option(System.getenv("TEST_REPOSITORY_USER"))
+    .getOrElse(sys.error("TEST_REPOSITORY_USER not set"))
+  val password = Option(System.getenv("TEST_REPOSITORY_PASSWORD"))
+    .getOrElse(sys.error("TEST_REPOSITORY_PASSWORD not set"))
 
   val repo = MavenRepository(
-    sys.env.getOrElse("TEST_REPOSITORY", sys.error("TEST_REPOSITORY not set")),
+    Option(System.getenv("TEST_REPOSITORY")).getOrElse(sys.error("TEST_REPOSITORY not set")),
     authentication = Some(Authentication(user, password))
   )
 

--- a/modules/tests/jvm/src/it/scala/coursier/test/HttpAuthenticationTests.scala
+++ b/modules/tests/jvm/src/it/scala/coursier/test/HttpAuthenticationTests.scala
@@ -10,9 +10,12 @@ object HttpAuthenticationTests extends TestSuite {
   val tests = Tests {
     'httpAuthentication - {
 
-      val testRepo = sys.env.getOrElse("TEST_REPOSITORY", sys.error("TEST_REPOSITORY not set"))
-      val user = sys.env.getOrElse("TEST_REPOSITORY_USER", sys.error("TEST_REPOSITORY_USER not set"))
-      val password = sys.env.getOrElse("TEST_REPOSITORY_PASSWORD", sys.error("TEST_REPOSITORY_PASSWORD not set"))
+      val testRepo = Option(System.getenv("TEST_REPOSITORY"))
+        .getOrElse(sys.error("TEST_REPOSITORY not set"))
+      val user = Option(System.getenv("TEST_REPOSITORY_USER"))
+        .getOrElse(sys.error("TEST_REPOSITORY_USER not set"))
+      val password = Option(System.getenv("TEST_REPOSITORY_PASSWORD"))
+        .getOrElse(sys.error("TEST_REPOSITORY_PASSWORD not set"))
 
       * - {
         // no authentication -> should fail

--- a/modules/tests/jvm/src/it/scala/coursier/test/HttpHttpsRedirectionTests.scala
+++ b/modules/tests/jvm/src/it/scala/coursier/test/HttpHttpsRedirectionTests.scala
@@ -8,7 +8,8 @@ object HttpHttpsRedirectionTests extends TestSuite {
 
   val tests = Tests {
 
-    val testRepo = sys.env.getOrElse("TEST_REDIRECT_REPOSITORY", sys.error("TEST_REDIRECT_REPOSITORY not set"))
+    val testRepo = Option(System.getenv("TEST_REDIRECT_REPOSITORY"))
+      .getOrElse(sys.error("TEST_REDIRECT_REPOSITORY not set"))
     val deps = Seq(Dependency(mod"com.chuusai:shapeless_2.12", "2.3.2"))
 
     // typer error in 2.11.12 if we make that a lazy val

--- a/modules/tests/jvm/src/test/scala/coursier/test/compatibility/package.scala
+++ b/modules/tests/jvm/src/test/scala/coursier/test/compatibility/package.scala
@@ -35,7 +35,8 @@ package object compatibility {
     dir
   }
 
-  private val fillChunks = sys.env.get("FETCH_MOCK_DATA").exists(s => s == "1" || s == "true")
+  private val fillChunks = Option(System.getenv("FETCH_MOCK_DATA"))
+    .exists(s => s == "1" || s == "true")
 
   def artifact[F[_]: Sync]: Repository.Fetch[F] =
     MockCache.create[F](baseRepo, writeMissing = fillChunks, pool = pool).fetch

--- a/project/ScalaVersionPlugin.scala
+++ b/project/ScalaVersionPlugin.scala
@@ -19,7 +19,7 @@ object ScalaVersionPlugin extends AutoPlugin {
         }
     },
     commands += Command("scalaFromEnv")(_ => Parser.success(())) { (st, _) =>
-      val sv = sys.env.get("SCALA_VERSION") match {
+      val sv = Option(System.getenv("SCALA_VERSION")) match {
         case None =>
           throw new Exception("SCALA_VERSION not set")
         case Some(s) if s.count(_ == '.') == 1 =>


### PR DESCRIPTION
The latter is case-insensitive on Windows, as expected, unlike `sys.env.get`.