### PR TITLE
Enhance bootstrap launcher to download artifacts using global credentials.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -218,9 +218,16 @@ lazy val catsJs = cats.js
 lazy val `bootstrap-launcher` = project("bootstrap-launcher")
   .enablePlugins(SbtProguard)
   .disablePlugins(MimaPlugin)
+  .configs(Integration)
   .settings(
     pureJava,
     dontPublish,
+    hasITs,
+    utest,
+    libraryDependencies ++= Seq(
+      Deps.collectionCompat % Test,
+      Deps.java8Compat % Test
+    ),
     addPathsSources,
     addWindowsAnsiPsSources,
     mainClass.in(Compile) := Some("coursier.bootstrap.launcher.Launcher"),

--- a/modules/bootstrap-launcher/src/it/scala/coursier/bootstrap/launcher/DownloadTests.scala
+++ b/modules/bootstrap-launcher/src/it/scala/coursier/bootstrap/launcher/DownloadTests.scala
@@ -1,0 +1,96 @@
+package coursier.bootstrap.launcher
+
+import utest._
+
+import coursier.bootstrap.launcher.credentials.Credentials
+import coursier.bootstrap.launcher.credentials.DirectCredentials
+import coursier.paths.CachePath
+
+import scala.jdk.CollectionConverters._
+import java.nio.file.Files
+import java.io.File
+import java.nio.file.Path
+import java.net.URL
+import java.nio.file.Paths
+import java.net.URI
+import java.util.Collections
+
+object DownloadTests extends TestSuite {
+  
+  private val testRepository = Option(System.getenv("TEST_REPOSITORY")).getOrElse(sys.error("TEST_REPOSITORY not set"))
+  private val testRepositoryUser = Option(System.getenv("TEST_REPOSITORY_USER")).getOrElse(sys.error("TEST_REPOSITORY_USER not set"))
+  private val testRepositoryPassword = Option(System.getenv("TEST_REPOSITORY_PASSWORD")).getOrElse(sys.error("TEST_REPOSITORY_PASSWORD not set"))
+  private val testRepositoryHost = new URI(testRepository).getHost
+
+  private def deleteRecursive(f: File): Unit = {
+    if (f.isDirectory)
+      f.listFiles().foreach(deleteRecursive)
+    if (f.exists())
+      f.delete()
+  }
+
+  private def withTmpDir[T](f: Path => T): T = {
+    val dir = Files.createTempDirectory("coursier-test")
+    val shutdownHook: Thread =
+      new Thread {
+        override def run() =
+          deleteRecursive(dir.toFile)
+      }
+    Runtime.getRuntime.addShutdownHook(shutdownHook)
+    try f(dir)
+    finally {
+      deleteRecursive(dir.toFile)
+      Runtime.getRuntime.removeShutdownHook(shutdownHook)
+    }
+  }
+
+  val tests = Tests {
+
+    test("public URL") {
+      withTmpDir { dir =>
+        val remoteUrls = Seq(
+          new URL("https://repo1.maven.org/maven2/com/chuusai/shapeless_2.12/2.3.3/shapeless_2.12-2.3.3.jar")
+        )
+        val download = new Download(1, dir.toFile, Collections.emptyList())
+        val localUrls = download.getLocalURLs(remoteUrls.asJava).asScala
+        assert(remoteUrls.size == localUrls.size)
+        assert(localUrls
+          .map(url => Paths.get(url.toURI).toFile)
+          .foldLeft(true)(_ && _.exists))
+      }
+    }
+
+    test ("private URL with credentials in the URL") {
+      withTmpDir { dir =>
+        val remoteUrls = Seq(
+          new URL(s"$testRepository/com/abc/test/0.1/test-0.1.pom"
+            .replaceFirst(testRepositoryHost, s"$testRepositoryUser:$testRepositoryPassword@$testRepositoryHost"))
+        )
+        val download = new Download(1, dir.toFile, Collections.emptyList())
+        val localUrls = download.getLocalURLs(remoteUrls.asJava).asScala
+        assert(remoteUrls.size == localUrls.size)
+        assert(localUrls
+          .map(url => Paths.get(url.toURI).toFile)
+          .foldLeft(true)(_ && _.exists))
+      }
+    }
+
+    test ("priavte URL with configured credentials") {
+      withTmpDir { dir =>
+        val remoteUrls = Seq(
+          new URL(s"$testRepository/com/abc/test/0.1/test-0.1.pom")
+        )
+        val download = new Download(1, dir.toFile, Collections.singletonList(
+          new DirectCredentials(testRepositoryHost, testRepositoryUser, testRepositoryPassword).withMatchHost(true).withHttpsOnly(false)
+        ))
+        val localUrls = download.getLocalURLs(remoteUrls.asJava).asScala
+        assert(remoteUrls.size == localUrls.size)
+        assert(localUrls
+          .map(url => Paths.get(url.toURI).toFile)
+          .foldLeft(true)(_ && _.exists))
+      }
+    }
+
+  }
+
+}

--- a/modules/bootstrap-launcher/src/main/java/coursier/bootstrap/launcher/credentials/CredentialsParser.java
+++ b/modules/bootstrap-launcher/src/main/java/coursier/bootstrap/launcher/credentials/CredentialsParser.java
@@ -1,0 +1,38 @@
+package coursier.bootstrap.launcher.credentials;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Java copy of coursier.parse.CredentialsParser
+ */
+public class CredentialsParser {
+
+  private static final Pattern CREDENTIALS_PARSER_PATTERN = Pattern
+      .compile("([a-zA-Z0-9.-]*)(\\(.*\\))?[ ]+([^ :][^:]*):(.*)");
+
+  public static final Optional<DirectCredentials> parse(String s) {
+    final Matcher m = CREDENTIALS_PARSER_PATTERN.matcher(s);
+    if (m.matches()) {
+      return Optional.of(new DirectCredentials(m.group(1), m.group(3), m.group(4))
+        .withRealmOpt(Optional.ofNullable(m.group(2)).map(r -> r.replaceFirst("^\\(", "").replaceFirst("\\)$", "")).orElseGet(() -> null)));
+    } else {
+      return Optional.empty();
+    }
+  }
+
+  public static final List<DirectCredentials> parseList(String input) {
+    return Arrays.stream(input.split("\\r?\\n")) // Java 11: input.lines()
+      .map(s -> s.replaceFirst("^\\s+", "")) // not trimming chars on the right (password)
+      .filter(s -> !s.isEmpty())
+      .map(CredentialsParser::parse)
+      .filter(o -> o.isPresent())
+      .map(o -> o.get())
+      .collect(Collectors.toList());
+  }
+
+}

--- a/modules/bootstrap-launcher/src/main/java/coursier/bootstrap/launcher/credentials/DirectCredentials.java
+++ b/modules/bootstrap-launcher/src/main/java/coursier/bootstrap/launcher/credentials/DirectCredentials.java
@@ -1,0 +1,320 @@
+package coursier.bootstrap.launcher.credentials;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Java copy of coursier.credentials.DirectCredentials
+ */
+public final class DirectCredentials extends Credentials {
+
+  private static final long serialVersionUID = 1L;
+
+  public static final boolean DEFAULT_MATCH_HOST = true;
+  public static final boolean DEFAULT_HTTPS_ONLY = false;
+  public static final boolean DEFAULT_PASS_ON_REDIRECT = false;
+
+  private static final String DEFAULT_HOST = "";
+  private static final boolean DEFAULT_OPTIONAL = true;
+
+  private final String host;
+  private final String usernameOpt;
+  private final Password<String> passwordOpt;
+  private final String realmOpt;
+  private final boolean optional;
+  private final boolean matchHost;
+  private final boolean httpsOnly;
+  private final boolean passOnRedirect;
+
+  private DirectCredentials(
+    String host,
+    String username,
+    Password<String> password,
+    String realm,
+    boolean optional,
+    boolean matchHost,
+    boolean httpsOnly,
+    boolean passOnRedirect
+  ) {
+    this.host = (host != null) ? host : DEFAULT_HOST;
+    this.usernameOpt = username;
+    this.passwordOpt = password;
+    this.realmOpt = realm;
+    this.optional = optional;
+    this.matchHost = matchHost;
+    this.httpsOnly = httpsOnly;
+    this.passOnRedirect = passOnRedirect;
+  }
+
+  public DirectCredentials(
+    String host,
+    String username,
+    String password,
+    String realm,
+    boolean optional,
+    boolean matchHost,
+    boolean httpsOnly,
+    boolean passOnRedirect
+  ) {
+    this(
+      host,
+      username,
+      (password != null) ? new Password<String>(password) : null,
+      realm,
+      optional,
+      matchHost,
+      httpsOnly,
+      passOnRedirect);
+  }
+
+  public DirectCredentials(
+    String host,
+    String username,
+    String password
+  ) {
+    this(
+      host,
+      username,
+      password,
+      null,
+      DEFAULT_OPTIONAL,
+      DEFAULT_MATCH_HOST,
+      DEFAULT_HTTPS_ONLY,
+      DEFAULT_PASS_ON_REDIRECT);
+  }
+
+  public DirectCredentials(
+    String host,
+    String username,
+    String password,
+    String realm
+  ) {
+    this(
+      host,
+      username,
+      password,
+      realm,
+      DEFAULT_OPTIONAL,
+      DEFAULT_MATCH_HOST,
+      DEFAULT_HTTPS_ONLY,
+      DEFAULT_PASS_ON_REDIRECT);
+  }
+
+  @Override
+  public List<DirectCredentials> get() {
+    return Collections.singletonList(this);
+  }
+
+  public String getHost() {
+    return host;
+  }
+
+  public Optional<String> getUsernameOpt() {
+    return Optional.ofNullable(usernameOpt);
+  }
+
+  public Optional<Password<String>> getPasswordOpt() {
+    return Optional.ofNullable(passwordOpt);
+  }
+
+  public Optional<String> getRealmOpt() {
+    return Optional.ofNullable(realmOpt);
+  }
+
+  public boolean isOptional() {
+    return optional;
+  }
+
+  public boolean isMatchHost() {
+    return matchHost;
+  }
+
+  public boolean isHttpsOnly() {
+    return httpsOnly;
+  }
+
+  public boolean isPassOnRedirect() {
+    return passOnRedirect;
+  }
+
+  public DirectCredentials withHost(String host) {
+    return new DirectCredentials(
+      host,
+      this.usernameOpt,
+      this.passwordOpt,
+      this.realmOpt,
+      this.optional,
+      this.matchHost,
+      this.httpsOnly,
+      this.passOnRedirect
+    );
+  }
+
+  public DirectCredentials withUsernameOpt(String username) {
+    return new DirectCredentials(
+      this.host,
+      username,
+      this.passwordOpt,
+      this.realmOpt,
+      this.optional,
+      this.matchHost,
+      this.httpsOnly,
+      this.passOnRedirect
+    );
+  }
+
+  public DirectCredentials withUsername(String username) {
+    return withUsernameOpt(Objects.requireNonNull(username));
+  }
+
+  public DirectCredentials withPasswordOpt(String password) {
+    return new DirectCredentials(
+      this.host,
+      this.usernameOpt,
+      password,
+      this.realmOpt,
+      this.optional,
+      this.matchHost,
+      this.httpsOnly,
+      this.passOnRedirect
+    );
+  }
+
+  public DirectCredentials withPassword(String password) {
+    return withPasswordOpt(Objects.requireNonNull(password));
+  }
+
+  public DirectCredentials withRealmOpt(String realm) {
+    return new DirectCredentials(
+      this.host,
+      this.usernameOpt,
+      this.passwordOpt,
+      realm,
+      this.optional,
+      this.matchHost,
+      this.httpsOnly,
+      this.passOnRedirect
+    );
+  }
+
+  public DirectCredentials withRealm(String realm) {
+    return withRealmOpt(Objects.requireNonNull(realm));
+  }
+
+  public DirectCredentials withOptional(boolean optional) {
+    return new DirectCredentials(
+      this.host,
+      this.usernameOpt,
+      this.passwordOpt,
+      this.realmOpt,
+      optional,
+      this.matchHost,
+      this.httpsOnly,
+      this.passOnRedirect
+    );
+  }
+
+  public DirectCredentials withMatchHost(boolean matchHost) {
+    return new DirectCredentials(
+      this.host,
+      this.usernameOpt,
+      this.passwordOpt,
+      this.realmOpt,
+      this.optional,
+      matchHost,
+      this.httpsOnly,
+      this.passOnRedirect
+    );
+  }
+
+  public DirectCredentials withHttpsOnly(boolean httpsOnly) {
+    return new DirectCredentials(
+      this.host,
+      this.usernameOpt,
+      this.passwordOpt,
+      this.realmOpt,
+      this.optional,
+      this.matchHost,
+      httpsOnly,
+      this.passOnRedirect
+    );
+  }
+
+  public DirectCredentials withPassOnRedirect(boolean passOnRedirect) {
+    return new DirectCredentials(
+      this.host,
+      this.usernameOpt,
+      this.passwordOpt,
+      this.realmOpt,
+      this.optional,
+      this.matchHost,
+      this.httpsOnly,
+      passOnRedirect
+    );
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder b = new StringBuilder("DirectCredentials(");
+    b.append(String.valueOf(host));
+    b.append(", ");
+    b.append(String.valueOf(usernameOpt));
+    b.append(", ");
+    b.append(String.valueOf(passwordOpt));
+    b.append(", ");
+    b.append(String.valueOf(realmOpt));
+    b.append(", ");
+    b.append(String.valueOf(optional));
+    b.append(", ");
+    b.append(String.valueOf(matchHost));
+    b.append(", ");
+    b.append(String.valueOf(httpsOnly));
+    b.append(", ");
+    b.append(String.valueOf(passOnRedirect));
+    b.append(")");
+    return b.toString();
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((host == null) ? 0 : host.hashCode());
+    result = prime * result + (httpsOnly ? 1231 : 1237);
+    result = prime * result + (matchHost ? 1231 : 1237);
+    result = prime * result + (optional ? 1231 : 1237);
+    result = prime * result + (passOnRedirect ? 1231 : 1237);
+    result = prime * result + ((passwordOpt == null) ? 0 : passwordOpt.hashCode());
+    result = prime * result + ((realmOpt == null) ? 0 : realmOpt.hashCode());
+    result = prime * result + ((usernameOpt == null) ? 0 : usernameOpt.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if (obj == null) return false;
+    if (getClass() != obj.getClass()) return false;
+    DirectCredentials other = (DirectCredentials) obj;
+    if (host == null) {
+      if (other.host != null) return false;
+    } else if (!host.equals(other.host)) return false;
+    if (httpsOnly != other.httpsOnly) return false;
+    if (matchHost != other.matchHost) return false;
+    if (optional != other.optional) return false;
+    if (passOnRedirect != other.passOnRedirect) return false;
+    if (passwordOpt == null) {
+      if (other.passwordOpt != null) return false;
+    } else if (!passwordOpt.equals(other.passwordOpt)) return false;
+    if (realmOpt == null) {
+      if (other.realmOpt != null) return false;
+    } else if (!realmOpt.equals(other.realmOpt)) return false;
+    if (usernameOpt == null) {
+      if (other.usernameOpt != null) return false;
+    } else if (!usernameOpt.equals(other.usernameOpt)) return false;
+    return true;
+  }
+ 
+}

--- a/modules/bootstrap-launcher/src/main/java/coursier/bootstrap/launcher/credentials/FileCredentials.java
+++ b/modules/bootstrap-launcher/src/main/java/coursier/bootstrap/launcher/credentials/FileCredentials.java
@@ -1,0 +1,127 @@
+package coursier.bootstrap.launcher.credentials;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+/**
+ * Java copy of coursier.credentials.FileCredentials
+ */
+public final class FileCredentials extends Credentials {
+
+  private static final long serialVersionUID = 1L;
+
+  private static final boolean DEFAULT_OPTIONAL = true;
+
+  private final String path;
+  private final boolean optional;
+
+  public FileCredentials(String path, boolean optional) {
+    this.path = Objects.requireNonNull(path);
+    this.optional = optional;
+  }
+
+  public FileCredentials(String path) {
+    this(path, DEFAULT_OPTIONAL);
+  }
+
+  @Override
+  public List<DirectCredentials> get() throws IOException {
+    final Path f = Paths.get(path);
+
+    if (Files.isRegularFile(f)) {
+      final String content = new String(Files.readAllBytes(f), Charset.defaultCharset());
+      return parse(content, path);
+    } else if (optional) {
+      return Collections.emptyList();
+    } else {
+      throw new RuntimeException(String.format("Credentials file %s not found", path));
+    }
+  }
+
+  public static List<DirectCredentials> parse(String content, String origin) throws IOException {
+    final Properties props = new Properties();
+    props.load(new StringReader(content));
+
+    final List<String> userProps = props
+      .stringPropertyNames()
+      .stream()
+      .filter(name -> name.endsWith(".username"))
+      .collect(Collectors.toList());
+
+    return userProps.stream().map(userProp -> {
+      final String prefix = userProp.substring(0, userProp.length() - ".username".length());
+
+      final String user = props.getProperty(userProp);
+      final String password = Optional.ofNullable(props.getProperty(prefix + ".password"))
+        .orElseThrow(() -> new RuntimeException(String.format("Property %s.password not found in %s", prefix, origin)));
+
+      final String host = Optional.ofNullable(props.getProperty(prefix + ".host"))
+        .orElseThrow(() -> new RuntimeException(String.format("Property %s.host not found in %s", prefix, origin)));
+
+      final String realmOpt = props.getProperty(prefix + ".realm"); // fliter if empty?
+
+      final boolean matchHost = Optional.ofNullable(props.getProperty(prefix + ".auto"))
+        .map(Boolean::parseBoolean).orElse(DirectCredentials.DEFAULT_MATCH_HOST);
+      final boolean httpsOnly = Optional.ofNullable(props.getProperty(prefix + ".https-only"))
+        .map(Boolean::parseBoolean).orElse(DirectCredentials.DEFAULT_HTTPS_ONLY);
+      final boolean passOnRedirect = Optional.ofNullable(props.getProperty(prefix + ".pass-on-redirect"))
+        .map(Boolean::parseBoolean).orElse(DirectCredentials.DEFAULT_PASS_ON_REDIRECT);
+
+      return new DirectCredentials(host, user, password, realmOpt)
+        .withMatchHost(matchHost)
+        .withHttpsOnly(httpsOnly)
+        .withPassOnRedirect(passOnRedirect);
+    }).collect(Collectors.toList());
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public boolean isOptional() {
+    return optional;
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder b = new StringBuilder("FileCredentials(");
+    b.append(String.valueOf(path));
+    b.append(", ");
+    b.append(String.valueOf(optional));
+    b.append(")");
+    return b.toString();
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + (optional ? 1231 : 1237);
+    result = prime * result + ((path == null) ? 0 : path.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if (obj == null) return false;
+    if (getClass() != obj.getClass()) return false;
+    FileCredentials other = (FileCredentials) obj;
+    if (optional != other.optional) return false;
+    if (path == null) {
+      if (other.path != null) return false;
+    } else if (!path.equals(other.path)) return false;
+    return true;
+  }
+
+}

--- a/modules/bootstrap-launcher/src/main/java/coursier/bootstrap/launcher/credentials/Password.java
+++ b/modules/bootstrap-launcher/src/main/java/coursier/bootstrap/launcher/credentials/Password.java
@@ -1,0 +1,44 @@
+package coursier.bootstrap.launcher.credentials;
+
+import java.io.Serializable;
+
+/**
+ * Java copy of coursier.credentials.Password
+ */
+public final class Password<T> implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private final T value;
+
+  public Password(T value) {
+    this.value = value;
+  }
+
+  public T getValue() {
+    return value;
+  }
+
+  @Override
+  public final String toString() {
+    return "****";
+  }
+
+  @Override
+  public final int hashCode() {
+    return "****".hashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if (obj == null) return false;
+    if (getClass() != obj.getClass()) return false;
+    Password<?> other = (Password<?>) obj;
+    if (value == null) {
+      if (other.value != null) return false;
+    } else if (!value.equals(other.value)) return false;
+    return true;
+  }
+
+}

--- a/modules/bootstrap-launcher/src/test/resources/bootstrap-credentials.properties
+++ b/modules/bootstrap-launcher/src/test/resources/bootstrap-credentials.properties
@@ -1,0 +1,10 @@
+simple.username=simple
+simple.password=SiMpLe
+simple.host=127.0.0.1
+simple.realm=simple realm
+
+secure.username=secure
+secure.password=sEcUrE
+secure.host=127.0.0.1
+secure.realm=secure realm
+secure.https-only=true

--- a/modules/bootstrap-launcher/src/test/scala/coursier/bootstrap/launcher/credentials/CredentialsParserTests.scala
+++ b/modules/bootstrap-launcher/src/test/scala/coursier/bootstrap/launcher/credentials/CredentialsParserTests.scala
@@ -1,0 +1,71 @@
+package coursier.bootstrap.launcher.credentials
+
+import utest._
+
+import scala.jdk.CollectionConverters._
+import scala.compat.java8.OptionConverters._
+
+object CredentialsParserTests extends TestSuite {
+
+  val tests = Tests {
+
+    test("simple") {
+      val s = "artifacts.foo.com(tha realm) alex:my-pass"
+      val res = CredentialsParser.parse(s).asScala
+      val expectedRes = Some(new DirectCredentials("artifacts.foo.com", "alex", "my-pass").withRealm("tha realm"))
+      assert(res == expectedRes)
+    }
+
+    test("noRealm") {
+      val s = "artifacts.foo.com alex:my-pass"
+      val res = CredentialsParser.parse(s).asScala
+      val expectedRes = Some(new DirectCredentials("artifacts.foo.com", "alex", "my-pass"))
+      assert(res == expectedRes)
+    }
+
+    test("space in user name") {
+      val s = "artifacts.foo.com(tha realm) alex a:my-pass"
+      val res = CredentialsParser.parse(s).asScala
+      val expectedRes = Some(new DirectCredentials("artifacts.foo.com", "alex a", "my-pass").withRealm("tha realm"))
+      assert(res == expectedRes)
+    }
+
+    test("special chars in password") {
+      val s = "artifacts.foo.com(tha realm) alex:$%_^12//,.;:"
+      val res = CredentialsParser.parse(s).asScala
+      val expectedRes = Some(new DirectCredentials("artifacts.foo.com", "alex", "$%_^12//,.;:").withRealm("tha realm"))
+      assert(res == expectedRes)
+    }
+
+    test("seq") {
+      test("empty") {
+        val res = CredentialsParser.parseList("").asScala
+        val expectedRes = Seq()
+        assert(res == expectedRes)
+      }
+
+      test("one") {
+        val res = CredentialsParser.parseList("artifacts.foo.com alex:my-pass").asScala
+        val expectedRes = Seq(new DirectCredentials("artifacts.foo.com", "alex", "my-pass"))
+        assert(res == expectedRes)
+      }
+
+      test("several") {
+        val res = CredentialsParser.parseList(
+          """artifacts.foo.com alex:my-pass
+            |
+            |  artifacts.foo.com(tha realm) alex a:my-pass
+            |artifacts.foo.com(tha realm) alex:$%_^12//,.;:   """.stripMargin
+        ).asScala
+        val expectedRes = Seq(
+          new DirectCredentials("artifacts.foo.com", "alex", "my-pass"),
+          new DirectCredentials("artifacts.foo.com", "alex a", "my-pass").withRealm("tha realm"),
+          new DirectCredentials("artifacts.foo.com", "alex", "$%_^12//,.;:   ").withRealm("tha realm")
+        )
+        assert(res == expectedRes)
+      }
+    }
+
+  }
+
+}

--- a/modules/bootstrap-launcher/src/test/scala/coursier/bootstrap/launcher/credentials/DirectCredentialsTests.scala
+++ b/modules/bootstrap-launcher/src/test/scala/coursier/bootstrap/launcher/credentials/DirectCredentialsTests.scala
@@ -1,0 +1,19 @@
+package coursier.bootstrap.launcher.credentials
+
+import utest._
+
+import scala.compat.java8.OptionConverters._
+
+object DirectCredentialsTests extends TestSuite {
+  
+  val tests = Tests {
+    test("no password in toString") {
+      val cred = new DirectCredentials("host", "alex", "1234")
+      assert(cred.getUsernameOpt.asScala.contains("alex"))
+      assert(cred.getPasswordOpt.asScala.map(_.getValue).contains("1234"))
+      assert(cred.toString.contains("alex"))
+      assert(!cred.toString.contains("1234"))
+    }
+  }
+
+}

--- a/modules/bootstrap-launcher/src/test/scala/coursier/bootstrap/launcher/credentials/FileCredentialsParseTests.scala
+++ b/modules/bootstrap-launcher/src/test/scala/coursier/bootstrap/launcher/credentials/FileCredentialsParseTests.scala
@@ -1,0 +1,38 @@
+package coursier.bootstrap.launcher.credentials
+
+import utest._
+
+import scala.jdk.CollectionConverters._
+import scala.compat.java8.OptionConverters._
+import java.io.File
+
+object FileCredentialsParseTests extends TestSuite {
+  
+  val tests = Tests {
+
+    test {
+
+      val credFilePath = Option(getClass.getResource("/bootstrap-credentials.properties"))
+        .map(u => new File(u.toURI).getAbsolutePath)
+        .getOrElse {
+          throw new Exception("bootstrap-credentials.properties resource not found")
+        }
+      val credFile = new File(credFilePath)
+      assert(credFile.exists())
+
+      val parsed = new FileCredentials(credFilePath).get().asScala.sortBy(_.getUsernameOpt.asScala.getOrElse(""))
+      val expected = Seq(
+        new DirectCredentials("127.0.0.1", "secure", "sEcUrE", "secure realm")
+          .withOptional(true)
+          .withHttpsOnly(true),
+        new DirectCredentials("127.0.0.1", "simple", "SiMpLe", "simple realm")
+          .withOptional(true)
+          .withHttpsOnly(false)
+      )
+
+      assert(parsed == expected)
+    }
+
+  }
+
+}

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -20,6 +20,7 @@ object Deps {
   def caseApp = "com.github.alexarchambault" %% "case-app" % "2.0.0"
   def catsCore = "org.typelevel" %% "cats-core" % "2.2.0"
   def collectionCompat = "org.scala-lang.modules" %% "scala-collection-compat" % versions.collectionCompat
+  def java8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.1"
   def concurrentReferenceHashMap = "io.github.alexarchambault" % "concurrent-reference-hash-map" % "1.0.0"
   def dataClass = "io.github.alexarchambault" %% "data-class" % "0.2.4"
   def dockerClient = "com.spotify" % "docker-client" % "8.16.0"

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -20,13 +20,13 @@ object Deps {
   def caseApp = "com.github.alexarchambault" %% "case-app" % "2.0.0"
   def catsCore = "org.typelevel" %% "cats-core" % "2.2.0"
   def collectionCompat = "org.scala-lang.modules" %% "scala-collection-compat" % versions.collectionCompat
-  def java8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.1"
   def concurrentReferenceHashMap = "io.github.alexarchambault" % "concurrent-reference-hash-map" % "1.0.0"
   def dataClass = "io.github.alexarchambault" %% "data-class" % "0.2.4"
   def dockerClient = "com.spotify" % "docker-client" % "8.16.0"
   def fastParse = "com.lihaoyi" %% "fastparse" % versions.fastParse
   def http4sBlazeServer = "org.http4s" %% "http4s-blaze-server" % versions.http4s
   def http4sDsl = "org.http4s" %% "http4s-dsl" % versions.http4s
+  def java8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.1"
   def jimfs = "com.google.jimfs" % "jimfs" % "1.1"
   def jol = "org.openjdk.jol" % "jol-core" % "0.14"
   def jsoniterCore = "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % versions.jsoniterScala


### PR DESCRIPTION
Possible implementation for issue: https://github.com/coursier/coursier/issues/1774

Within my organisation we use a private authenticated Artifactory instance to serve all internal and external repositories. Ideally we would like to retrieve artifacts through this repository and not via a proxy. (A proxy requires domain credentials, while Artifactory only requires a user specific Artifactry API key, which more secure for adding to configuration files/properties/variables than domain credentials.)

When I configure the following `mirror.properties`:

```
central.from=https://repo1.maven.org/maven2
central.to=https://private.artifactory.com/artifactory/mavencentral
jcenter.from=https://jcenter.bintray.com
jcenter.to=https://private.artifactory.com/artifactory/jcenter
typesafe.from=https://repo.typesafe.com/typesafe/ivy-releases
typesafe.to=https://private.artifactory.com/artifactory/typesafe-ivy-releases
```

Most artifact retrievals succeed, but artifacts retrieved by the bootstrap launcher fail. For example, the Scala Metals plugin for VSCode fails to download various artifacts due to `401 Unauthorized` errors when the bootstrap launcher does not use the configured [global credentials](https://get-coursier.io/docs/other-credentials.html#property-file):

```
Java home: C:\Users\user\working\tools\jdk1.8.0_261-x64
Metals version: 0.9.10
Error while downloading https://private.artifactory.com/artifactory/virtual-java/com/chuusai/shapeless_2.12/2.3.3/shapeless_2.12-2.3.3.jar: Server returned HTTP response code: 401 for URL: https://private.artifactory.com/artifactory/virtual-java/com/chuusai/shapeless_2.12/2.3.3/shapeless_2.12-2.3.3.jar, ignoring it
Error while downloading https://private.artifactory.com/artifactory/virtual-java/com/github/alexarchambault/case-app-annotations_2.12/2.0.0-M9/case-app-annotations_2.12-2.0.0-M9.jar: Server returned HTTP response code: 401 for URL: https://private.artifactory.com/artifactory/virtual-java/com/github/alexarchambault/case-app-annotations_2.12/2.0.0-M9/case-app-annotations_2.12-2.0.0-M9.jar, ignoring it
Error while downloading https://private.artifactory.com/artifactory/virtual-scala/com.lightbend/emoji_2.12/1.2.1/jars/emoji_2.12.jar: Server returned HTTP response code: 401 for URL: https://private.artifactory.com/artifactory/virtual-scala/com.lightbend/emoji_2.12/1.2.1/jars/emoji_2.12.jar, ignoring it
Error while downloading https://private.artifactory.com/artifactory/virtual-java/com/github/alexarchambault/argonaut-shapeless_6.2_2.12/1.2.0-M11/argonaut-shapeless_6.2_2.12-1.2.0-M11.jar: Server returned HTTP response code: 401 for URL: https://private.artifactory.com/artifactory/virtual-java/com/github/alexarchambault/argonaut-shapeless_6.2_2.12/1.2.0-M11/argonaut-shapeless_6.2_2.12-1.2.0-M11.jar, ignoring it
```

The bootstrap launcher is a Java-only module, which makes sense as it will only have use of the core Java libraries before any dependencies are downloaded, but as a consequence it does not have access to the current Scala-based `Credentials` functionality. If ideally [global credentials](https://get-coursier.io/docs/other-credentials.html#property-file) is used from bootstraps, the this could be implemented in a number of ways, each with different pros and cons:

1. The `bootstrap-launcher` module is enhanced with just enough Java-based functionality to utilize the [global credentials](https://get-coursier.io/docs/other-credentials.html#property-file) without any changes to the existing, out-of-scope Scala-based credentials functionality. Pros: No change to the the Scala `Credentials` API or implementation. Cons: Some duplication.
2. A new or exisitng Java-only module, like `paths`, could be enhanced with the complete credentials functionality, the Scala API updated to delegate to the Java implementation and the `boostrap-launcher` updated to utilize the common credentials functionality. Pros: A single credentials implementation. Cons: Change, compatibility and larger initiative.
3. Something else?

Is there a preferred implementation in mind?

What do you think?

Happy to discuss.