### PR TITLE
Add aarch64 and 32bit Arm to supported architectures

### DIFF
--- a/modules/jvm/src/main/scala/coursier/jvm/JvmIndex.scala
+++ b/modules/jvm/src/main/scala/coursier/jvm/JvmIndex.scala
@@ -82,6 +82,7 @@ object JvmIndex {
   lazy val currentArchitecture: Either[String, String] =
     Option(System.getProperty("os.arch")).map(_.toLowerCase(Locale.ROOT)) match {
       case Some("x86_64" | "amd64") => Right("amd64")
+      case Some("aarch64") => Right("arm64")
       case unrecognized => Left(s"Unrecognized CPU architecture: ${unrecognized.getOrElse("")}")
     }
 

--- a/modules/jvm/src/main/scala/coursier/jvm/JvmIndex.scala
+++ b/modules/jvm/src/main/scala/coursier/jvm/JvmIndex.scala
@@ -83,6 +83,7 @@ object JvmIndex {
     Option(System.getProperty("os.arch")).map(_.toLowerCase(Locale.ROOT)) match {
       case Some("x86_64" | "amd64") => Right("amd64")
       case Some("aarch64") => Right("arm64")
+      case Some("arm") => Right("arm")
       case unrecognized => Left(s"Unrecognized CPU architecture: ${unrecognized.getOrElse("")}")
     }
 


### PR DESCRIPTION
This adds `aarch64` as supported architectures in the JvmIndex.

Are there any tests I should add?