### PR TITLE
Ignore HTTP 403 Forbidden on optional artifacts

### DIFF
--- a/modules/cache/jvm/src/main/scala/coursier/cache/ArtifactError.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/ArtifactError.scala
@@ -17,6 +17,11 @@ sealed abstract class ArtifactError(
     case _: ArtifactError.NotFound => true
     case _ => false
   }
+
+  final def forbidden: Boolean = this match {
+    case _: ArtifactError.Forbidden => true
+    case _ => false
+  }
 }
 
 object ArtifactError {
@@ -32,6 +37,13 @@ object ArtifactError {
     val permanent: Option[Boolean] = None
   ) extends ArtifactError(
     "not found",
+    file
+  )
+
+  final class Forbidden(
+    val file: String
+  ) extends ArtifactError(
+    "forbidden",
     file
   )
 

--- a/modules/cache/jvm/src/main/scala/coursier/cache/internal/Downloader.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/internal/Downloader.scala
@@ -215,6 +215,8 @@ import scala.util.control.NonFatal
 
         if (respCodeOpt.contains(404))
           Left(new ArtifactError.NotFound(url, permanent = Some(true)))
+        else if (respCodeOpt.contains(403))
+          Left(new ArtifactError.Forbidden(url))
         else if (respCodeOpt.contains(401))
           Left(new ArtifactError.Unauthorized(url, realm = CacheUrl.realm(conn)))
         else {

--- a/modules/coursier/jvm/src/main/scala/coursier/Artifacts.scala
+++ b/modules/coursier/jvm/src/main/scala/coursier/Artifacts.scala
@@ -325,7 +325,7 @@ object Artifacts {
       val artifactToFile = new mutable.ListBuffer[(Artifact, File)]
 
       results.foreach {
-        case (artifact, Left(err)) if artifact.optional && err.notFound =>
+        case (artifact, Left(err)) if artifact.optional && (err.notFound || err.forbidden) =>
           ignoredErrors += artifact -> err
         case (artifact, Left(err)) =>
           errors += artifact -> err


### PR DESCRIPTION
Fixes #1961 / https://github.com/sbt/sbt/issues/6300
Ref #1541

I think some corporate proxies are returning HTTP 403 Forbidden when
accessing a missing source JAR files.
Given Coursier does not ignore these errors, it would have the effect of
`updateClassifier` failing whenever the source JARs are missing from an
external repository, resulting in IntelliJ import failure.

I don't have a test case on this.