### PR TITLE
fixing symlink resolution to `cs`

### DIFF
--- a/modules/install/src/main/scala/coursier/install/InstallDir.scala
+++ b/modules/install/src/main/scala/coursier/install/InstallDir.scala
@@ -370,7 +370,7 @@ import scala.util.control.NonFatal
               else
                 baseNativePreamble
                   .withKind(Preamble.Kind.Sh)
-                  .withCommand(""""$(cd "$(dirname $(readlink "$0"))"; pwd)/""" + auxName(dest0.getFileName.toString, "") + "\"") // FIXME needs directory
+                  .withCommand(""""$(dirname "$(readlink -f "$0" || realpath "$0" || stat -f%Y "$0" )")"/""" + auxName(dest0.getFileName.toString, "") + "\"") // FIXME needs directory
             writing(tmpDest, verbosity, Some(currentTime)) {
               InfoFile.writeInfoFile(tmpDest, Some(preamble), infoEntries)
               FileUtil.tryMakeExecutable(tmpDest)

--- a/modules/install/src/main/scala/coursier/install/InstallDir.scala
+++ b/modules/install/src/main/scala/coursier/install/InstallDir.scala
@@ -370,7 +370,7 @@ import scala.util.control.NonFatal
               else
                 baseNativePreamble
                   .withKind(Preamble.Kind.Sh)
-                  .withCommand(""""$(cd "$(dirname "$0")"; pwd)/""" + auxName(dest0.getFileName.toString, "") + "\"") // FIXME needs directory
+                  .withCommand(""""$(cd "$(dirname $(readlink "$0"))"; pwd)/""" + auxName(dest0.getFileName.toString, "") + "\"") // FIXME needs directory
             writing(tmpDest, verbosity, Some(currentTime)) {
               InfoFile.writeInfoFile(tmpDest, Some(preamble), infoEntries)
               FileUtil.tryMakeExecutable(tmpDest)


### PR DESCRIPTION
Added readlink/realpath/stat piped to resolve actual path of `cs` when symlinked. I can not test on MacOS so I added realpath and stat based on: [stackoverflow](https://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac#4031502)

Could you please advise how to test ?

Please see: #1951 