### PR TITLE
Handle gzip content encoding

### DIFF
--- a/modules/cache/jvm/src/main/scala/coursier/cache/internal/Downloader.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/internal/Downloader.scala
@@ -243,10 +243,11 @@ import scala.util.control.NonFatal
 
           val lastModifiedOpt = Option(conn.getLastModified).filter(_ > 0L)
 
-          val in = if (conn.getContentEncoding == "gzip") {
-              new BufferedInputStream(new GZIPInputStream(conn.getInputStream), bufferSize)
-          } else {
-              new BufferedInputStream(conn.getInputStream, bufferSize)
+          val in = {
+            val baseStream =
+              if (conn.getContentEncoding == "gzip") new GZIPInputStream(conn.getInputStream)
+              else conn.getInputStream
+            new BufferedInputStream(baseStream, bufferSize)
           }
 
           val result =

--- a/modules/cache/jvm/src/main/scala/coursier/cache/internal/Downloader.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/internal/Downloader.scala
@@ -6,6 +6,7 @@ import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.{Files, StandardCopyOption}
 import java.util.Locale
 import java.util.concurrent.ExecutorService
+import java.util.zip.GZIPInputStream
 import javax.net.ssl.{HostnameVerifier, SSLSocketFactory}
 
 import coursier.cache._
@@ -242,7 +243,11 @@ import scala.util.control.NonFatal
 
           val lastModifiedOpt = Option(conn.getLastModified).filter(_ > 0L)
 
-          val in = new BufferedInputStream(conn.getInputStream, bufferSize)
+          val in = if (conn.getContentEncoding == "gzip") {
+              new BufferedInputStream(new GZIPInputStream(conn.getInputStream), bufferSize)
+          } else {
+              new BufferedInputStream(conn.getInputStream, bufferSize)
+          }
 
           val result =
             try {

--- a/modules/cache/jvm/src/test/scala-2.12/coursier/cache/FileCacheTests.scala
+++ b/modules/cache/jvm/src/test/scala-2.12/coursier/cache/FileCacheTests.scala
@@ -5,6 +5,7 @@ import java.net.{URI, URL, URLClassLoader}
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path, Paths}
 import java.util
+import java.util.zip.GZIPOutputStream
 
 import cats.effect.IO
 import coursier.cache.TestUtil._
@@ -900,16 +901,15 @@ object FileCacheTests extends TestSuite {
       }
 
       test("decodeGzip") {
-        val data = new ByteArrayOutputStream();
-        val gzipStream = new util.zip.GZIPOutputStream(data);
-
-        gzipStream.write("hello".getBytes())
+        val data = new ByteArrayOutputStream
+        val gzipStream = new GZIPOutputStream(data)
+        gzipStream.write("hello".getBytes(StandardCharsets.UTF_8))
         gzipStream.close()
 
         val routes = HttpService[IO] {
           case GET -> Root / "hello.txt" =>
-            Ok(data.toByteArray()).map(_.putHeaders(
-              Header("Content-Encoding", "gzip"),
+            Ok(data.toByteArray).map(_.putHeaders(
+              Header("Content-Encoding", "gzip")
             ))
         }
 


### PR DESCRIPTION
Fixes #1281

I have a server that responds with gzip encoded content and it breaks coursier because checksums don't match after downloading. I thought I'd fix it here instead of maintaining a locally modified version.