### PR TITLE
Cache computed digests only in cache

### DIFF
--- a/modules/cache/jvm/src/main/scala/coursier/cache/FileCache.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/FileCache.scala
@@ -681,7 +681,7 @@ import scala.util.control.NonFatal
                 Left(new ArtifactError.ChecksumFormatError(sumType, sumFile.getPath))
 
               case Some(sum) =>
-                val calculatedSum: BigInteger = FileCache.persistedDigest(sumType, localFile0)
+                val calculatedSum: BigInteger = FileCache.persistedDigest(location, sumType, localFile0)
 
                 if (sum == calculatedSum)
                   Right(())
@@ -1083,35 +1083,44 @@ object FileCache {
   private val checksumHeader = Seq("MD5", "SHA1", "SHA256")
 
   /**
-    * Store computed cache in files so we don't have to recompute them over and over.
+    * Store computed cache in a file so we don't have to recompute them over and over.
     */
-  private def persistedDigest(sumType: String, localFile: File): BigInteger = {
-    val cacheFile = auxiliaryFile(localFile, sumType + ".computed")
-    val cacheFilePath = cacheFile.toPath
+  private def persistedDigest(location: File, sumType: String, localFile: File): BigInteger = {
+    // only store computed files within coursier cache folder
+    val isInCache: Boolean = {
+      val location0 = location.getCanonicalPath.stripSuffix("/") + "/"
+      localFile.getCanonicalPath.startsWith(location0)
+    }
 
     val digested: Array[Byte] =
-      try Files.readAllBytes(cacheFilePath) catch {
-        case _: NoSuchFileException =>
-          val bytes: Array[Byte] = digest(sumType, localFile)
+      if (!isInCache) computeDigest(sumType, localFile)
+      else {
+        val cacheFile = auxiliaryFile(localFile, sumType + ".computed")
+        val cacheFilePath = cacheFile.toPath
 
-          // Atomically write file by using a temp file in the same directory
-          val tmpFile = File.createTempFile(cacheFile.getName, ".tmp", cacheFile.getParentFile).toPath
-          try {
-            Files.write(tmpFile, bytes)
-            try Files.move(tmpFile, cacheFilePath, StandardCopyOption.ATOMIC_MOVE)
-            catch {
-              // In the case of multiple processes/threads which all compute this digest, first thread wins.
-              case _: FileAlreadyExistsException => ()
-            }
-          } finally Files.deleteIfExists(tmpFile)
+        try Files.readAllBytes(cacheFilePath) catch {
+          case _: NoSuchFileException =>
+            val bytes: Array[Byte] = computeDigest(sumType, localFile)
 
-          bytes
+            // Atomically write file by using a temp file in the same directory
+            val tmpFile = File.createTempFile(cacheFile.getName, ".tmp", cacheFile.getParentFile).toPath
+            try {
+              Files.write(tmpFile, bytes)
+              try Files.move(tmpFile, cacheFilePath, StandardCopyOption.ATOMIC_MOVE)
+              catch {
+                // In the case of multiple processes/threads which all compute this digest, first thread wins.
+                case _: FileAlreadyExistsException => ()
+              }
+            } finally Files.deleteIfExists(tmpFile)
+
+            bytes
+        }
       }
 
     new BigInteger(1, digested)
   }
 
-  private def digest(sumType: String, localFile: File): Array[Byte] = {
+  private def computeDigest(sumType: String, localFile: File): Array[Byte] = {
     val md = MessageDigest.getInstance(sumType)
 
     var is: FileInputStream = null

--- a/modules/cache/jvm/src/test/scala-2.12/coursier/cache/TestUtil.scala
+++ b/modules/cache/jvm/src/test/scala-2.12/coursier/cache/TestUtil.scala
@@ -148,6 +148,30 @@ object TestUtil {
     }
   }
 
+  def resourceFile(name: String): File =
+    Option(getClass.getResource(name)) match {
+      case Some(url) => new File(url.toURI)
+      case None => throw new Exception(s"resource $name not found")
+    }
+
+  /**
+    * Copies a file and all files in the same folder with the same name plus a suffix
+    * @return `file` in the new location
+    */
+  def copiedWithMetaTo(file: File, toDir: Path): Path = {
+    val dir = file.getParentFile
+
+    val fromTo: Map[File, Path] =
+      dir
+        .list((_: File, name: String) => name.startsWith(file.getName))
+        .map(name => new File(dir, name) -> toDir.resolve(name))
+        .toMap
+
+    fromTo.foreach { case (from, to) => Files.copy(from.toPath, to) }
+
+    fromTo(file)
+  }
+
   private def checksum(b: Array[Byte], alg: String, len: Int): String = {
     val md = MessageDigest.getInstance(alg)
     val digest = md.digest(b)


### PR DESCRIPTION
This came up in https://github.com/sbt/sbt/pull/6036

## Implementation
I refactored the tests slightly further, so if they look up a resource from classpath they now always copy it into a temporary directory. This made it easier to tell `FileCache` to use that temporary path as it's `location`, and file clobbering should be less of a problem.

Note that one of the tests (`wrong stored digest should delete file in cache`) changed behavior since we're within the cache directory now, so it deletes the file instead of reporting bad digest. I think that makes sense


The implementation of the check itself was really just a copy/paste of the delete check you pointed me towards.


## Sbt tests

I verified that this fixes the `dependency-management/cached-resolution-circular` scripted test.

For the other failing test, `dependency-management/snapshot-local`, It *cough* may be fixed. 

In Ci we had this message, and it's gone:
```
lmcoursier.internal.shaded.coursier.cache.ArtifactError$WrongChecksum: wrong checksum: /tmp/sbt_6fbf198e/ivy-cache/local/com.badexample/badexample/1.0-SNAPSHOT/jars/badexample.jar (expected SHA-1 d273b8422062d22e9626f6a041b1a4a8ca7a0bd8 in /tmp/sbt_6fbf198e/ivy-cache/local/com.badexample/badexample/1.0-SNAPSHOT/jars/badexample.jar.sha1, got bd7badf4b6f850a35560fb9c5cf3876e2633edb0)
```

I get this wall of text locally now, which is weird enough that it miight just be on my machine:
```
[info] About to run tests: 
[info]  * dependency-management/snapshot-local
[info] Running 1 / 1 (100.00%) scripted tests with RunFromSourceMain
[info] Running dependency-management/snapshot-local
[info] [info] Updated file /tmp/sbt_32f08791/project/build.properties: set sbt.version to 1.4.1-SNAPSHOT
[info] [info] welcome to sbt 1.4.1-SNAPSHOT (AdoptOpenJDK Java 1.8.0_222)
[info] [info] loading project definition from /tmp/sbt_32f08791/project
[info] [info] loading settings for project sbt_32f08791 from build.sbt ...
[info] [info] set current project to sbt_32f08791 (in build file:/tmp/sbt_32f08791/)
[info] [info] welcome to sbt 1.4.1-SNAPSHOT (AdoptOpenJDK Java 1.8.0_222)
[info] [info] loading project definition from /tmp/sbt_32f08791/project
[info] [info] loading settings for project sbt_32f08791 from build.sbt ...
[info] [info] set current project to sbt_32f08791 (in build file:/tmp/sbt_32f08791/)
[info] [info] * FileRepository(local, Patterns(ivyPatterns=Vector(${ivy.home}/local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), artifactPatterns=Vector(${ivy.home}/local/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), isMavenCompatible=false, descriptorOptional=false, skipConsistencyCheck=false), FileConfiguration(true, None))
[info] [info] * public: https://repo1.maven.org/maven2/
[info] [info] * scala-ea: https://scala-ci.typesafe.com/artifactory/scala-integration/
[info] [info] * scala-pr: https://scala-ci.typesafe.com/artifactory/scala-pr-validation-snapshots/
[info] [info] * FileRepository(shared, Patterns(ivyPatterns=Vector(${ivy.home}/shared/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), artifactPatterns=Vector(${ivy.home}/shared/[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)([branch]/)[revision]/[type]s/[artifact](-[classifier]).[ext]), isMavenCompatible=false, descriptorOptional=false, skipConsistencyCheck=false), FileConfiguration(false, None))
[info] [success] Total time: 0 s, completed Nov 2, 2020 1:34:27 AM
[info] [info] Main Scala API documentation to /tmp/sbt_32f08791/common/target/scala-2.12/api...
[info] [info] compiling 1 Scala source to /tmp/sbt_32f08791/common/target/scala-2.12/classes ...
[info] [info] Non-compiled module 'compiler-bridge_2.12' for Scala 2.12.12. Compiling...
[info] [info] Non-compiled module 'compiler-bridge_2.12' for Scala 2.12.12. Compiling...
[info] [info]   Compilation completed in 7.536s.
[info] [info]   Compilation completed in 7.536s.
[info] [error] ## Exception when compiling 1 sources to /tmp/sbt_32f08791/common/target/scala-2.12/classes
[info] [error] java.util.ServiceConfigurationError: xsbti.compile.CompilerInterface2: Provider xsbt.CompilerBridge not found
[info] [error] java.util.ServiceLoader.fail(ServiceLoader.java:239)
[info] [error] java.util.ServiceLoader.access$300(ServiceLoader.java:185)
[info] [error] java.util.ServiceLoader$LazyIterator.nextService(ServiceLoader.java:372)
[info] [error] java.util.ServiceLoader$LazyIterator.access$700(ServiceLoader.java:323)
[info] [error] java.util.ServiceLoader$LazyIterator$2.run(ServiceLoader.java:407)
[info] [error] java.security.AccessController.doPrivileged(Native Method)
[info] [error] java.util.ServiceLoader$LazyIterator.next(ServiceLoader.java:409)
[info] [error] java.util.ServiceLoader$1.next(ServiceLoader.java:480)
[info] [error] sbt.internal.inc.AnalyzingCompiler.loadService(AnalyzingCompiler.scala:317)
[info] [error] sbt.internal.inc.AnalyzingCompiler.compile(AnalyzingCompiler.scala:90)
[info] [error] sbt.internal.inc.MixedAnalyzingCompiler.$anonfun$compile$7(MixedAnalyzingCompiler.scala:186)
[info] [error] scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
[info] [error] sbt.internal.inc.MixedAnalyzingCompiler.timed(MixedAnalyzingCompiler.scala:241)
[info] [error] sbt.internal.inc.MixedAnalyzingCompiler.$anonfun$compile$4(MixedAnalyzingCompiler.scala:176)
[info] [error] sbt.internal.inc.MixedAnalyzingCompiler.$anonfun$compile$4$adapted(MixedAnalyzingCompiler.scala:157)
[info] [error] sbt.internal.inc.JarUtils$.withPreviousJar(JarUtils.scala:232)
[info] [error] sbt.internal.inc.MixedAnalyzingCompiler.compileScala$1(MixedAnalyzingCompiler.scala:157)
[info] [error] sbt.internal.inc.MixedAnalyzingCompiler.compile(MixedAnalyzingCompiler.scala:204)
[info] [error] sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileInternal$1(IncrementalCompilerImpl.scala:571)
[info] [error] sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileInternal$1$adapted(IncrementalCompilerImpl.scala:571)
[info] [error] sbt.internal.inc.Incremental$.$anonfun$apply$5(Incremental.scala:174)
[info] [error] sbt.internal.inc.Incremental$.$anonfun$apply$5$adapted(Incremental.scala:172)
[info] [error] sbt.internal.inc.Incremental$$anon$2.run(Incremental.scala:459)
[info] [error] sbt.internal.inc.IncrementalCommon$CycleState.next(IncrementalCommon.scala:116)
[info] [error] sbt.internal.inc.IncrementalCommon$$anon$1.next(IncrementalCommon.scala:56)
[info] [error] sbt.internal.inc.IncrementalCommon$$anon$1.next(IncrementalCommon.scala:52)
[info] [error] sbt.internal.inc.IncrementalCommon.cycle(IncrementalCommon.scala:261)
[info] [error] sbt.internal.inc.Incremental$.$anonfun$incrementalCompile$8(Incremental.scala:414)
[info] [error] sbt.internal.inc.Incremental$.withClassfileManager(Incremental.scala:499)
[info] [error] sbt.internal.inc.Incremental$.incrementalCompile(Incremental.scala:401)
[info] [error] sbt.internal.inc.Incremental$.apply(Incremental.scala:166)
[info] [error] sbt.internal.inc.IncrementalCompilerImpl.compileInternal(IncrementalCompilerImpl.scala:571)
[info] [error] sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileIncrementally$1(IncrementalCompilerImpl.scala:489)
[info] [error] sbt.internal.inc.IncrementalCompilerImpl.handleCompilationError(IncrementalCompilerImpl.scala:332)
[info] [error] sbt.internal.inc.IncrementalCompilerImpl.compileIncrementally(IncrementalCompilerImpl.scala:419)
[info] [error] sbt.internal.inc.IncrementalCompilerImpl.compile(IncrementalCompilerImpl.scala:137)
[info] [error] sbt.Defaults$.compileIncrementalTaskImpl(Defaults.scala:2176)
[info] [error] sbt.Defaults$.$anonfun$compileIncrementalTask$2(Defaults.scala:2133)
[info] [error] sbt.internal.io.Retry$.apply(Retry.scala:40)
[info] [error] sbt.internal.io.Retry$.apply(Retry.scala:23)
[info] [error] sbt.internal.server.BspCompileTask$.compute(BspCompileTask.scala:31)
[info] [error] sbt.Defaults$.$anonfun$compileIncrementalTask$1(Defaults.scala:2129)
[info] [error] scala.Function1.$anonfun$compose$1(Function1.scala:49)
[info] [error] sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:62)
[info] [error] sbt.std.Transform$$anon$4.work(Transform.scala:68)
[info] [error] sbt.Execute.$anonfun$submit$2(Execute.scala:282)
[info] [error] sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:23)
[info] [error] sbt.Execute.work(Execute.scala:291)
[info] [error] sbt.Execute.$anonfun$submit$1(Execute.scala:282)
[info] [error] sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:265)
[info] [error] sbt.CompletionService$$anon$2.call(CompletionService.scala:64)
[info] [error] java.util.concurrent.FutureTask.run(FutureTask.java:266)
[info] [error] java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[info] [error] java.util.concurrent.FutureTask.run(FutureTask.java:266)
[info] [error] java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[info] [error] java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[info] [error] java.lang.Thread.run(Thread.java:748)
[info] [error]            
[info] [info] Attempting to fetch org.scala-sbt:compiler-bridge_2.12:1.4.1.
[info] [error] java.util.ServiceConfigurationError: xsbti.compile.CompilerInterface2: Provider xsbt.CompilerBridge not found
[info] [error] 	at java.util.ServiceLoader.fail(ServiceLoader.java:239)
[info] [error] 	at java.util.ServiceLoader.access$300(ServiceLoader.java:185)
[info] [error] 	at java.util.ServiceLoader$LazyIterator.nextService(ServiceLoader.java:372)
[info] [error] 	at java.util.ServiceLoader$LazyIterator.access$700(ServiceLoader.java:323)
[info] [error] 	at java.util.ServiceLoader$LazyIterator$2.run(ServiceLoader.java:407)
[info] [error] 	at java.security.AccessController.doPrivileged(Native Method)
[info] [error] 	at java.util.ServiceLoader$LazyIterator.next(ServiceLoader.java:409)
[info] [error] 	at java.util.ServiceLoader$1.next(ServiceLoader.java:480)
[info] [error] 	at sbt.internal.inc.AnalyzingCompiler.loadService(AnalyzingCompiler.scala:317)
[info] [error] 	at sbt.internal.inc.AnalyzingCompiler.compile(AnalyzingCompiler.scala:90)
[info] [error] 	at sbt.internal.inc.MixedAnalyzingCompiler.$anonfun$compile$7(MixedAnalyzingCompiler.scala:186)
[info] [error] 	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
[info] [error] 	at sbt.internal.inc.MixedAnalyzingCompiler.timed(MixedAnalyzingCompiler.scala:241)
[info] [error] 	at sbt.internal.inc.MixedAnalyzingCompiler.$anonfun$compile$4(MixedAnalyzingCompiler.scala:176)
[info] [error] 	at sbt.internal.inc.MixedAnalyzingCompiler.$anonfun$compile$4$adapted(MixedAnalyzingCompiler.scala:157)
[info] [error] 	at sbt.internal.inc.JarUtils$.withPreviousJar(JarUtils.scala:232)
[info] [error] 	at sbt.internal.inc.MixedAnalyzingCompiler.compileScala$1(MixedAnalyzingCompiler.scala:157)
[info] [error] 	at sbt.internal.inc.MixedAnalyzingCompiler.compile(MixedAnalyzingCompiler.scala:204)
[info] [error] 	at sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileInternal$1(IncrementalCompilerImpl.scala:571)
[info] [error] 	at sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileInternal$1$adapted(IncrementalCompilerImpl.scala:571)
[info] [error] 	at sbt.internal.inc.Incremental$.$anonfun$apply$5(Incremental.scala:174)
[info] [error] 	at sbt.internal.inc.Incremental$.$anonfun$apply$5$adapted(Incremental.scala:172)
[info] [error] 	at sbt.internal.inc.Incremental$$anon$2.run(Incremental.scala:459)
[info] [error] 	at sbt.internal.inc.IncrementalCommon$CycleState.next(IncrementalCommon.scala:116)
[info] [error] 	at sbt.internal.inc.IncrementalCommon$$anon$1.next(IncrementalCommon.scala:56)
[info] [error] 	at sbt.internal.inc.IncrementalCommon$$anon$1.next(IncrementalCommon.scala:52)
[info] [error] 	at sbt.internal.inc.IncrementalCommon.cycle(IncrementalCommon.scala:261)
[info] [error] 	at sbt.internal.inc.Incremental$.$anonfun$incrementalCompile$8(Incremental.scala:414)
[info] [error] 	at sbt.internal.inc.Incremental$.withClassfileManager(Incremental.scala:499)
[info] [error] 	at sbt.internal.inc.Incremental$.incrementalCompile(Incremental.scala:401)
[info] [error] 	at sbt.internal.inc.Incremental$.apply(Incremental.scala:166)
[info] [error] 	at sbt.internal.inc.IncrementalCompilerImpl.compileInternal(IncrementalCompilerImpl.scala:571)
[info] [error] 	at sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileIncrementally$1(IncrementalCompilerImpl.scala:489)
[info] [error] 	at sbt.internal.inc.IncrementalCompilerImpl.handleCompilationError(IncrementalCompilerImpl.scala:332)
[info] [error] 	at sbt.internal.inc.IncrementalCompilerImpl.compileIncrementally(IncrementalCompilerImpl.scala:419)
[info] [error] 	at sbt.internal.inc.IncrementalCompilerImpl.compile(IncrementalCompilerImpl.scala:137)
[info] [error] 	at sbt.Defaults$.compileIncrementalTaskImpl(Defaults.scala:2176)
[info] [error] 	at sbt.Defaults$.$anonfun$compileIncrementalTask$2(Defaults.scala:2133)
[info] [error] 	at sbt.internal.io.Retry$.apply(Retry.scala:40)
[info] [error] 	at sbt.internal.io.Retry$.apply(Retry.scala:23)
[info] [error] 	at sbt.internal.server.BspCompileTask$.compute(BspCompileTask.scala:31)
[info] [error] 	at sbt.Defaults$.$anonfun$compileIncrementalTask$1(Defaults.scala:2129)
[info] [error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
[info] [error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:62)
[info] [error] 	at sbt.std.Transform$$anon$4.work(Transform.scala:68)
[info] [error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:282)
[info] [error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:23)
[info] [error] 	at sbt.Execute.work(Execute.scala:291)
[info] [error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:282)
[info] [error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:265)
[info] [error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:64)
[info] [error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[info] [error] 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[info] [error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[info] [error] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[info] [error] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[info] [error] 	at java.lang.Thread.run(Thread.java:748)
[info] [error] sbt.internal.scriptedtest.ScriptedLauncher$3$1$1$1$1$1: sbt.internal.scriptedtest.ScriptedLauncher$3$1$1$1$foo: sbt.internal.scriptedtest.ScriptedLauncher$3$1$1$1$foo: sbt.internal.scriptedtest.ScriptedLauncher$3$1$1$1$foo: Cannot redefine component. ID: sbt.internal.scriptedtest.ScriptedLauncher$1@1992ca72, files: /tmp/sbt_11da27cd/org.scala-sbt-compiler-bridge_2.12-1.4.1-bin_2.12.12__52.0.jar
[info] [error] Caused by: sbt.internal.scriptedtest.ScriptedLauncher$3$1$1$1$foo: sbt.internal.scriptedtest.ScriptedLauncher$3$1$1$1$foo: sbt.internal.scriptedtest.ScriptedLauncher$3$1$1$1$foo: Cannot redefine component. ID: sbt.internal.scriptedtest.ScriptedLauncher$1@1992ca72, files: /tmp/sbt_11da27cd/org.scala-sbt-compiler-bridge_2.12-1.4.1-bin_2.12.12__52.0.jar
[info] [error] (common / Compile / compileIncremental) java.util.ServiceConfigurationError: xsbti.compile.CompilerInterface2: Provider xsbt.CompilerBridge not found
[info] [error] (common / Compile / doc) sbt.internal.scriptedtest.ScriptedLauncher$3$1$1$1$1$1: sbt.internal.scriptedtest.ScriptedLauncher$3$1$1$1$foo: sbt.internal.scriptedtest.ScriptedLauncher$3$1$1$1$foo: sbt.internal.scriptedtest.ScriptedLauncher$3$1$1$1$foo: Cannot redefine component. ID: sbt.internal.scriptedtest.ScriptedLauncher$1@1992ca72, files: /tmp/sbt_11da27cd/org.scala-sbt-compiler-bridge_2.12-1.4.1-bin_2.12.12__52.0.jar
[info] [error] Total time: 10 s, completed Nov 2, 2020 1:34:36 AM
[error] x dependency-management/snapshot-local 
[error]  Cause of test exception: {line 8}  Command failed: common/publishLocal failed
[error] stack trace is suppressed; run last scripted for the full output
[error] (scripted) Failed tests:
[error] 	dependency-management/snapshot-local
```