### PR TITLE
Be fine with Mill-generated manifests

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -506,6 +506,9 @@ trait Cli extends CsModule with CoursierPublishModule with Launchers {
     ivy"com.chuusai::shapeless:2.3.7"
   )
   def mainClass = Some("coursier.cli.Coursier")
+  def finalMainClassOpt = T{
+    Right("coursier.cli.Coursier"): Either[String, String]
+  }
   def manifest = T{
     import java.util.jar.Attributes.Name
     val ver = publishVersion()

--- a/build.sc
+++ b/build.sc
@@ -506,6 +506,19 @@ trait Cli extends CsModule with CoursierPublishModule with Launchers {
     ivy"com.chuusai::shapeless:2.3.7"
   )
   def mainClass = Some("coursier.cli.Coursier")
+  def manifest = T{
+    import java.util.jar.Attributes.Name
+    val ver = publishVersion()
+    super.manifest().add(
+      Name.IMPLEMENTATION_TITLE.toString -> "coursier-cli",
+      Name.IMPLEMENTATION_VERSION.toString -> ver,
+      Name.SPECIFICATION_VENDOR.toString -> "io.get-coursier",
+      Name.SPECIFICATION_TITLE.toString -> "coursier-cli",
+      Name.IMPLEMENTATION_VENDOR_ID.toString -> "io.get-coursier",
+      Name.SPECIFICATION_VERSION.toString -> ver,
+      Name.IMPLEMENTATION_VENDOR.toString -> "io.get-coursier"
+    )
+  }
   def docJar = T{
     val jar = T.dest / "empty.jar"
     val baos = new java.io.ByteArrayOutputStream

--- a/modules/cli-tests/src/main/scala/coursier/clitests/LaunchTests.scala
+++ b/modules/cli-tests/src/main/scala/coursier/clitests/LaunchTests.scala
@@ -54,5 +54,11 @@ abstract class LaunchTests extends TestSuite {
       if (LauncherTestUtil.isWindows) "disabled"
       else { inlineAppWithId(); "" }
     }
+
+    test("no vendor and title in manifest") {
+      val output = LauncherTestUtil.output(launcher, "launch", "io.get-coursier:coursier-cli_2.12:2.0.16+69-g69cab05e6", "--", "launch", "io.get-coursier:echo:1.0.1", "--", "foo")
+      val expectedOutput = "foo" + System.lineSeparator()
+      assert(output == expectedOutput)
+    }
   }
 }


### PR DESCRIPTION
Mill doesn't add Implementation-Vendor-Id and Specification-Title in the
manifests it generates, which the main class detection code uses to pick
a main class.

These changes default to the main class from the first JAR in the class
path (which has been determistic for some time now, and corresponds to the
JAR of the first specified dependency), no matter its
Implementation-Vendor-Id and Specification-Title attributes.