### PR TITLE
Correct property activation when value starts with !

### DIFF
--- a/modules/tests/shared/src/test/scala/coursier/test/ActivationTests.scala
+++ b/modules/tests/shared/src/test/scala/coursier/test/ActivationTests.scala
@@ -157,6 +157,19 @@ object ActivationTests extends TestSuite {
         assert(isActive)
       }
 
+      test("match with missing property") {
+        val isActive = activation.isActive(
+          Map(
+            "required" -> "a",
+            "requiredWithValue" -> "foo",
+          ),
+          Os.empty,
+          None
+        )
+
+        assert(isActive)
+      }
+
       test("noMatch") {
         test {
           val isActive = activation.isActive(


### PR DESCRIPTION
From Maven documentation (https://maven.apache.org/guides/introduction/introduction-to-profiles.html):

```xml
The following profile will be activated when the system property "debug" is not defined, or is defined with a value which is not "true".

    <profiles>
      <profile>
        <activation>
          <property>
            <name>debug</name>
            <value>!true</value>
          </property>
        </activation>
        ...
      </profile>
    </profiles>
```

Old behaviour was incorrect, and forced the property to be **present** _and_ have a different value.

This caused the issue https://github.com/sbt/sbt/issues/6564, and I believe this provides a fix.

To verify, here's what Coursier 2.0.16 returns:

```
➜  coursier git:(correct-property-activation) ✗ cs --version
2.0.16
➜  coursier git:(correct-property-activation) ✗ cs fetch org.openjfx:javafx-base:18-ea+2
Error fetching artifacts:
https://repo1.maven.org/maven2/org/openjfx/javafx-base/18-ea+2/javafx-base-18-ea+2-${javafx.platform}.jar: not found: https://repo1.maven.org/maven2/org/openjfx/javafx-base/18-ea+2/javafx-base-18-ea+2-${javafx.platform}.jar
```

And here's what current version does:

```
➜  coursier git:(correct-property-activation) ✗ ./mill -i cli.run fetch org.openjfx:javafx-base:18-ea+2
[411/411] cli.run
<coursier_cache>/v1/https/repo1.maven.org/maven2/org/openjfx/javafx-base/18-ea%2B2/javafx-base-18-ea%2B2.jar
<coursier_cache>/v1/https/repo1.maven.org/maven2/org/openjfx/javafx-base/18-ea%2B2/javafx-base-18-ea%2B2-mac-aarch64.jar
```

TODO:

- [x] Add a test to ActivationTests, after @alexarchambault verifies the sanity of this