### PR TITLE
fix credentials matching "by realm" / improve WWW-Authenticate: header parsing

### DIFF
--- a/modules/cache/jvm/src/main/scala/coursier/cache/CacheUrl.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/CacheUrl.scala
@@ -400,7 +400,9 @@ object CacheUrl {
     private val Param = (
       "\\s*(\\S+?)" + Pattern.quote("=\"") +
         "([^" + Pattern.quote("\"") + "]*)" +
-        Pattern.quote("\"") + ",?"
+        Pattern.quote("\"") +
+        "\\s*"  + // skip any trailing spaces
+        "(?:,|$)" // either we're at the end or we have a trailing comma
     ).r
 
     /* Extracting the realm from lines such as:
@@ -420,7 +422,6 @@ object CacheUrl {
       wwwAuthenticate match {
         case BasicAuthBase(basicAuthLine) =>
           Param.findAllMatchIn(basicAuthLine)
-            .iterator
             .map(mobj => mobj.group(1).toLowerCase(Locale.ROOT) -> mobj.group(2))
             .collectFirst { case ("realm", realm) => realm }
 

--- a/modules/cache/jvm/src/test/scala-2.12/coursier/cache/TestUtil.scala
+++ b/modules/cache/jvm/src/test/scala-2.12/coursier/cache/TestUtil.scala
@@ -99,8 +99,8 @@ object TestUtil {
     res.nonEmpty
   }
 
-  def unauth(realm: String, challenge: String = "Basic") =
-    Unauthorized(`WWW-Authenticate`(NonEmptyList.one(Challenge(challenge, realm))))
+  def unauth(realm: String, challenge: String = "Basic", params: Map[String, String] = Map.empty) =
+    Unauthorized(`WWW-Authenticate`(NonEmptyList.one(Challenge(challenge, realm, params))))
 
   implicit class UserUriOps(private val uri: Uri) extends AnyVal {
     def withUser(userOpt: Option[String]): Uri =

--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -100,6 +100,7 @@ object Mima {
         // private class
         (pb: Problem) => pb.matchName.forall(!_.startsWith("coursier.cache.CacheUrl#Args")),
         (pb: Problem) => pb.matchName.forall(!_.startsWith("coursier.cache.CacheUrl$Args")),
+        (pb: Problem) => pb.matchName.forall(!_.startsWith("coursier.cache.CacheUrl.BasicRealm")),
         // ignore shaded-stuff related errors
         (pb: Problem) => pb.matchName.forall(!_.startsWith("coursier.cache.shaded."))
       )


### PR DESCRIPTION
With certain repository managers, such as recent versions of the Sonatype Nexus Repository Manager, the WWW-Authenticate header line returned during an HTTP/401 result contains the desired realm, but also additional fields.

In case the authentication credentials are supplied by sbt, the "authentication" is always empty, until an http/401 bounce enables Coursier to locate the correct credentials.

With repositories behaving as above, this causes Coursier to fail to match the realm with the list of user-supplied credentials, and ultimately builds fail by never being able to access authentication-protected artifacts.

This PR revises the parsing of the WWW-Authenticate line by making it more tolerant to server-supplied variations 

Fixes: #1421 