### PR TITLE
Update concurrent-reference-hash-map to 1.1.0

### DIFF
--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -20,7 +20,7 @@ object Deps {
   def caseApp = "com.github.alexarchambault" %% "case-app" % "2.0.0"
   def catsCore = "org.typelevel" %% "cats-core" % "2.2.0"
   def collectionCompat = "org.scala-lang.modules" %% "scala-collection-compat" % versions.collectionCompat
-  def concurrentReferenceHashMap = "io.github.alexarchambault" % "concurrent-reference-hash-map" % "1.0.0"
+  def concurrentReferenceHashMap = "io.github.alexarchambault" % "concurrent-reference-hash-map" % "1.1.0"
   def dataClass = "io.github.alexarchambault" %% "data-class" % "0.2.4"
   def dockerClient = "com.spotify" % "docker-client" % "8.16.0"
   def fastParse = "com.lihaoyi" %% "fastparse" % versions.fastParse

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -70,9 +70,13 @@ object Settings {
     },
     evictionRules ++= Seq(
       "org.scala-js" %% "scalajs-library" % "semver",
-      "org.scala-lang.modules" % "scala-collection-compat_*" % "semver"
+      "org.scala-lang.modules" % "scala-collection-compat_*" % "semver",
+      "io.github.alexarchambault" % "concurrent-reference-hash-map" % "semver"
     ),
-    compatibilityReconciliations += "org.scala-lang.modules" %% "*" % "semver"
+    compatibilityReconciliations ++= Seq(
+      "org.scala-lang.modules" %% "*" % "semver",
+      "io.github.alexarchambault" % "concurrent-reference-hash-map" % "semver"
+    )
   ) ++ {
     val prop = sys.props.getOrElse("publish.javadoc", "").toLowerCase(Locale.ROOT)
     if (prop == "0" || prop == "false")


### PR DESCRIPTION
This removes one of the (L)GPL dependency of coursier (the newer [concurrent-reference-hash-map](https://github.com/alexarchambault/concurrent-reference-hash-map) version is licensed under Apache 2).
The other (L)GPL dependency is the JNI module of [windows-ansi](https://github.com/alexarchambault/windows-ansi), but only the CLI of coursier depends on it. If the changes of https://github.com/coursier/coursier/pull/2025 go well, it should be possible to either drop it altogether, or at least evict it at image generation time, so that no bits of it land in the `cs` binaries.