### PR TITLE
Fix rare IllegalArgumentException: toMillis not allowed

### DIFF
--- a/modules/cache/jvm/src/main/scala/coursier/cache/FileCache.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/FileCache.scala
@@ -245,7 +245,7 @@ import dataclass.data
             else if (cacheErrors && errFile0.exists()) {
               val ts = errFile0.lastModified()
               val now = System.currentTimeMillis()
-              if (ts > 0L && now < ts + ttl.fold(0L)(_.toMillis))
+              if (ts > 0L && (ttl.exists(!_.isFinite) || now < ts + ttl.fold(0L)(_.toMillis)))
                 Left(new ArtifactError.NotFound(url))
               else
                 Right(())


### PR DESCRIPTION
Happens sometimes with `--ttl Inf`, which became the default in `2.0.0-RC6-22` when an application name rather than Maven coordinates is passed on the command-line.