### PR TITLE
Recheck JVM archive extraction directory after acquiring the file lock.

### DIFF
--- a/modules/jvm/src/main/scala/coursier/jvm/JvmCache.scala
+++ b/modules/jvm/src/main/scala/coursier/jvm/JvmCache.scala
@@ -57,7 +57,8 @@ import scala.util.control.NonFatal
       // FileSystemException being raised on the Files.move(...) call below.
       if (dir.isDirectory) {
         dir
-      } else {
+      }
+      else {
         logger0.extracting(entry.id, archive.getAbsolutePath, dir)
         val dir0 =
           try {


### PR DESCRIPTION
The existing locking code for extracting JVM archives unconditionally attempts the extraction after acquiring the file lock for the extracted directory, but the check for whether that directory exists happens before the lock is acquired.  This means that while waiting for the lock (or losing the race to get it), another process could successfully extract the archive.  We then successfully acquire the lock, but the extraction fails because the directory now exists.

I believe this should fix the root cause of https://github.com/pantsbuild/pants/issues/12293.