### PR TITLE
Fix a minor bug in the docs about how to add cs to the PATH env var

### DIFF
--- a/doc/docs/cli-installation.md
+++ b/doc/docs/cli-installation.md
@@ -21,6 +21,7 @@ $ ./cs
 > $ curl -fLo cs https://git.io/coursier-cli-"$(uname | tr LD ld)"
 > $ chmod +x cs
 > $ ./cs install cs
+> $ ./cs install --setup
 > $ rm cs
 > ```
 > 


### PR DESCRIPTION
Hi!

I believe to have found a slight mistake in the documentation on how to put the `cs` command on the `PATH`. The documentation is missing the step `./cs install --setup` which is the one that actually updates the `PATH` by appending some things to a setup script like `~/.profile`.

I found this because I got confused when following the documentation and finding out that `./cs install cs` does not actually put anything on the `PATH`. I only found out about the correct way when watching your Scala Love talk where you do `./cs install --setup`.