### PR TITLE
Remove emoji library dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -269,10 +269,8 @@ lazy val publish = project("publish")
     libs ++= Seq(
       Deps.argonautShapeless,
       Deps.catsCore,
-      Deps.emoji,
       Deps.okhttp
     ),
-    resolvers += Resolver.typesafeIvyRepo("releases"), // for "com.lightbend" %% "emoji"
     onlyIn("2.11", "2.12"), // not all dependencies there yet for 2.13
   )
 

--- a/launcher.sc
+++ b/launcher.sc
@@ -67,7 +67,7 @@ def uploadJavaLauncher(): Unit = {
   WaitForSync(
     initialLauncher0,
     module,
-    Seq("--no-default", "-r", "central", "-r", "typesafe:ivy-releases"),
+    Seq("--no-default", "-r", "central"),
     "sonatype:public",
     attempts = 25
   )
@@ -80,7 +80,6 @@ def uploadJavaLauncher(): Unit = {
     extraArgs = Seq(
       "--no-default",
       "-r", "central",
-      "-r", "typesafe:ivy-releases",
     ),
     output = javaLauncher,
     forceBat = true
@@ -137,7 +136,6 @@ def uploadAssembly(): Unit = {
     extraArgs = Seq(
       "--no-default",
       "-r", "central",
-      "-r", "typesafe:ivy-releases",
       "--assembly"
     ),
     output = assembly
@@ -195,7 +193,6 @@ def generateNativeImage(
       (if (allowIvy2Local) Nil else Seq("--no-default")) ++
       Seq(
         "-r", "central",
-        "-r", "typesafe:ivy-releases",
       ),
     output = output,
     mainClass = "coursier.cli.Coursier",

--- a/modules/cli/src/main/scala/coursier/cli/publish/Publish.scala
+++ b/modules/cli/src/main/scala/coursier/cli/publish/Publish.scala
@@ -7,7 +7,6 @@ import java.time.Instant
 import java.util.concurrent.ScheduledExecutorService
 
 import caseapp._
-import com.lightbend.emoji.ShortCodes.Defaults.defaultImplicit.emoji
 import coursier.cache.internal.ThreadUtil
 import coursier.publish.checksum.{ChecksumType, Checksums}
 import coursier.publish.fileset.{FileSet, Group}
@@ -252,7 +251,7 @@ object Publish extends CaseApp[PublishOptions] {
         val modules = Group.split(sortedFinalFileSet)
           .collect { case m: Group.Module => m }
           .sortBy(m => (m.organization.value, m.name.value, m.version))
-        out.println(s"\n ${emoji("eyes").mkString} Check results at")
+        out.println("\n \ud83d\udc40 Check results at")
         for (m <- modules) {
           val base = actualReadRepo.root + m.baseDir.map("/" + _).mkString
           out.println(s"  $base")

--- a/modules/publish/src/main/scala/coursier/publish/dir/logger/InteractiveDirLogger.scala
+++ b/modules/publish/src/main/scala/coursier/publish/dir/logger/InteractiveDirLogger.scala
@@ -3,7 +3,6 @@ package coursier.publish.dir.logger
 import java.io.{OutputStream, OutputStreamWriter}
 import java.nio.file.Path
 
-import com.lightbend.emoji.ShortCodes.Defaults.defaultImplicit.emoji
 import coursier.publish.logging.ProgressLogger
 
 final class InteractiveDirLogger(out: OutputStreamWriter, dirName: String, verbosity: Int) extends DirLogger {
@@ -12,7 +11,7 @@ final class InteractiveDirLogger(out: OutputStreamWriter, dirName: String, verbo
     "Read",
     s"files from $dirName",
     out,
-    doneEmoji = emoji("mag").map(_.toString())
+    doneEmoji = Some("\ud83d\udd0d")
   )
 
   override def reading(dir: Path): Unit =

--- a/modules/publish/src/main/scala/coursier/publish/logging/ProgressLogger.scala
+++ b/modules/publish/src/main/scala/coursier/publish/logging/ProgressLogger.scala
@@ -5,7 +5,6 @@ import java.lang.{Boolean => JBoolean}
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.{ConcurrentHashMap, Executors, ScheduledFuture, TimeUnit}
 
-import com.lightbend.emoji.ShortCodes.Defaults.defaultImplicit.emoji
 import coursier.cache.internal.Terminal.Ansi
 import coursier.cache.internal.ThreadUtil
 
@@ -22,7 +21,7 @@ final class ProgressLogger[T](
   elementName: String,
   out: Writer,
   updateOnChange: Boolean = false,
-  doneEmoji: Option[String] = emoji("heavy_check_mark").map(Console.GREEN + _ + Console.RESET)
+  doneEmoji: Option[String] = Some(Console.GREEN + "✔" + Console.RESET)
 ) {
 
   import ProgressLogger._

--- a/modules/publish/src/main/scala/coursier/publish/upload/logger/InteractiveUploadLogger.scala
+++ b/modules/publish/src/main/scala/coursier/publish/upload/logger/InteractiveUploadLogger.scala
@@ -2,7 +2,6 @@ package coursier.publish.upload.logger
 
 import java.io.{OutputStream, OutputStreamWriter, Writer}
 
-import com.lightbend.emoji.ShortCodes.Defaults.defaultImplicit.emoji
 import coursier.publish.fileset.FileSet
 import coursier.publish.logging.ProgressLogger
 import coursier.publish.upload.Upload
@@ -24,7 +23,7 @@ final class InteractiveUploadLogger(out: Writer, dummy: Boolean, isLocal: Boolea
     },
     "files",
     out,
-    doneEmoji = emoji("truck").map(_.toString())
+    doneEmoji = Some("\ud83d\ude9a")
   )
 
   override def uploadingSet(id: Object, fileSet: FileSet): Unit =

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -20,7 +20,6 @@ object Deps {
   def catsCore = "org.typelevel" %% "cats-core" % "2.2.0"
   def dataClass = "io.github.alexarchambault" %% "data-class" % "0.2.3"
   def dockerClient = "com.spotify" % "docker-client" % "8.16.0"
-  def emoji = "com.lightbend" %% "emoji" % "1.2.1"
   def fastParse = "com.lihaoyi" %% "fastparse" % versions.fastParse
   def http4sBlazeServer = "org.http4s" %% "http4s-blaze-server" % versions.http4s
   def http4sDsl = "org.http4s" %% "http4s-dsl" % versions.http4s

--- a/scripts/generate-launcher.sh
+++ b/scripts/generate-launcher.sh
@@ -11,7 +11,7 @@ if [[ "$DOWNLOAD_LAUNCHER" == true ]]; then
   LAUNCHER="./coursier-$VERSION"
   curl -fLo "$LAUNCHER" "https://github.com/coursier/coursier/releases/download/v$VERSION/coursier"
   chmod +x "$LAUNCHER"
-  EXTRA_ARGS="launch -r typesafe:ivy-releases io.get-coursier:coursier-cli_2.12:2.0.0-RC2-6 -E io.get-coursier:coursier-okhttp_2.12 --"
+  EXTRA_ARGS="launch io.get-coursier:coursier-cli_2.12:2.0.0-RC2-6 -E io.get-coursier:coursier-okhttp_2.12 --"
 else
   LAUNCHER="$(dirname "$0")/../modules/cli/target/pack/bin/coursier"
   EXTRA_ARGS=""
@@ -27,6 +27,5 @@ MODULE="${MODULE:-"coursier-cli"}"
   "io.get-coursier::$MODULE:$VERSION" \
   --no-default \
   -r central \
-  -r typesafe:ivy-releases \
   -f -o "$OUTPUT" \
   "$@"


### PR DESCRIPTION
Allows to get rid of typesafe:ivy-releases when fetching the cli class path.