### PR TITLE
Don't re-download JVM index when not necessary

### DIFF
--- a/modules/cli/src/main/scala/coursier/cli/install/Install.scala
+++ b/modules/cli/src/main/scala/coursier/cli/install/Install.scala
@@ -14,6 +14,8 @@ import coursier.launcher.internal.Windows
 import coursier.paths.Util
 import coursier.util.Sync
 
+import scala.concurrent.duration.Duration
+
 object Install extends CaseApp[InstallOptions] {
 
   def run(options: InstallOptions, args: RemainingArgs): Unit = {
@@ -31,9 +33,10 @@ object Install extends CaseApp[InstallOptions] {
 
     val pool = Sync.fixedThreadPool(params.cache.parallel)
     val cache = params.cache.cache(pool, params.output.logger())
+    val noUpdateCoursierCache = params.cache.cache(pool, params.output.logger(), overrideTtl = Some(Duration.Inf))
 
     val graalvmHome = { version: String =>
-      params.sharedJava.javaHome(cache, params.output.verbosity)
+      params.sharedJava.javaHome(cache, noUpdateCoursierCache, params.output.verbosity)
         .get(s"graalvm:$version")
     }
 

--- a/modules/cli/src/main/scala/coursier/cli/install/Update.scala
+++ b/modules/cli/src/main/scala/coursier/cli/install/Update.scala
@@ -7,6 +7,8 @@ import caseapp.core.RemainingArgs
 import coursier.install.{Channels, InstallDir, Updatable}
 import coursier.util.{Sync, Task}
 
+import scala.concurrent.duration.Duration
+
 object Update extends CaseApp[UpdateOptions] {
   def run(options: UpdateOptions, args: RemainingArgs): Unit = {
 
@@ -28,9 +30,10 @@ object Update extends CaseApp[UpdateOptions] {
 
     val pool = Sync.fixedThreadPool(params.cache.parallel)
     val cache = params.cache.cache(pool, params.output.logger())
+    val noUpdateCoursierCache = params.cache.cache(pool, params.output.logger(), overrideTtl = Some(Duration.Inf))
 
     val graalvmHome = { version: String =>
-      params.sharedJava.javaHome(cache, params.output.verbosity)
+      params.sharedJava.javaHome(cache, noUpdateCoursierCache, params.output.verbosity)
         .get(s"graalvm:$version")
     }
 

--- a/modules/cli/src/main/scala/coursier/cli/jvm/Java.scala
+++ b/modules/cli/src/main/scala/coursier/cli/jvm/Java.scala
@@ -12,6 +12,8 @@ import coursier.jvm.{Execve, JvmCache, JvmCacheLogger}
 import coursier.launcher.internal.Windows
 import coursier.util.{Sync, Task}
 
+import scala.concurrent.duration.Duration
+
 object Java extends CaseApp[JavaOptions] {
   override def stopAtFirstUnrecognized = true
   def run(options: JavaOptions, args: RemainingArgs): Unit = {
@@ -34,8 +36,9 @@ object Java extends CaseApp[JavaOptions] {
     val pool = Sync.fixedThreadPool(params.cache.parallel)
     val logger = params.output.logger()
     val coursierCache = params.cache.cache(pool, logger)
+    val noUpdateCoursierCache = params.cache.cache(pool, logger, overrideTtl = Some(Duration.Inf))
 
-    val (jvmCache, javaHome) = params.shared.cacheAndHome(coursierCache, params.output.verbosity)
+    val (jvmCache, javaHome) = params.shared.cacheAndHome(coursierCache, noUpdateCoursierCache, params.output.verbosity)
 
     if (params.installed) {
       val task =

--- a/modules/cli/src/main/scala/coursier/cli/jvm/JavaHome.scala
+++ b/modules/cli/src/main/scala/coursier/cli/jvm/JavaHome.scala
@@ -11,6 +11,8 @@ import coursier.jvm.{JvmCache, JvmCacheLogger}
 import coursier.launcher.internal.Windows
 import coursier.util.{Sync, Task}
 
+import scala.concurrent.duration.Duration
+
 object JavaHome extends CaseApp[JavaHomeOptions] {
 
   def run(options: JavaHomeOptions, args: RemainingArgs): Unit = {
@@ -20,8 +22,9 @@ object JavaHome extends CaseApp[JavaHomeOptions] {
     val pool = Sync.fixedThreadPool(params.cache.parallel)
     val logger = params.output.logger()
     val coursierCache = params.cache.cache(pool, logger)
+    val noUpdateCoursierCache = params.cache.cache(pool, logger, overrideTtl = Some(Duration.Inf))
 
-    val (jvmCache, javaHome) = params.shared.cacheAndHome(coursierCache, params.output.verbosity)
+    val (jvmCache, javaHome) = params.shared.cacheAndHome(coursierCache, noUpdateCoursierCache, params.output.verbosity)
     val task = javaHome.getWithRetainedId(params.shared.id)
 
     logger.init()

--- a/modules/cli/src/main/scala/coursier/cli/jvm/SharedJavaParams.scala
+++ b/modules/cli/src/main/scala/coursier/cli/jvm/SharedJavaParams.scala
@@ -20,21 +20,26 @@ final case class SharedJavaParams(
   def id: String =
     jvm.getOrElse(coursier.jvm.JavaHome.defaultId)
 
-  def cacheAndHome(cache: Cache[Task], verbosity: Int): (JvmCache, coursier.jvm.JavaHome) = {
+  def cacheAndHome(cache: Cache[Task], noUpdateCache: Cache[Task], verbosity: Int): (JvmCache, coursier.jvm.JavaHome) = {
+    val noUpdateJvmCache = JvmCache()
+      .withBaseDirectory(jvmDir.toFile)
+      .withCache(noUpdateCache)
+      .withDefaultIndex
     val jvmCache = JvmCache()
       .withBaseDirectory(jvmDir.toFile)
       .withCache(cache)
       .withDefaultIndex
     val javaHome = coursier.jvm.JavaHome()
       .withCache(jvmCache)
+      .withNoUpdateCache(Some(noUpdateJvmCache))
       .withJvmCacheLogger(jvmCacheLogger(verbosity))
       .withAllowSystem(allowSystemJvm)
       .withInstallIfNeeded(!localOnly)
       .withUpdate(update)
     (jvmCache, javaHome)
   }
-  def javaHome(cache: Cache[Task], verbosity: Int): coursier.jvm.JavaHome = {
-    val (_, home) = cacheAndHome(cache, verbosity)
+  def javaHome(cache: Cache[Task], noUpdateCache: Cache[Task], verbosity: Int): coursier.jvm.JavaHome = {
+    val (_, home) = cacheAndHome(cache, noUpdateCache, verbosity)
     home
   }
 

--- a/modules/cli/src/main/scala/coursier/cli/params/CacheParams.scala
+++ b/modules/cli/src/main/scala/coursier/cli/params/CacheParams.scala
@@ -48,7 +48,8 @@ final case class CacheParams(
 
   def cache(
     pool: ExecutorService,
-    logger: CacheLogger
+    logger: CacheLogger,
+    overrideTtl: Option[Duration] = None
   ): FileCache[Task] = {
 
     var c = FileCache[Task]()
@@ -57,7 +58,7 @@ final case class CacheParams(
       .withChecksums(checksum)
       .withLogger(logger)
       .withPool(pool)
-      .withTtl(ttl)
+      .withTtl(overrideTtl.orElse(ttl))
       .withRetry(retryCount)
       .withFollowHttpToHttpsRedirections(followHttpToHttpsRedirections)
       .withLocalArtifactsShouldBeCached(cacheLocalArtifacts)

--- a/modules/cli/src/main/scala/coursier/cli/setup/Setup.scala
+++ b/modules/cli/src/main/scala/coursier/cli/setup/Setup.scala
@@ -12,6 +12,8 @@ import coursier.jvm.JvmCache
 import coursier.launcher.internal.Windows
 import coursier.util.{Sync, Task}
 
+import scala.concurrent.duration.Duration
+
 object Setup extends CaseApp[SetupOptions] {
 
   def run(options: SetupOptions, args: RemainingArgs): Unit = {
@@ -21,8 +23,9 @@ object Setup extends CaseApp[SetupOptions] {
     val pool = Sync.fixedThreadPool(params.cache.parallel)
     val logger = params.output.logger()
     val cache = params.cache.cache(pool, logger)
+    val noUpdateCoursierCache = params.cache.cache(pool, params.output.logger(), overrideTtl = Some(Duration.Inf))
 
-    val javaHome = params.sharedJava.javaHome(cache, params.output.verbosity)
+    val javaHome = params.sharedJava.javaHome(cache, noUpdateCoursierCache, params.output.verbosity)
 
     val envVarUpdaterOpt =
       if (params.env.env) None

--- a/modules/jvm/src/main/scala/coursier/jvm/JavaHome.scala
+++ b/modules/jvm/src/main/scala/coursier/jvm/JavaHome.scala
@@ -20,7 +20,8 @@ import dataclass._
   pathExtensions: Option[Seq[String]] = JavaHome.defaultPathExtensions,
   allowSystem: Boolean = true,
   @since
-  update: Boolean = false
+  update: Boolean = false,
+  noUpdateCache: Option[JvmCache] = None
 ) {
 
   def withCache(cache: JvmCache): JavaHome =
@@ -107,7 +108,7 @@ import dataclass._
         case Some(dir) => Task.point(Some(JavaHome.systemId -> dir))
       }
     else
-      cache match {
+      noUpdateCache.orElse(cache) match {
         case None => Task.point(None)
         case Some(cache0) =>
           val id0 =


### PR DESCRIPTION
If a matching JVM is found locally, and `--update` is not passed, just use the index already in cache.