### PR TITLE
Add aliases for Apache repositories

### DIFF
--- a/modules/cli/src/main/scala/coursier/cli/options/RepositoryOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/RepositoryOptions.scala
@@ -6,7 +6,7 @@ import coursier.cli.install.SharedChannelOptions
 final case class RepositoryOptions(
 
   @Help("Repository - for multiple repositories, separate with comma and/or add this option multiple times (e.g. -r central,ivy2local -r sonatype:snapshots, or equivalently -r central,ivy2local,sonatype:snapshots)")
-  @Value("maven|sonatype:$repo|ivy2local|bintray:$org/$repo|bintray-ivy:$org/$repo|typesafe:ivy-$repo|typesafe:$repo|sbt-plugin:$repo|scala-integration|scala-nightlies|ivy:$pattern|jitpack|clojars|jcenter")
+  @Value("maven|sonatype:$repo|ivy2local|bintray:$org/$repo|bintray-ivy:$org/$repo|typesafe:ivy-$repo|typesafe:$repo|sbt-plugin:$repo|scala-integration|scala-nightlies|ivy:$pattern|jitpack|clojars|jcenter|apache:$repo")
   @Short("r")
     repository: List[String] = Nil,
 

--- a/modules/coursier/shared/src/main/scala/coursier/Repositories.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/Repositories.scala
@@ -48,4 +48,7 @@ object Repositories {
     MavenRepository("https://maven-central-eu.storage-download.googleapis.com/maven2")
   def centralGcsAsia: MavenRepository =
     MavenRepository("https://maven-central-asia.storage-download.googleapis.com/maven2")
+
+  def apache(id: String): MavenRepository =
+    MavenRepository(s"https://repository.apache.org/content/repositories/$id")
 }

--- a/modules/coursier/shared/src/main/scala/coursier/internal/SharedRepositoryParser.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/internal/SharedRepositoryParser.scala
@@ -55,6 +55,8 @@ object SharedRepositoryParser {
       Right(Repositories.centralGcsEu)
     else if (s == "gcs-asia")
       Right(Repositories.centralGcsAsia)
+    else if (s.startsWith("apache:"))
+      Right(Repositories.apache(s.stripPrefix("apache:")))
     else
       Right(MavenRepository(s))
 

--- a/modules/coursier/shared/src/test/scala/coursier/parse/RepositoryParserTests.scala
+++ b/modules/coursier/shared/src/test/scala/coursier/parse/RepositoryParserTests.scala
@@ -101,6 +101,18 @@ object RepositoryParserTests extends TestSuite {
       val res = RepositoryParser.repository(repo)
       assert(res == Right(expected))
     }
+
+    test("apache") {
+      test("snapshots") {
+        val res = RepositoryParser.repository("apache:snapshots")
+        assert(res.exists(isMavenRepo))
+      }
+
+      test("releases") {
+        val res = RepositoryParser.repository("apache:releases")
+        assert(res.exists(isMavenRepo))
+      }
+    }
   }
 
 }


### PR DESCRIPTION
Allows to fetch spark snapshots, for example:
```text
$ cs resolve -r apache:snapshots org.apache.spark:spark-sql_2.13:3.2.0-SNAPSHOT
```