### PR TITLE
Add in license parsing to `PomParser`

### DIFF
--- a/modules/core/jvm/src/test/scala/coursier/maven/PomParserTests.scala
+++ b/modules/core/jvm/src/test/scala/coursier/maven/PomParserTests.scala
@@ -87,5 +87,100 @@ object PomParserTests extends TestSuite {
       val expected = Seq("info.versionScheme" -> "semver-spec")
       assert(properties == expected)
     }
+
+    "licenses are optional" - {
+      val success = MavenRepository.parseRawPomSax(
+        """
+          |<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+          |  <modelVersion>4.0.0</modelVersion>
+          |  <groupId>com.example</groupId>
+          |  <artifactId>awesome-project</artifactId>
+          |  <version>1.0-SNAPSHOT</version>
+          |</project>""".stripMargin
+      )
+      assert(success.isRight)
+      val licenses = success.toOption.get.info.licenses
+      val expected = Seq()
+      assert(licenses == expected)
+    }
+
+    "licenses with just name and url" - {
+      val success = MavenRepository.parseRawPomSax(
+        """
+          |<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+          |  <modelVersion>4.0.0</modelVersion>
+          |  <groupId>com.example</groupId>
+          |  <artifactId>awesome-project</artifactId>
+          |  <version>1.0-SNAPSHOT</version>
+          |  <licenses>
+          |    <license>
+          |      <name>Apache License, Version 2.0</name>
+          |      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+          |    </license>
+          |  </licenses>
+          |</project>""".stripMargin
+      )
+      assert(success.isRight)
+      val licenses = success.toOption.get.info.licenses
+      val expected = Seq(
+        "Apache License, Version 2.0" -> Some("https://www.apache.org/licenses/LICENSE-2.0.txt")
+      )
+      assert(licenses == expected)
+    }
+
+    "multiple licenses with just name and url" - {
+      val success = MavenRepository.parseRawPomSax(
+        """
+          |<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+          |  <modelVersion>4.0.0</modelVersion>
+          |  <groupId>com.example</groupId>
+          |  <artifactId>awesome-project</artifactId>
+          |  <version>1.0-SNAPSHOT</version>
+          |  <licenses>
+          |    <license>
+          |      <name>Apache License, Version 2.0</name>
+          |      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+          |    </license>
+          |    <license>
+          |      <name>Fake Awesome License 3.0</name>
+          |      <url>https://fake-awesome-license.org</url>
+          |    </license>
+          |  </licenses>
+          |</project>""".stripMargin
+      )
+      assert(success.isRight)
+      val licenses = success.toOption.get.info.licenses
+      val expected = Seq(
+        "Apache License, Version 2.0" -> Some("https://www.apache.org/licenses/LICENSE-2.0.txt"),
+        "Fake Awesome License 3.0" -> Some("https://fake-awesome-license.org")
+      )
+      assert(licenses == expected)
+    }
+
+    "license with maven only details" - {
+      val success = MavenRepository.parseRawPomSax(
+        """
+          |<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+          |  <modelVersion>4.0.0</modelVersion>
+          |  <groupId>com.example</groupId>
+          |  <artifactId>awesome-project</artifactId>
+          |  <version>1.0-SNAPSHOT</version>
+          |  <licenses>
+          |    <license>
+          |      <name>Apache License, Version 2.0</name>
+          |      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+          |      <distribution>repo</distribution>
+          |      <comments>Very insightful comment</comments>
+          |    </license>
+          |  </licenses>
+          |</project>""".stripMargin
+      )
+      assert(success.isRight)
+      val licenses = success.toOption.get.info.licenses
+      val expected = Seq(
+        "Apache License, Version 2.0" -> Some("https://www.apache.org/licenses/LICENSE-2.0.txt")
+      )
+      assert(licenses == expected)
+    }
   }
 }

