### PR TITLE
Python native libs

### DIFF
--- a/modules/cli/src/main/scala/coursier/cli/launch/Launch.scala
+++ b/modules/cli/src/main/scala/coursier/cli/launch/Launch.scala
@@ -289,7 +289,11 @@ object Launch extends CaseApp[LaunchOptions] {
             .asScala
             .map(e => (e.getKey, e.getValue))
             .toVector
-          (props, EnvironmentUpdate(Seq("PYTHONHOME" -> home), Nil))
+          val envVars =
+            if (params.shared.python)
+              Seq("PYTHONHOME" -> home, "SCALAPY_PYTHON_LIBRARY" -> Jep.pythonLDLibrary())
+            else Seq("PYTHONHOME" -> home)
+          (props, EnvironmentUpdate(envVars, Nil))
         } catch {
           case NonFatal(e) =>
             if (params.shared.resolve.output.verbosity >= 1)

--- a/modules/paths/src/main/java/coursier/paths/Jep.java
+++ b/modules/paths/src/main/java/coursier/paths/Jep.java
@@ -162,7 +162,7 @@ public class Jep {
 
     String python = pythonExecutable();
 
-    return callProcess(python, "-c", "import sys;print(sys.prefix)");
+    return callProcess(python, "-c", "import sys;print(sys.exec_prefix)");
   }
 
   public static List<Map.Entry<String, String>> pythonProperties() throws Exception {

--- a/modules/paths/src/main/java/coursier/paths/Jep.java
+++ b/modules/paths/src/main/java/coursier/paths/Jep.java
@@ -164,6 +164,14 @@ public class Jep {
     return callProcess(python, "-c", "import sys;print(sys.exec_prefix)");
   }
 
+  public static String pythonLDLibrary() throws Exception {
+    String python = pythonExecutable();
+    String cmd = "import sysconfig;print(sysconfig.get_config_var('LDVERSION'))";
+    String pythonLDVersion = callProcess(python, "-c", cmd);
+
+    return "python" + pythonLDVersion;
+  }
+
   public static List<Map.Entry<String, String>> pythonProperties() throws Exception {
     String pythonExecPrefix = new File(new File(pythonHome()), "lib").getAbsolutePath();
     String pythonLIBPL = pythonNativeLibs();

--- a/modules/paths/src/main/java/coursier/paths/Jep.java
+++ b/modules/paths/src/main/java/coursier/paths/Jep.java
@@ -124,7 +124,7 @@ public class Jep {
     return version;
   }
 
-  public static String pythonExecutable() throws Exception {
+  private static String pythonExecutable() throws Exception {
     String fromEnv = System.getenv("PYTHONEXECUTABLE");
     if (fromEnv != null && !fromEnv.isEmpty() && existsInPath(fromEnv))
       return fromEnv;
@@ -141,12 +141,6 @@ public class Jep {
     throw new JepException(
       "No existing Python executable found, either in PATH, in PYTHONEXECUTABLE environment variable or in python.executable system property."
     );
-  }
-
-  private static String pythonNativeLibs() throws Exception {
-    String python = pythonExecutable();
-    String cmd = "import sysconfig;print(sysconfig.get_config_var('LIBPL'))";
-    return callProcess(python, "-c", cmd);
   }
 
   public static String pythonHome() throws Exception {
@@ -173,9 +167,7 @@ public class Jep {
   }
 
   public static List<Map.Entry<String, String>> pythonProperties() throws Exception {
-    String pythonExecPrefix = new File(new File(pythonHome()), "lib").getAbsolutePath();
-    String pythonLIBPL = pythonNativeLibs();
-    String jnaLibraryPath = pythonLIBPL + ":" + pythonExecPrefix;
+    String jnaLibraryPath = new File(new File(pythonHome()), "lib").getAbsolutePath();
 
     ArrayList<Map.Entry<String, String>> list = new ArrayList<>();
 

--- a/modules/paths/src/main/java/coursier/paths/Jep.java
+++ b/modules/paths/src/main/java/coursier/paths/Jep.java
@@ -143,10 +143,9 @@ public class Jep {
     );
   }
 
-  public static String pythonNativeLibs() throws Exception {
+  private static String pythonNativeLibs() throws Exception {
     String python = pythonExecutable();
-    String cmd = "from sysconfig import get_config_var;print(get_config_var('LIBPL'))";
-
+    String cmd = "import sysconfig;print(sysconfig.get_config_var('LIBPL'))";
     return callProcess(python, "-c", cmd);
   }
 
@@ -166,7 +165,9 @@ public class Jep {
   }
 
   public static List<Map.Entry<String, String>> pythonProperties() throws Exception {
-    String jnaLibraryPath = pythonNativeLibs();
+    String pythonExecPrefix = new File(new File(pythonHome()), "lib").getAbsolutePath();
+    String pythonLIBPL = pythonNativeLibs();
+    String jnaLibraryPath = pythonLIBPL + ":" + pythonExecPrefix;
 
     ArrayList<Map.Entry<String, String>> list = new ArrayList<>();
 


### PR DESCRIPTION
I changed a few things regarding the python native libs.

 - Use `sys.exec_prefix` instead of `sys.prefix`. Often they are the same but when they are not, [exec_prefix](https://docs.python.org/3/library/sys.html#sys.exec_prefix) is where the native libs are located.
 - Let python handle `PYTHONHOME` itself. So basically call `PYTHONHOME=<...> python -c "import sys;print(sys.exec_prefix)"` instead of dealing with it in coursier since [sometimes it gets complicated](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONHOME).
 - `exec_prefix` can be shared among multiple python installations. Without further specification ScalaPy might pick up the wrong python libs. For example if the `python` on `PATH` is 3.9 but there is a `python3.7` also installed with the same `exec_prefix`, ScalaPy would pick up the `python3.7` lib [instead](
https://github.com/shadaj/scalapy/blob/6e4f09dbed07ea5bf55f2cd086c7929276c08b8b/core/jvm/src/main/scala/me/shadaj/scalapy/interpreter/CPythonAPI.scala#L10-L24). To fix this I get the correct name of the python lib (`python` + `LDVERSION`) and set it to `SCALAPY_PYTHON_LIBRARY`.
- Users can specify another python other than the one on `PATH` by setting the [PYTHONEXECUTABLE](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONEXECUTABLE) env var.

I did went down the `sysconfig.get_config_var('LIBPL')` path but turned out it would complicate things and is not necessary anw.