### PR TITLE
fix hex string validation

### DIFF
--- a/modules/cache/jvm/src/main/scala/coursier/cache/CacheChecksum.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/CacheChecksum.scala
@@ -14,7 +14,7 @@ object CacheChecksum {
   )
 
   private def ifHexString(s: String) =
-    s.forall(c => c.isDigit || c >= 'a' && c <= 'z')
+    s.forall(c => c.isDigit || c >= 'a' && c <= 'f')
 
   private def findChecksum(elems: Seq[String]): Option[BigInteger] =
     elems.collectFirst {

--- a/modules/tests/jvm/src/test/scala/coursier/test/ChecksumTests.scala
+++ b/modules/tests/jvm/src/test/scala/coursier/test/ChecksumTests.scala
@@ -58,6 +58,12 @@ object ChecksumTests extends TestSuite {
         sha1ParseTest(cleanSha1, dirtySha1)
       }
 
+      test("nonHexValue") - {
+        val content = "0000000000000000000000000000000z"
+        val res = CacheChecksum.parseChecksum(content)
+        assert(res.isEmpty)
+      }
+
       test("binarySha1") - {
         val content = Platform.readFullySync(getClass.getResource("/empty.sha1").openStream())
         val res = CacheChecksum.parseRawChecksum(content)


### PR DESCRIPTION
CacheChecksum.ifHexString appears to have incorrect implementation, sometimes causing the following error:

[error] java.lang.NumberFormatException: For input string: "apolo"
[error] 	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
[error] 	at java.lang.Integer.parseInt(Integer.java:580)
[error] 	at java.math.BigInteger.<init>(BigInteger.java:470)
[error] 	at lmcoursier.internal.shaded.coursier.cache.CacheChecksum$$anonfun$findChecksum$1.applyOrElse(CacheChecksum.scala:22)
[error] 	at lmcoursier.internal.shaded.coursier.cache.CacheChecksum$$anonfun$findChecksum$1.applyOrElse(CacheChecksum.scala:20)
[error] 	at scala.collection.TraversableOnce.collectFirst(TraversableOnce.scala:172)
[error] 	at scala.collection.TraversableOnce.collectFirst$(TraversableOnce.scala:159)
[error] 	at scala.collection.AbstractTraversable.collectFirst(Traversable.scala:108)
[error] 	at lmcoursier.internal.shaded.coursier.cache.CacheChecksum$.findChecksum(CacheChecksum.scala:20)

Same error reported by different person: https://github.com/sbt/sbt/issues/6243
