### PR TITLE
Allow to specify a custom JVM index URL on the command-line

### DIFF
--- a/modules/cli/src/main/scala/coursier/cli/bootstrap/Bootstrap.scala
+++ b/modules/cli/src/main/scala/coursier/cli/bootstrap/Bootstrap.scala
@@ -275,11 +275,9 @@ object Bootstrap extends CaseApp[BootstrapOptions] {
 
         val graalvmVersion = params.specific.graalvmVersionOpt.getOrElse("latest.release")
 
-        val handle = JvmCache()
-          .withCache(
-            params.sharedLaunch.resolve.cache.cache(pool, params.sharedLaunch.resolve.output.logger())
-          )
-          .withDefaultIndex
+        val handle = params
+          .specific
+          .jvmCache(params.sharedLaunch.resolve.cache.cache(pool, params.sharedLaunch.resolve.output.logger()))
         val javaHomeTask = handle.get(s"graalvm:$graalvmVersion")
         val javaHome = javaHomeTask.unsafeRun()(ExecutionContext.fromExecutorService(pool))
 

--- a/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapSpecificOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapSpecificOptions.scala
@@ -50,7 +50,9 @@ final case class BootstrapSpecificOptions(
   @Help("Use proguarded bootstrap")
     proguarded: Boolean = true,
   @Help("Have the bootstrap or assembly disable jar checking via a hard-coded Java property (default: true for bootstraps with resources, false else)")
-    disableJarChecking: Option[Boolean] = None
+    disableJarChecking: Option[Boolean] = None,
+  jvmDir: Option[String] = None,
+  jvmIndex: Option[String] = None
 ) {
   def addApp(app: RawAppDescriptor, native: Boolean): BootstrapSpecificOptions = {
     val count = Seq(

--- a/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapSpecificParams.scala
+++ b/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapSpecificParams.scala
@@ -4,8 +4,11 @@ import java.nio.file.{Path, Paths}
 
 import cats.data.{Validated, ValidatedNel}
 import cats.implicits._
+import coursier.cache.Cache
+import coursier.jvm.JvmCache
 import coursier.launcher.MergeRule
 import coursier.launcher.internal.Windows
+import coursier.util.Task
 
 final case class BootstrapSpecificParams(
   output: Path,
@@ -27,7 +30,9 @@ final case class BootstrapSpecificParams(
   graalvmVersionOpt: Option[String],
   graalvmJvmOptions: Seq[String],
   graalvmOptions: Seq[String],
-  disableJarCheckingOpt: Option[Boolean]
+  disableJarCheckingOpt: Option[Boolean],
+  jvmDir: Path,
+  jvmIndexUrlOpt: Option[String]
 ) {
   import BootstrapSpecificParams.BootstrapPackaging
   def batOutput: Path =
@@ -38,6 +43,16 @@ final case class BootstrapSpecificParams(
       hybrid,
       embedFiles
     )
+
+  def jvmCache(cache: Cache[Task]): JvmCache = {
+    val c = JvmCache()
+      .withBaseDirectory(jvmDir.toFile)
+      .withCache(cache)
+    jvmIndexUrlOpt match {
+      case None => c.withDefaultIndex
+      case Some(jvmIndexUrl) => c.withIndex(jvmIndexUrl)
+    }
+  }
 }
 
 object BootstrapSpecificParams {
@@ -104,6 +119,15 @@ object BootstrapSpecificParams {
 
     val prependRules = if (options.defaultAssemblyRules) MergeRule.default else Nil
 
+    val jvmDir = options.jvmDir.filter(_.nonEmpty).map(Paths.get(_)).getOrElse {
+      JvmCache.defaultBaseDirectory.toPath
+    }
+
+    val jvmIndex = options
+      .jvmIndex
+      .map(_.trim)
+      .filter(_ != "default")
+
     (validateOutputType, rulesV).mapN {
       (_, rules) =>
         val javaOptions = options.javaOpt
@@ -128,7 +152,9 @@ object BootstrapSpecificParams {
           graalvmVersion,
           graalvmJvmOptions,
           graalvmOptions,
-          options.disableJarChecking
+          options.disableJarChecking,
+          jvmDir,
+          jvmIndex
         )
     }
   }

--- a/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapSpecificParams.scala
+++ b/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapSpecificParams.scala
@@ -5,7 +5,7 @@ import java.nio.file.{Path, Paths}
 import cats.data.{Validated, ValidatedNel}
 import cats.implicits._
 import coursier.cache.Cache
-import coursier.jvm.JvmCache
+import coursier.jvm.{JvmCache, JvmIndex}
 import coursier.launcher.MergeRule
 import coursier.launcher.internal.Windows
 import coursier.util.Task
@@ -127,6 +127,7 @@ object BootstrapSpecificParams {
       .jvmIndex
       .map(_.trim)
       .filter(_ != "default")
+      .map(JvmIndex.handleAliases)
 
     (validateOutputType, rulesV).mapN {
       (_, rules) =>

--- a/modules/cli/src/main/scala/coursier/cli/jvm/SharedJavaOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/jvm/SharedJavaOptions.scala
@@ -7,5 +7,6 @@ final case class SharedJavaOptions(
   jvmDir: Option[String] = None,
   systemJvm: Option[Boolean] = None,
   localOnly: Boolean = false,
-  update: Boolean = false
+  update: Boolean = false,
+  jvmIndex: Option[String] = None
 )

--- a/modules/cli/src/main/scala/coursier/cli/jvm/SharedJavaParams.scala
+++ b/modules/cli/src/main/scala/coursier/cli/jvm/SharedJavaParams.scala
@@ -6,7 +6,7 @@ import java.nio.file.{Path, Paths}
 import cats.data.{Validated, ValidatedNel}
 import cats.implicits._
 import coursier.cache.Cache
-import coursier.jvm.{JvmCache, JvmCacheLogger}
+import coursier.jvm.{JvmCache, JvmCacheLogger, JvmIndex}
 import coursier.util.Task
 
 final case class SharedJavaParams(
@@ -95,6 +95,7 @@ object SharedJavaParams {
       .jvmIndex
       .map(_.trim)
       .filter(_ != "default")
+      .map(JvmIndex.handleAliases)
 
     checkSystemV.map { _ =>
       SharedJavaParams(

--- a/modules/cli/src/main/scala/coursier/cli/launch/LaunchParams.scala
+++ b/modules/cli/src/main/scala/coursier/cli/launch/LaunchParams.scala
@@ -27,10 +27,7 @@ final case class LaunchParams(
         val logger = cache.loggerOpt.getOrElse(CacheLogger.nop)
         for {
           _ <- Task.delay(logger.init())
-          cache0 = coursier.jvm.JvmCache()
-            .withCache(cache)
-            .withDefaultLogger(sharedJava.jvmCacheLogger(shared.resolve.output.verbosity))
-            .withDefaultIndex
+          (cache0, _) = sharedJava.cacheAndHome(cache, cache, shared.resolve.output.verbosity)
           handle = coursier.jvm.JavaHome()
             .withCache(cache0)
           javaExe <- handle.javaBin(id)

--- a/modules/jvm/src/main/scala/coursier/jvm/JvmCache.scala
+++ b/modules/jvm/src/main/scala/coursier/jvm/JvmCache.scala
@@ -314,6 +314,13 @@ import scala.util.control.NonFatal
   def withIndex(index: Task[JvmIndex]): JvmCache =
     withIndex(Some(index))
 
+  def withIndex(indexUrl: String): JvmCache = {
+    val indexTask = cache.loggerOpt.filter(_ => handleLoggerLifecycle).getOrElse(CacheLogger.nop).using {
+      JvmIndex.load(cache, indexUrl)
+    }
+    withIndex(indexTask)
+  }
+
   def withDefaultIndex: JvmCache = {
     val indexTask = cache.loggerOpt.filter(_ => handleLoggerLifecycle).getOrElse(CacheLogger.nop).using {
       JvmIndex.load(cache)

--- a/modules/jvm/src/main/scala/coursier/jvm/JvmIndex.scala
+++ b/modules/jvm/src/main/scala/coursier/jvm/JvmIndex.scala
@@ -13,8 +13,20 @@ import scala.util.{Failure, Success, Try}
 
 object JvmIndex {
 
+  def handleAliases(indexName: String): String =
+    indexName match {
+      case "cs"    => coursierIndexUrl
+      case "jabba" => jabbaIndexUrl
+      case other   => other
+    }
+
   def defaultIndexUrl: String =
+    jabbaIndexUrl
+
+  def jabbaIndexUrl: String =
     "https://github.com/shyiko/jabba/raw/master/index.json"
+  def coursierIndexUrl: String =
+    "https://github.com/coursier/jvm-index/raw/master/index.json"
 
   private def artifact(url: String) = Artifact(url).withChanging(true)
 


### PR DESCRIPTION
This mainly adds a `--jvm-index` option to the `java`, `java-home`, `install`, `update`, and `setup` commands. Use like
```text
$ cs java --jvm-index https://github.com/coursier/jvm-index/raw/master/index.json --jvm graalvm:20.2.0 -version
openjdk version "1.8.0_262"
OpenJDK Runtime Environment (build 1.8.0_262-b10)
OpenJDK 64-Bit Server VM GraalVM CE 20.2.0 (build 25.262-b10-jvmci-20.2-b03, mixed mode)
```