### PR TITLE
Allow passing explicit classloader for CacheUrl.url

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -144,11 +144,13 @@ lazy val cache = crossProject("cache")(JSPlatform, JVMPlatform)
     libraryDependencies ++= Seq(
       Deps.svm % Provided,
       Deps.windowsAnsi
-    )
+    ),
+    classloadersForCustomProtocolTest(customProtocol.jvm),
   )
   .jsSettings(
     name := "fetch-js",
-    libs += Deps.cross.scalaJsDom.value
+    libs += Deps.cross.scalaJsDom.value,
+    classloadersForCustomProtocolTest(customProtocol.js),
   )
   .settings(
     shared,
@@ -175,6 +177,9 @@ lazy val cache = crossProject("cache")(JSPlatform, JVMPlatform)
 lazy val cacheJvm = cache.jvm
 lazy val cacheJs = cache.js
 
+lazy val customProtocol = crossProject("customProtocol")(JSPlatform, JVMPlatform)
+  .settings(dontPublish)
+  
 lazy val scalaz = crossProject("interop", "scalaz")(JSPlatform, JVMPlatform)
   .dependsOn(cache, tests % "test->test")
   .jsConfigure(_.disablePlugins(MimaPlugin))

--- a/build.sbt
+++ b/build.sbt
@@ -145,12 +145,11 @@ lazy val cache = crossProject("cache")(JSPlatform, JVMPlatform)
       Deps.svm % Provided,
       Deps.windowsAnsi
     ),
