### PR TITLE
Update coursier native launcher installation documentation

### DIFF
--- a/doc/docs/cli-installation.md
+++ b/doc/docs/cli-installation.md
@@ -4,26 +4,16 @@ title: Installation
 
 ## Native launcher
 
-### Linux
+### Linux & macOS
 
-On Linux, download and run the coursier launcher with
+On Linux and macOS, download and run the coursier launcher with
 ```bash
-$ curl -fLo cs https://git.io/coursier-cli-linux &&
-    chmod +x cs &&
-    ./cs
+$ curl -fLo cs https://git.io/coursier-cli-"$(uname | tr LD ld)"
+$ chmod +x cs
+$ ./cs
 ```
 
-### macOS
-
-Download and run the coursier launcher with
-```bash
-$ curl -fLo cs https://git.io/coursier-cli-macos &&
-    chmod +x cs &&
-    (xattr -d com.apple.quarantine cs || true) &&
-    ./cs
-```
-
-Note the `xattr` command to circumvent notarization on macOS Catalina.
+### macOS - brew based installation
 
 Alternatively, the native launcher can be installed via [homebrew](https://brew.sh) with
 ```bash

--- a/doc/docs/cli-installation.md
+++ b/doc/docs/cli-installation.md
@@ -7,11 +7,28 @@ title: Installation
 ### Linux & macOS
 
 On Linux and macOS, download and run the coursier launcher with
+
 ```bash
 $ curl -fLo cs https://git.io/coursier-cli-"$(uname | tr LD ld)"
 $ chmod +x cs
 $ ./cs
 ```
+
+> Note: The above instructions explain how to install a local copy of `cs`. The next thing you may want to do is to add `cs` to your PATH. The easiest way to accomplish this is to let `cs` do it for you! The following adapted installation instructions show the complete process:
+>
+> 
+> ```
+> $ curl -fLo cs https://git.io/coursier-cli-"$(uname | tr LD ld)"
+> $ chmod +x cs
+> $ ./cs install cs
+> $ rm cs
+> ```
+> 
+> Apart from now having `cs` on your PATH, updating `cs` is now as simple as executing the following command:
+> 
+> ```
+> $ cs update cs
+> ```
 
 ### macOS - brew based installation
 


### PR DESCRIPTION
- MacOS and Linux instructions to install the native launcher
  are now unified