--- a/modules/core/shared/src/main/scala/coursier/core/Definitions.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Definitions.scala
@@ -257,13 +257,60 @@ object Attributes {
 @data class Info(
   description: String,
   homePage: String,
-  licenses: Seq[(String, Option[String])],
   developers: Seq[Info.Developer],
   publication: Option[Versions.DateTime],
-  scm: Option[Info.Scm]
-)
+  scm: Option[Info.Scm],
+  licenseInfo: Seq[Info.License]
+) {
+  def licenses: Seq[(String, Option[String])] = licenseInfo.map(li => li.name -> li.url)
+
+  def withLicenses(license: Seq[(String, Option[String])]) = {
+    new Info(
+      description,
+      homePage,
+      developers,
+      publication,
+      scm,
+      license.map(l => Info.License(l._1, l._2, None, None))
+    )
+  }
+
+  def this(
+    description: String,
+    homePage: String,
+    licenses: Seq[(String, Option[String])],
+    developers: Seq[Info.Developer],
+    publication: Option[Versions.DateTime],
+    scm: Option[Info.Scm]
+  ) = {
+    this(
+      description,
+      homePage,
+      developers,
+      publication,
+      scm,
+      licenses.map(l => Info.License(l._1, l._2, None, None))
+      )
+  }
+}
 
 object Info {
+  def apply(
+    description: String,
+    homePage: String,
+    licenses: Seq[(String, Option[String])],
+    developers: Seq[Info.Developer],
+    publication: Option[Versions.DateTime],
+    scm: Option[Info.Scm]
+  ): Info = new Info(
+    description,
+    homePage,
+    developers,
+    publication,
+    scm,
+    licenseInfo = licenses.map(l => License(l._1, l._2, None, None))
+  )
+
   @data class Developer(
     id: String,
     name: String,
@@ -276,7 +323,14 @@ object Info {
     developerConnection: Option[String]
   )
 
-  val empty = Info("", "", Nil, Nil, None, None)
+  @data class License(
+    name: String,
+    url: Option[String],
+    distribution: Option[String], // Maven-specific
+    comments: Option[String] // Maven-specific
+  )
+
+  val empty = Info("", "", Nil, None, None, Nil)
 }
 
 // Maven-specific

--- a/modules/core/shared/src/main/scala/coursier/core/Definitions.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Definitions.scala
@@ -290,7 +290,7 @@ object Attributes {
       publication,
       scm,
       licenses.map(l => Info.License(l._1, l._2, None, None))
-      )
+    )
   }
 }
 

--- a/modules/core/shared/src/main/scala/coursier/maven/PomParser.scala
+++ b/modules/core/shared/src/main/scala/coursier/maven/PomParser.scala
@@ -95,7 +95,6 @@ object PomParser {
 
     var description = ""
     var url = ""
-    val licenses = Nil // Left in for binary compat
     val licenseInfo = new ListBuffer[Info.License]
     var licenseName = ""
     var licenseUrl = Option.empty[String]

--- a/modules/core/shared/src/main/scala/coursier/maven/PomParser.scala
+++ b/modules/core/shared/src/main/scala/coursier/maven/PomParser.scala
@@ -95,7 +95,9 @@ object PomParser {
 
     var description = ""
     var url = ""
-    val licenses = Nil // TODO
+    var licenses = new ListBuffer[(String, Option[String])]
+    var licenseName = ""
+    var licenseUrl = Option.empty[String]
     val developers = Nil // TODO
     val publication = Option.empty[Versions.DateTime] // TODO
     var scmOpt = Option.empty[Info.Scm]
@@ -352,6 +354,11 @@ object PomParser {
     (s, scm) => {
       s.scmOpt = Some(scm)
     }
+  ) ++ licenseHandlers(
+    "license" :: "licenses" :: "project" :: Nil,
+    (s, n, u) => {
+      s.licenses += n -> u
+    }
   )
 
   private def profileHandlers(prefix: List[String], add: (State, Profile) => Unit) =
@@ -583,6 +590,24 @@ object PomParser {
       content("developerConnection" :: prefix) {
         (state, content) =>
           state.scmDeveloperConnection = Some(content)
+      }
+    )
+
+  private def licenseHandlers(prefix: List[String], add: (State, String, Option[String]) => Unit) =
+    Seq(
+      new SectionHandler(prefix) {
+        def start(state: State): Unit = {}
+        def end(state: State): Unit = {
+          add(state, state.licenseName, state.licenseUrl)
+        }
+      },
+      content("name" :: prefix) {
+        (state, content) =>
+          state.licenseName = content
+      },
+      content("url" :: prefix) {
+        (state, content) =>
+          state.licenseUrl = Some(content)
       }
     )
 }

--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -82,6 +82,10 @@ object Mima {
         ProblemFilters.exclude[IncompatibleMethTypeProblem]("coursier.core.DependencySet#Sets.this"),
         ProblemFilters.exclude[IncompatibleMethTypeProblem]("coursier.core.DependencySet#Sets.apply"),
         ProblemFilters.exclude[IncompatibleResultTypeProblem]("coursier.core.DependencySet#Sets.required"),
+
+        // PomParser#State is private, so this can be ignored
+        ProblemFilters.exclude[DirectMissingMethodProblem]("coursier.maven.PomParser#State.licenses"),
+
         // ignore shaded-stuff related errors
         (pb: Problem) => pb.matchName.forall(!_.startsWith("coursier.core.shaded."))
       )


### PR DESCRIPTION
I've had an idea I've been playing around with lately about using Coursier for license reporting. I noticed the Ivy parsing seemed to be there, but not the Pom. This adds in license parsing to the PomParser.

~One thing to note is that currently in `Info` licenses are modeled as `(String, Option[String])` since in Ivy there is just a name and url. In Maven it seems that there can also be a distribution and comments. Do you think those should be added in right away and licenses changed in `Info` to a case class like:~

☝️ All added now.

Let me know your thoughts!