### PR TITLE
Fixes Resolution to contain actual version

### DIFF
--- a/modules/core/shared/src/main/scala/coursier/core/Resolution.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Resolution.scala
@@ -1286,7 +1286,7 @@ object Resolution {
           Some(classifiers.getOrElse(Nil) ++ Seq(dep.attributes.classifier))
 
       (pub, artifact) <- source.artifacts(dep, proj, classifiers0)
-    } yield (dep, pub, artifact)
+    } yield (dep.withVersion(proj.actualVersion), pub, artifact)
 
 
   @deprecated("Use the artifacts overload accepting types and classifiers instead", "1.1.0-M8")

--- a/modules/coursier/shared/src/test/scala/coursier/ResolveTests.scala
+++ b/modules/coursier/shared/src/test/scala/coursier/ResolveTests.scala
@@ -217,6 +217,25 @@ object ResolveTests extends TestSuite {
             await(validateDependencies(res))
           }
 
+          test("resolveConcreteVersion") - async {
+
+            val res = await {
+              resolve0
+                .addDependencies(
+                  dep"com.chuusai:shapeless_2.12:2.3+"
+                )
+                .future()
+            }
+
+            await(validateDependencies(res))
+            val transitives = res.dependencyArtifacts().map(_._1)
+
+            assert(transitives.find(d => d.module == mod"com.chuusai:shapeless_2.12") match {
+              case Some(d) => d.version == "2.3.3"
+              case _       => false
+            })
+          }
+
           test("out") - async {
 
             val res = await {


### PR DESCRIPTION
Fixes #2009

Problem
--------
Resolution#dependencyArtifacts returns Dependency value with interval inside.

Solution
--------
Since Project contains the actual version, this make the change to copy that value in.