### PR TITLE
Attempt to fix #1884

### DIFF
--- a/modules/jvm/src/main/scala/coursier/jvm/JvmIndex.scala
+++ b/modules/jvm/src/main/scala/coursier/jvm/JvmIndex.scala
@@ -195,7 +195,12 @@ object JvmIndex {
       arch <- arch.map(Right(_)).getOrElse(JvmIndex.currentArchitecture)
       osIndex <- content.get(os).toRight(s"No JVM found for OS $os")
       archIndex <- osIndex.get(arch).toRight(s"No JVM found for OS $os and CPU architecture $arch")
-      versionIndex <- archIndex.get(jdkNamePrefix.getOrElse("") + name).toRight(s"JVM $name not found")
+      versionIndex <- 
+        archIndex.get(jdkNamePrefix.getOrElse("") + name)
+          // While almost all entries in https://github.com/shyiko/jabba/blob/master/index.json follows `jdk@*` pattern
+          // there's also one `jdk` entry. Fixes https://github.com/coursier/coursier/issues/1884
+          .orElse(archIndex.get(name))
+          .toRight(s"JVM $name not found")
       needs1Prefix = versionIndex.keysIterator.forall(_.startsWith("1."))
       version0 =
         if (needs1Prefix) {

--- a/modules/jvm/src/test/scala/coursier/jvm/JvmIndexTests.scala
+++ b/modules/jvm/src/test/scala/coursier/jvm/JvmIndexTests.scala
@@ -59,12 +59,16 @@ object JvmIndexTests extends TestSuite {
             "1.19-2" -> "zip+https://openfoo.com/jdk-19.2.zip",
             "1.20-1" -> "zip+https://openfoo.com/jdk-20.1.zip",
             "1.20-2" -> "zip+https://openfoo.com/jdk-20.2.zip"
+          ),
+          "jdk" -> Map(
+            "1.6.65" -> "zip+https://jdk.com/jdk-1.6.65.zip"
           )
         )))
       )
 
       val open192 = JvmIndexEntry(os, arch, "openfoo", "1.19-2", ArchiveType.Zip, "https://openfoo.com/jdk-19.2.zip")
       val open202 = JvmIndexEntry(os, arch, "openfoo", "1.20-2", ArchiveType.Zip, "https://openfoo.com/jdk-20.2.zip")
+      val jdk = JvmIndexEntry(os, arch, "jdk", "1.6.65", ArchiveType.Zip, "https://jdk.com/jdk-1.6.65.zip")
 
       test("add prefix") {
         val res = index.lookup("openfoo", "19-2", os = Some(os), arch = Some(arch))
@@ -99,6 +103,12 @@ object JvmIndexTests extends TestSuite {
       test("accept 1 plus") {
         val res = index.lookup("openfoo", "1+", os = Some(os), arch = Some(arch))
         val expected = Right(open202)
+        assert(res == expected)
+      }
+
+      test("work for") {
+        val res = index.lookup("jdk", "1.6.65", os = Some(os), arch = Some(arch))
+        val expected = Right(jdk)
         assert(res == expected)
       }
     }


### PR DESCRIPTION
I wrote a unit test reproducing https://github.com/coursier/coursier/issues/1884 and managed to fix the direct reason for it.

However it still doesn't work. For `jdk1.6.65`:

```
[info] running coursier.cli.Coursier java --jvm jdk:1.6.65 -version
JVM jdk:1.6.65 not found in index: Unrecognized archive type 'dmg'
```

For `1.15.0`:

```
Extraction failed: org.codehaus.plexus.archiver.ArchiverException: Error while expanding /Users/michal/Library/Caches/Coursier/v1/https/download.oracle.com/otn-pub/java/jdk/15.0.1%252B9/51f4f36ad4ef43e39d0dfdbaf6549e32/jdk-15.0.1_osx-x64_bin.tar.gz
```

Which makes sense given that following link from jabba (https://github.com/shyiko/jabba/blob/master/index.json#L1358) you are redirected to https://download.oracle.com/errors/download-fail-1505220.html

Therefore I don't know if there's a proper fix on the coursier side. I wonder why jabba maintains links that do not work though