### PR TITLE
Cache computed digests in auxiliary files along with downloaded files #1675

### DIFF
--- a/modules/cache/jvm/src/test/scala-2.12/coursier/cache/FileCacheTests.scala
+++ b/modules/cache/jvm/src/test/scala-2.12/coursier/cache/FileCacheTests.scala
@@ -3,7 +3,8 @@ package coursier.cache
 import java.io.File
 import java.net.URI
 import java.nio.charset.StandardCharsets
-import java.nio.file.Files
+import java.nio.file.{Files, Paths}
+import java.util
 
 import cats.effect.IO
 import coursier.cache.TestUtil._
@@ -1022,6 +1023,79 @@ object FileCacheTests extends TestSuite {
         assert(res.left.exists(_.contains("java.net.UnknownHostException")))
       }
     }
+
+    "stored digests work" - {
+      val dummyFileUri = Option(getClass.getResource("/data/foo.xml"))
+        .map(_.toURI.toASCIIString)
+        .getOrElse {
+          throw new Exception("data/foo.xml resource not found")
+        }
+
+      val artifact = Artifact(
+        dummyFileUri,
+        Map(
+          "SHA-512" -> s"$dummyFileUri.sha512", // should not exist
+          "SHA-256" -> s"$dummyFileUri.sha256", // should not exist
+          "SHA-1" -> s"$dummyFileUri.sha1",
+          "MD5" -> s"$dummyFileUri.md5"
+        ),
+        Map(),
+        changing = false,
+        optional = false,
+        None
+      )
+
+      * - async {
+        val res = await {
+          FileCache()
+            .withChecksums(Seq(Some("SHA-1")))
+            .file(artifact)
+            .run
+            .future()
+        }
+        res match {
+          case Right(file: File) =>
+            val computedPath = Paths.get(s"${file.getParent}/.${file.getName}__sha1.computed")
+            val expected = stringToByteArray("f9627d29027e5a853b65242cfbbb44f354f3836f")
+            val actual = Files.readAllBytes(computedPath)
+            assert(util.Arrays.equals(actual, expected))
+          case Left(e) => throw e
+        }
+      }
+      * - async {
+        val res = await {
+          FileCache()
+            .withChecksums(Seq(Some("MD5")))
+            .file(artifact)
+            .run
+            .future()
+        }
+        res match {
+          case Right(file: File) =>
+            val computedPath = Paths.get(s"${file.getParent}/.${file.getName}__md5.computed")
+            val expected = stringToByteArray("001717e73bca14e4fb2df3cabd6eac98")
+            val actual = Files.readAllBytes(computedPath)
+            assert(util.Arrays.equals(actual, expected))
+          case Left(e) => throw e
+        }
+      }
+    }
   }
 
+  // https://stackoverflow.com/questions/6650650/hex-encoded-string-to-byte-array/28157958#28157958
+  def stringToByteArray(s: String): Array[Byte] = {
+    val byteArray = new Array[Byte](s.length / 2)
+    val strBytes = new Array[String](s.length / 2)
+    var k = 0
+    var i = 0
+    while (i < s.length) {
+      val j = i + 2
+      strBytes(k) = s.substring(i, j)
+      byteArray(k) = Integer.parseInt(strBytes(k), 16).toByte
+      k += 1
+
+      i = i + 2
+    }
+    byteArray
+  }
 }

--- a/modules/cli/src/test/scala/coursier/cli/FetchTests.scala
+++ b/modules/cli/src/test/scala/coursier/cli/FetchTests.scala
@@ -1045,6 +1045,9 @@ object FetchTests extends TestSuite {
         val junitPomFile = runFetchJunit()
         val originalPomContent = Files.readAllBytes(junitPomFile)
 
+        // Corrupt the pom content
+        Files.write(junitPomFile, "bad pom".getBytes(UTF_8))
+
         // Corrupt the content of the calculated pom checksum
         val storedDigestFile = FileCache.auxiliaryFile(junitPomFile.toFile, "SHA-1.computed").toPath
         Files.write(storedDigestFile, Array[Byte](1, 2, 3))
@@ -1112,6 +1115,9 @@ object FetchTests extends TestSuite {
 
         val originalJunitJar = runFetchJunit()
         val originalJunitJarContent = Files.readAllBytes(originalJunitJar)
+
+        // Corrupt the jar content
+        Files.write(originalJunitJar, "bad jar".getBytes(UTF_8))
 
         // Corrupt the content of the calculated jar checksum
         val storedDigestFile = FileCache.auxiliaryFile(originalJunitJar.toFile, "SHA-1.computed").toPath

--- a/modules/cli/src/test/scala/coursier/cli/FetchTests.scala
+++ b/modules/cli/src/test/scala/coursier/cli/FetchTests.scala
@@ -1045,8 +1045,9 @@ object FetchTests extends TestSuite {
         val junitPomFile = runFetchJunit()
         val originalPomContent = Files.readAllBytes(junitPomFile)
 
-        // Corrupt the pom content
-        Files.write(junitPomFile, "bad pom".getBytes(UTF_8))
+        // Corrupt the content of the calculated pom checksum
+        val storedDigestFile = FileCache.auxiliaryFile(junitPomFile.toFile, "SHA-1.computed").toPath
+        Files.write(storedDigestFile, Array[Byte](1, 2, 3))
 
         // Run fetch again and it should pass because of retrying om the bad pom.
         val pom = runFetchJunit()
@@ -1112,8 +1113,9 @@ object FetchTests extends TestSuite {
         val originalJunitJar = runFetchJunit()
         val originalJunitJarContent = Files.readAllBytes(originalJunitJar)
 
-        // Corrupt the jar content
-        Files.write(originalJunitJar, "bad jar".getBytes(UTF_8))
+        // Corrupt the content of the calculated jar checksum
+        val storedDigestFile = FileCache.auxiliaryFile(originalJunitJar.toFile, "SHA-1.computed").toPath
+        Files.write(storedDigestFile, Array[Byte](1,2,3))
 
         // Run fetch again and it should pass because of retrying on the bad jar.
         val jar = runFetchJunit()


### PR DESCRIPTION
So this is a first take. I did try it locally when developing it, and it did shave a few seconds off resolve time for the benchmark project.

I have a few doubts about this implementation:
- It currently writes binary files, which is unnoticeably faster and somewhat easier to write, but they cant be `cat`ed on the command line. I'll change to a textual format if you think it's a problem
- I wanted to look closer at performance before submitting, but like you said it shouldn't make things slower. I went with an exception-based approach instead of something like `if (exists(cachedFile)) readFile()`. Performing IO twice in the common path (cached files exists) seemed slower in the profiler. There is quite a bit of overhead also from reading all the small files, an improvement down the line might be to save all computed digests in a central place.
- You'll be a better judge of this than me, but I tried a lockless approach with atomic files moves, where last thread to compute the digests "wins". As far as I can see this should be fast and safe, but I'll add back locking if you think it's necessary.

Take this from here however you like, you can brush up the code after merge or I'll do it if you point out what you don't like.