-    classloadersForCustomProtocolTest(customProtocol.jvm),
+    classloadersForCustomProtocolTest(customProtocolForTest),
   )
   .jsSettings(
     name := "fetch-js",
-    libs += Deps.cross.scalaJsDom.value,
-    classloadersForCustomProtocolTest(customProtocol.js),
+    libs += Deps.cross.scalaJsDom.value
   )
   .settings(
     shared,
@@ -177,8 +176,7 @@ lazy val cache = crossProject("cache")(JSPlatform, JVMPlatform)
 lazy val cacheJvm = cache.jvm
 lazy val cacheJs = cache.js
 
-lazy val customProtocol = crossProject("customProtocol")(JSPlatform, JVMPlatform)
-  .settings(dontPublish)
+lazy val customProtocolForTest = project("custom-protocol-for-test").settings(dontPublish)
   
 lazy val scalaz = crossProject("interop", "scalaz")(JSPlatform, JVMPlatform)
   .dependsOn(cache, tests % "test->test")

--- a/doc/docs/extra.md
+++ b/doc/docs/extra.md
@@ -95,7 +95,7 @@ class CustomprotocolHandler extends URLStreamHandlerFactory {
 
 Coursier will search for your plugin with the following order on various classloaders:
 
-1. The first classloader of those provided via the API (see `FileCache.withClassLoaders`)
+1. Custom classloaders provided via the API (see `FileCache.withClassLoaders`)
 2. `Thread.currentThread().getContextClassLoader`
 3. The classloader that loaded coursier itself (more precisely, `coursier.cache.CacheUrl.getClass.getClassLoader`)
 

--- a/doc/docs/extra.md
+++ b/doc/docs/extra.md
@@ -64,5 +64,44 @@ From sbt, add the setting `coursierUseSbtCredentials := true` for sbt-coursier t
 
 ## Extra protocols
 
-By default, coursier and sbt-coursier handle the `http://`, `https://`, and `file://` protocols. It should also be fine
-by protocols supported by `java.net.URL` (not thoroughly tested). Support for other protocols can be added via plugins. [coursier-s3](https://github.com/paulblei/coursier-s3), a plugin for S3, is under development, and illustrates how to write such plugins.
+By default, coursier and sbt-coursier handle the following protocols:
+
+* `http://`
+* `https://`
+* `file://`
+* protocols supported by `java.net.URL` (not thoroughly tested). See [javadoc](https://docs.oracle.com/en/java/javase/15/docs/api/java.base/java/net/URL.html#%3Cinit%3E(java.lang.String,java.lang.String,int,java.lang.String)) for more details.
+
+Other protocols can be added by implementing `java.net.URLStreamHandler` under the `coursier.cache.protocol` package name:
+
+```scala
+package coursier.cache.protocol
+
+import java.io.File
+import java.io.InputStream
+import java.net.{URL, URLConnection, URLStreamHandler, URLStreamHandlerFactory}
+import java.io.FileInputStream
+
+class CustomprotocolHandler extends URLStreamHandlerFactory {
+  def createURLStreamHandler(protocol: String): URLStreamHandler = new URLStreamHandler {
+    protected def openConnection(url: URL): URLConnection = {
+      new URLConnection(url) {
+        def connect(): Unit = ()
+        override def getInputStream(): InputStream = {
+          new FileInputStream(new File(new File(".").getAbsolutePath() + url.getPath()))
+        }
+      }
+    }
+  }
+}
+```
+
+Coursier will search for your plugin with the following order on various classloaders:
+
+1. The first classloader of the provided classloaders (see `FileCache.withClassLoaders`)
+2. `Thread.currentThread().getContextClassLoader`
+3. `getClass.getClassLoader`
+
+
+Real Word Examples:
+
+* [coursier-s3](https://github.com/rtfpessoa/coursier-s3), a plugin for S3, is under development

--- a/modules/cache/jvm/src/main/scala/coursier/cache/CacheUrl.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/CacheUrl.scala
@@ -39,15 +39,11 @@ object CacheUrl {
               None
           }
 
-        val clsOpt0: Option[Class[_]] = {
-          def fromProvided = classLoaders.toStream.map(clsOpt)
-          def fromThread = clsOpt(Thread.currentThread().getContextClassLoader)
-          def fromClass = clsOpt(getClass.getClassLoader)
-
-          fromProvided.append(List(fromThread, fromClass)).collectFirst {
-            case Some(cls) => cls
-          }
-        }
+        val clsOpt0: Option[Class[_]] =
+          (classLoaders.iterator ++ Iterator(Thread.currentThread().getContextClassLoader, getClass.getClassLoader))
+            .flatMap(clsOpt(_).iterator)
+            .toStream
+            .headOption
 
         def printError(e: Exception): Unit =
           scala.Console.err.println(

--- a/modules/cache/jvm/src/main/scala/coursier/cache/ConnectionBuilder.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/ConnectionBuilder.scala
@@ -19,7 +19,7 @@ import dataclass.data
   method: String = "GET",
   maxRedirectionsOpt: Option[Int] = Some(20),
   proxy: Option[Proxy] = None,
-  @since("2.0.13")
+  @since("2.0.16")
   classLoaders: Seq[ClassLoader] = Nil,
 ) {
 
@@ -48,4 +48,3 @@ import dataclass.data
       classLoaders
     ))
 }
-

--- a/modules/cache/jvm/src/main/scala/coursier/cache/ConnectionBuilder.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/ConnectionBuilder.scala
@@ -18,7 +18,9 @@ import dataclass.data
   hostnameVerifierOpt: Option[HostnameVerifier] = None,
   method: String = "GET",
   maxRedirectionsOpt: Option[Int] = Some(20),
-  proxy: Option[Proxy] = None
+  proxy: Option[Proxy] = None,
+  @since("2.0.13")
+  classLoaders: Seq[ClassLoader] = Nil,
 ) {
 
   def connection(): URLConnection = {
@@ -42,7 +44,8 @@ import dataclass.data
       method,
       None,
       redirectionCount = 0,
-      maxRedirectionsOpt
+      maxRedirectionsOpt,
+      classLoaders
     ))
 }
 

--- a/modules/cache/jvm/src/main/scala/coursier/cache/FileCache.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/FileCache.scala
@@ -36,7 +36,9 @@ import scala.util.control.NonFatal
   sslSocketFactoryOpt: Option[SSLSocketFactory] = None,
   hostnameVerifierOpt: Option[HostnameVerifier] = None,
   retry: Int = CacheDefaults.defaultRetryCount,
-  bufferSize: Int = CacheDefaults.bufferSize
+  bufferSize: Int = CacheDefaults.bufferSize,
+  @since("2.0.13")
+  classLoaders: Seq[ClassLoader] = Nil,
 )(implicit
   sync: Sync[F]
 ) extends Cache[F] {
@@ -98,7 +100,8 @@ import scala.util.control.NonFatal
       sslRetry,
       sslSocketFactoryOpt,
       hostnameVerifierOpt,
-      bufferSize
+      bufferSize,
+      classLoaders
     ).download
 
   def validateChecksum(

--- a/modules/cache/jvm/src/main/scala/coursier/cache/FileCache.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/FileCache.scala
@@ -37,7 +37,7 @@ import scala.util.control.NonFatal
   hostnameVerifierOpt: Option[HostnameVerifier] = None,
   retry: Int = CacheDefaults.defaultRetryCount,
   bufferSize: Int = CacheDefaults.bufferSize,
-  @since("2.0.13")
+  @since("2.0.16")
   classLoaders: Seq[ClassLoader] = Nil,
 )(implicit
   sync: Sync[F]

--- a/modules/cache/jvm/src/main/scala/coursier/cache/internal/Downloader.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/internal/Downloader.scala
@@ -37,7 +37,7 @@ import scala.util.control.NonFatal
   sslSocketFactoryOpt: Option[SSLSocketFactory] = None,
   hostnameVerifierOpt: Option[HostnameVerifier] = None,
   bufferSize: Int = CacheDefaults.bufferSize,
-  @since("2.0.13")
+  @since("2.0.16")
   classLoaders: Seq[ClassLoader] = Nil,
 )(implicit
   S: Sync[F]
@@ -730,11 +730,8 @@ object Downloader {
 
   private object UnknownProtocol {
     def unapply(t: Throwable): Option[(MalformedURLException, String)] = t match {
-      case ex: MalformedURLException => 
-        Option(ex.getMessage()) match {
-          case Some(msg) if msg.startsWith("unknown protocol: ") => Some((ex, msg))
-          case _ => None
-        }
+      case ex: MalformedURLException if ex.getMessage.startsWith("unknown protocol: ") => 
+        Some((ex, ex.getMessage))
       case _ => None
     }
   }

--- a/modules/cache/jvm/src/main/scala/coursier/cache/internal/Downloader.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/internal/Downloader.scala
@@ -36,7 +36,9 @@ import scala.util.control.NonFatal
   sslRetry: Int = CacheDefaults.sslRetryCount,
   sslSocketFactoryOpt: Option[SSLSocketFactory] = None,
   hostnameVerifierOpt: Option[HostnameVerifier] = None,
-  bufferSize: Int = CacheDefaults.bufferSize
+  bufferSize: Int = CacheDefaults.bufferSize,
+  @since("2.0.13")
+  classLoaders: Seq[ClassLoader] = Nil,
 )(implicit
   S: Sync[F]
 ) {
@@ -83,6 +85,7 @@ import scala.util.control.NonFatal
           .withHostnameVerifierOpt(hostnameVerifierOpt)
           .withMethod("HEAD")
           .withMaxRedirectionsOpt(maxRedirections)
+          .withClassLoaders(classLoaders)
           .connection()
 
         conn match {

--- a/modules/cache/jvm/src/test/scala-2.12/coursier/cache/FileCacheTests.scala
+++ b/modules/cache/jvm/src/test/scala-2.12/coursier/cache/FileCacheTests.scala
@@ -972,7 +972,7 @@ object FileCacheTests extends TestSuite {
             }
 
             res match {
-              case Right(file: File) =>
+              case Right(file) =>
                 val actual = new String(Files.readAllBytes(file.toPath))
                 val expected = new String(Files.readAllBytes(Paths.get("README.md")))
                 assert(actual == expected)

--- a/modules/cache/jvm/src/test/scala-2.12/coursier/cache/FileCacheTests.scala
+++ b/modules/cache/jvm/src/test/scala-2.12/coursier/cache/FileCacheTests.scala
@@ -945,11 +945,6 @@ object FileCacheTests extends TestSuite {
 
         res match {
           case Left(error: ArtifactError.DownloadError) =>
-            println("---")
-            println(error.reason)
-            println()
-            println(expectedReason)
-            println("---")
             assert(error.reason == expectedReason)
 
           case _ =>

--- a/modules/custom-protocol-for-test/src/main/scala/coursier/cache/protocol/CustomprotocolHandler.scala
+++ b/modules/custom-protocol-for-test/src/main/scala/coursier/cache/protocol/CustomprotocolHandler.scala
@@ -11,7 +11,7 @@ class CustomprotocolHandler extends URLStreamHandlerFactory {
       new URLConnection(url) {
         def connect(): Unit = ()
         override def getInputStream(): InputStream = {
-          new FileInputStream(new File(new File(".").getAbsolutePath() + url.getPath()))
+          new FileInputStream(new File(new File("."), url.getPath.stripPrefix("/")))
         }
       }
     }

--- a/modules/customProtocol/shared/src/main/scala/coursier/cache/protocol/CustomprotocolHandler.scala
+++ b/modules/customProtocol/shared/src/main/scala/coursier/cache/protocol/CustomprotocolHandler.scala
@@ -1,0 +1,19 @@
+package coursier.cache.protocol
+
+import java.io.File
+import java.io.InputStream
+import java.net.{URL, URLConnection, URLStreamHandler, URLStreamHandlerFactory}
+import java.io.FileInputStream
+
+class CustomprotocolHandler extends URLStreamHandlerFactory {
+  def createURLStreamHandler(protocol: String): URLStreamHandler = new URLStreamHandler {
+    protected def openConnection(url: URL): URLConnection = {
+      new URLConnection(url) {
+        def connect(): Unit = ()
+        override def getInputStream(): InputStream = {
+          new FileInputStream(new File(new File(".").getAbsolutePath() + url.getPath()))
+        }
+      }
+    }
+  }
+}

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -562,7 +562,7 @@ object Settings {
       val customLoaderClasspath = (fromProject / Compile / fullClasspath).value
       val dq = '"'
       val files = customLoaderClasspath.files.map(f => 
-        dq + f.toURI().toURL().toString + dq
+        dq + f.toURI.toString + dq
       ).mkString("Seq(", ", ", ")")
       
       val file = (Test / sourceManaged).value / "CustomLoaderClasspath.scala"


### PR DESCRIPTION
This is to be able to define protocol handlers in sbt.

I splitted the package name with the mkString function to avoid
shading the name.