### PR TITLE
Fixes ivy.xml properties parsing

### DIFF
--- a/modules/core/js/src/main/scala/coursier/core/compatibility/package.scala
+++ b/modules/core/js/src/main/scala/coursier/core/compatibility/package.scala
@@ -63,7 +63,7 @@ package object compatibility {
         (0 until attr.length)
           .map(idx => attr(idx))
           .map { a =>
-            (Option(a.prefix).getOrElse(""), a.name, a.value)
+            (Option(node.lookupNamespaceURI(a.prefix)).getOrElse(""), a.localName, a.value)
           }
       }
 

--- a/modules/core/jvm/src/test/scala/coursier/maven/PomParserTests.scala
+++ b/modules/core/jvm/src/test/scala/coursier/maven/PomParserTests.scala
@@ -67,5 +67,25 @@ object PomParserTests extends TestSuite {
       assert(scm.exists(_.connection.contains("scm:git:git@github.com:coursier/coursier.git")))
       assert(scm.exists(_.developerConnection.contains("foo")))
     }
+
+    "properties are parsed" - {
+      val success = MavenRepository.parseRawPomSax(
+        """
+          |<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+          |    <modelVersion>4.0.0</modelVersion>
+          |    <groupId>com.example</groupId>
+          |    <artifactId>awesome-project</artifactId>
+          |    <version>1.0-SNAPSHOT</version>
+          |
+          |    <properties>
+          |        <info.versionScheme>semver-spec</info.versionScheme>
+          |    </properties>
+          |</project>""".stripMargin
+      )
+      assert(success.isRight)
+      val properties = success.toOption.get.properties
+      val expected = Seq("info.versionScheme" -> "semver-spec")
+      assert(properties == expected)
+    }
   }
 }

--- a/modules/core/shared/src/main/scala/coursier/ivy/IvyXml.scala
+++ b/modules/core/shared/src/main/scala/coursier/ivy/IvyXml.scala
@@ -164,10 +164,11 @@ object IvyXml {
     } yield {
 
       val (module0, version) = modVer
-      val (extraInfo, attr) = module0.attributes partition { case (k, v) => k.startsWith("info.") }
+      val (extraInfo, attr) = module0.attributes
+        .partition(_._1.startsWith("info."))
       val module =
-        if (extraInfo.nonEmpty) module0.withAttributes(attr)
-        else module0
+        if (extraInfo.isEmpty) module0
+        else module0.withAttributes(attr)
 
       val dependenciesNodeOpt = node.children
         .find(_.label == "dependencies")

--- a/modules/core/shared/src/main/scala/coursier/ivy/IvyXml.scala
+++ b/modules/core/shared/src/main/scala/coursier/ivy/IvyXml.scala
@@ -163,7 +163,11 @@ object IvyXml {
       modVer <- info(infoNode)
     } yield {
 
-      val (module, version) = modVer
+      val (module0, version) = modVer
+      val (extraInfo, attr) = module0.attributes partition { case (k, v) => k.startsWith("info.") }
+      val module =
+        if (extraInfo.nonEmpty) module0.withAttributes(attr)
+        else module0
 
       val dependenciesNodeOpt = node.children
         .find(_.label == "dependencies")
@@ -222,15 +226,15 @@ object IvyXml {
         version,
         dependencies0,
         configurations0.toMap,
-        None,
-        Nil,
-        Nil,
-        Nil,
-        None,
-        None,
-        None,
+        parent = None,
+        dependencyManagement = Nil,
+        properties = extraInfo.toSeq,
+        profiles = Nil,
+        versions = None,
+        snapshotVersioning = None,
+        packagingOpt = None,
         relocated = false,
-        None,
+        actualVersionOpt = None,
         if (publicationsOpt.isEmpty)
           // no publications node -> default JAR artifact
           Seq(Configuration.all -> Publication(module.name.value, Type.jar, Extension.jar, Classifier.empty))

--- a/modules/tests/shared/src/test/scala/coursier/test/IvyXmlParsingTests.scala
+++ b/modules/tests/shared/src/test/scala/coursier/test/IvyXmlParsingTests.scala
@@ -45,5 +45,20 @@ object IvyXmlParsingTests extends TestSuite {
 
       assert(result == expected)
     }
+
+    'infoWithExtraInfo {
+      val node = """
+        <ivy-module version="2.0" xmlns:e="http://ant.apache.org/ivy/extra">
+          <info organisation="com.github.gseitz" module="sbt-release" revision="1.0.12" status="release"
+          e:sbtVersion="1.0" e:scalaVersion="2.12" e:info.versionScheme="semver-spec">
+          </info>
+        </ivy-module>
+      """
+
+      val result = IvyXml.project(xmlParseDom(node).toOption.get).map(_.properties)
+      val expected = Right(Seq("info.versionScheme" -> "semver-spec"))
+
+      assert(result == expected)
+    }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/coursier/coursier/issues/1819

sbt publishes "properties" as attributes on `info` element. This information could include things like Scaladoc URL and newly added version scheme.