### PR TITLE
Introduce `VersionOverride`

### DIFF
--- a/modules/install/src/main/scala/coursier/install/RawAppDescriptor.scala
+++ b/modules/install/src/main/scala/coursier/install/RawAppDescriptor.scala
@@ -3,8 +3,22 @@ package coursier.install
 import argonaut._
 import cats.data.{NonEmptyList, Validated, ValidatedNel}
 import cats.implicits._
-import coursier.core.{Classifier, Configuration, ModuleName, Resolution, Type}
-import coursier.parse.{DependencyParser, JavaOrScalaModule, ModuleParser, RepositoryParser}
+import coursier.core.{
+  Classifier,
+  Configuration,
+  ModuleName,
+  Resolution,
+  Type,
+  Repository,
+  VersionInterval
+}
+import coursier.parse.{
+  DependencyParser,
+  JavaOrScalaModule,
+  ModuleParser,
+  RepositoryParser,
+  JavaOrScalaDependency
+}
 import dataclass._
 
 import scala.language.implicitConversions
@@ -30,19 +44,18 @@ import scala.language.implicitConversions
   @since("2.0.1")
   prebuiltBinaries: Map[String, String] = Map.empty,
   @since("2.0.4")
-  jna: List[String] = Nil
+  jna: List[String] = Nil,
+  @since("2.1.0")
+  versionOverrides: List[RawAppDescriptor.RawVersionOverride] = Nil
 ) {
   def isEmpty: Boolean =
     this == RawAppDescriptor(Nil)
   def appDescriptor: ValidatedNel[String, AppDescriptor] = {
 
-    import RawAppDescriptor.validationNelToCats
+    import RawAppDescriptor._
 
-    val repositoriesV = validationNelToCats(RepositoryParser.repositories(repositories))
-
-    val dependenciesV = validationNelToCats(
-      DependencyParser.javaOrScalaDependencies(dependencies, Configuration.defaultCompile)
-    )
+    val repositoriesV       = parseRepositories(repositories)
+    val dependenciesV       = parseDependenices(dependencies)
     val sharedDependenciesV = validationNelToCats(ModuleParser.javaOrScalaModules(shared))
 
     val exclusionsV = validationNelToCats(ModuleParser.javaOrScalaModules(exclusions)).map(_.map {
@@ -93,15 +106,31 @@ import scala.language.implicitConversions
       }
     }
 
-    val (mainClassOpt, defaultMainClassOpt) =
-      mainClass match {
-        case Some(c) if c.endsWith("?") => (None, Some(c.stripSuffix("?")))
-        case Some(c)                    => (Some(c), None)
-        case None                       => (None, None)
-      }
+    val (mainClassOpt, defaultMainClassOpt) = mainClass.map(parseMainClass) match {
+      case Some(Left(mainClass))         => (Some(mainClass), None)
+      case Some(Right(defaultMainClass)) => (None, Some(defaultMainClass))
+      case None                          => (None, None)
+    }
 
-    (repositoriesV, dependenciesV, sharedDependenciesV, exclusionsV, launcherTypeV).mapN {
-      (repositories, dependencies, sharedDependencies, exclusions, launcherType) =>
+    val versionOverridesV =
+      versionOverrides.map(_.versionOverride).sequence.andThen(validateRanges)
+
+    (
+      repositoriesV,
+      dependenciesV,
+      sharedDependenciesV,
+      exclusionsV,
+      launcherTypeV,
+      versionOverridesV
+    ).mapN {
+      (
+        repositories,
+        dependencies,
+        sharedDependencies,
+        exclusions,
+        launcherType,
+        versionOverrides
+      ) =>
         AppDescriptor()
           .withRepositories(repositories)
           .withDependencies {
@@ -127,6 +156,7 @@ import scala.language.implicitConversions
           .withJvmOptionFile(jvmOptionFile)
           .withPrebuiltBinaries(prebuiltBinaries)
           .withJna(jna)
+          .withVersionOverrides(versionOverrides)
     }
   }
   def repr: String =
@@ -216,6 +246,71 @@ object RawAppDescriptor {
 
   }
 
+  @data class RawVersionOverride(
+    versionRange: String,
+    dependencies: Option[List[String]] = None,
+    repositories: Option[List[String]] = None,
+    mainClass: Option[String] = None,
+    properties: Option[RawAppDescriptor.Properties] = None
+  ) {
+    def versionOverride: ValidatedNel[String, VersionOverride] = {
+      val versionRangeV = coursier.core.Parse
+        .versionInterval(versionRange)
+        .toValidNel(s"""versionRange "$versionRange" is invalid""")
+      val repositoriesV = repositories.map(parseRepositories).sequence
+      val dependenciesV = dependencies.map(parseDependenices).sequence
+      val (mainClassOpt, defaultMainClassOpt) = mainClass.map(parseMainClass) match {
+        case Some(Left(mainClass))         => (Some(mainClass), Some(""))
+        case Some(Right(defaultMainClass)) => (Some(""), Some(defaultMainClass))
+        case None                          => (None, None)
+      }
+
+      (versionRangeV, repositoriesV, dependenciesV).mapN {
+        (versionRange, repositories, dependencies) =>
+          VersionOverride(versionRange)
+            .withDependencies(dependencies)
+            .withRepositories(repositories)
+            .withMainClass(mainClassOpt)
+            .withDefaultMainClass(defaultMainClassOpt)
+            .withJavaProperties(properties.map(_.props.sorted))
+      }
+    }
+  }
+
+  /* Left is mainClass and Right is defaultMainClass */
+  private def parseMainClass(mainClass: String): Either[String, String] =
+    if (mainClass.endsWith("?")) Right(mainClass.stripSuffix("?"))
+    else Left(mainClass)
+
+  private def parseDependenices(dependencies: Seq[String])
+    : ValidatedNel[String, Seq[JavaOrScalaDependency]] =
+    validationNelToCats(
+      DependencyParser.javaOrScalaDependencies(dependencies, Configuration.defaultCompile)
+    )
+
+  private def parseRepositories(repositories: Seq[String]): ValidatedNel[String, Seq[Repository]] =
+    validationNelToCats(RepositoryParser.repositories(repositories))
+
+  /** Check that there is no overlapping between version intervals
+    */
+  private[install] def validateRanges(versionOverrides: Seq[VersionOverride])
+    : ValidatedNel[String, Seq[VersionOverride]] =
+    versionOverrides
+      .map(_.versionRange)
+      .foldLeft[ValidatedNel[String, Seq[VersionInterval]]](Validated.valid(Seq.empty)) {
+        case (validRanges, range) =>
+          validRanges.andThen { ranges =>
+            val conflictingRanges = ranges.filter(_.merge(range).nonEmpty)
+
+            if (conflictingRanges.isEmpty) Validated.valid(ranges :+ range)
+            else {
+              val conflicts = conflictingRanges.map(i => "\"$i\"").mkString("[", ", ", "]")
+              Validated.invalidNel(s"""versionRange "$range" conflicts with $conflicts""")
+            }
+          }
+      }
+      .map(_ => versionOverrides)
+
   private[install] implicit def validationNelToCats[L, R](
     v: coursier.util.ValidationNel[L, R]
   ): ValidatedNel[L, R] =
@@ -241,7 +336,8 @@ object RawAppDescriptor {
     prebuilt: Option[String] = None,
     jvmOptionFile: Option[String] = None,
     prebuiltBinaries: Map[String, String] = Map.empty,
-    jna: List[String] = Nil
+    jna: List[String] = Nil,
+    versionOverrides: List[RawVersionOverride] = Nil
   ) {
     def get: RawAppDescriptor = {
       var d = RawAppDescriptor(dependencies)
@@ -259,6 +355,7 @@ object RawAppDescriptor {
         .withJvmOptionFile(jvmOptionFile)
         .withPrebuiltBinaries(prebuiltBinaries)
         .withJna(jna)
+        .withVersionOverrides(versionOverrides)
       for (t <- launcherType)
         d = d.withLauncherType(t)
       for (p <- properties)
@@ -285,7 +382,8 @@ object RawAppDescriptor {
       prebuilt = desc.prebuilt,
       jvmOptionFile = desc.jvmOptionFile,
       prebuiltBinaries = desc.prebuiltBinaries,
-      jna = desc.jna
+      jna = desc.jna,
+      versionOverrides = desc.versionOverrides
     )
 
   implicit val encoder: EncodeJson[RawAppDescriptor] =

--- a/modules/install/src/main/scala/coursier/install/VersionOverride.scala
+++ b/modules/install/src/main/scala/coursier/install/VersionOverride.scala
@@ -1,0 +1,14 @@
+package coursier.install
+
+import dataclass._
+import coursier.parse.JavaOrScalaDependency
+import coursier.core.{Repository, VersionInterval}
+
+@data class VersionOverride(
+  versionRange: VersionInterval,
+  dependencies: Option[Seq[JavaOrScalaDependency]] = None,
+  repositories: Option[Seq[Repository]] = None,
+  mainClass: Option[String] = None,
+  defaultMainClass: Option[String] = None,
+  javaProperties: Option[Seq[(String, String)]] = None
+)

--- a/modules/install/src/test/scala/coursier/install/RawAppDescriptorTests.scala
+++ b/modules/install/src/test/scala/coursier/install/RawAppDescriptorTests.scala
@@ -1,0 +1,33 @@
+package coursier.install
+
+import utest._
+import coursier.core.VersionInterval
+import coursier.core.Version
+import cats.data.Validated
+import coursier.core.Parse
+
+object RawAppDescriptorTests extends TestSuite {
+  val it1 = VersionInterval(Some(Version("2.0.1")), Some(Version("2.1.0")), true, true)
+  val it2 = VersionInterval(Some(Version("2.1.2")), Some(Version("2.3.0")), true, false)
+  val it3 = VersionInterval(Some(Version("3.0.0")), None, true, true)
+  val it4 = VersionInterval(Some(Version("2.2.0")), Some(Version("3.2.0")), false, false)
+
+  val vo1 = VersionOverride(it1)
+  val vo2 = VersionOverride(it2)
+  val vo3 = VersionOverride(it3)
+  val vo4 = VersionOverride(it4)
+
+  val tests: Tests = Tests {
+    test("validate disjoint version intervals") {
+      val versionOverrides = Seq(vo1, vo2, vo3)
+      val validated        = RawAppDescriptor.validateRanges(versionOverrides)
+      assert(validated == Validated.validNel(versionOverrides))
+    }
+
+    test("invalidate overlapping version intervals") {
+      val versionOverrides = Seq(vo1, vo2, vo4)
+      val validated        = RawAppDescriptor.validateRanges(versionOverrides)
+      assertMatch(validated) { case Validated.Invalid(_) => () }
+    }
+  }
+}

--- a/modules/install/src/test/scala/coursier/install/VersionRangeTests.scala
+++ b/modules/install/src/test/scala/coursier/install/VersionRangeTests.scala
@@ -1,0 +1,303 @@
+package coursier.install
+
+import utest._
+import coursier.core.Parse
+import coursier.core.Version
+
+/** This test class is a copy of
+  * https://github.com/sbt/librarymanagement/blob/develop/core/src/test/scala/sbt/librarymanagement/SemanticSelectorSpec.scala
+  * It shows that sbt semantic selectors can be expressed using coursier `VersionInterval` syntax.
+  * With some minor differences: in sbt 1.2.3-beta-gamma > 1.2.3-beta, not in coursier. And some
+  * limitations: coursier does not yet support the union of disjoint intervals It can be added later
+  * if the need arises: `class VersionRange(intervals: Seq[VersionInterval])`.
+  */
+object VersionRangeTests extends TestSuite {
+  val tests = Tests {
+    test("<=1.2.3") {
+      checkRange(
+        "(,1.2.3]",
+        Seq("1.2.3", "1.2-beta", "1.2.3-beta", "1.2", "1"),
+        Seq("1.2.4-alpha", "1.2.4", "1.3", "1.3.0", "2")
+      )
+    }
+
+    test("<=1.2") {
+      checkRange(
+        "(,1.2.max]",
+        Seq(
+          "1.2.345-beta",
+          "1.2.3-beta",
+          "1.2.3",
+          "1.2.0-beta",
+          "1.2.0",
+          "1.2",
+          "1"
+        ),
+        Seq("1.3.0", "1.3.0-alpha")
+      )
+    }
+
+    test("<=1") {
+      checkRange(
+        "(,1.max]",
+        Seq(
+          "1.234.567-alpha",
+          "1.234.567",
+          "1.234",
+          "1.0.0-alpha",
+          "1.0.0",
+          "1.0",
+          "1"
+        ),
+        Seq("2.0.0", "2.0.0-alpha")
+      )
+    }
+
+    test("<1.2.3") {
+      checkRange(
+        "(,1.2.3)",
+        Seq("1.2.3-alpha", "1.2.2", "1.2", "1"),
+        Seq("1.2.4-beta", "1.2.3", "1.3", "2")
+      )
+    }
+
+    test("<1.2") {
+      checkRange(
+        "(,1.2)",
+        Seq("1.2.0-alpha", "1.1.23", "1.1", "1"),
+        Seq("1.3-beta", "1.2.0", "1.2", "2")
+      )
+    }
+
+    test("<1") {
+      checkRange(
+        "(,1)",
+        Seq("1.0.0-beta", "0.9.9-beta", "0.9.12", "0.8", "0"),
+        Seq("1.0.1-beta", "1", "1.0", "1.0.0")
+      )
+    }
+
+    test(">=1.2.3") {
+      checkRange(
+        "[1.2.3,)",
+        Seq("1.2.4-beta", "1.2.3", "1.3", "2"),
+        Seq("1.2.3-beta", "1.2.2", "1.2", "1")
+      )
+    }
+
+    test(">=1.2") {
+      checkRange(
+        "[1.2,)",
+        Seq("1.2.1-beta", "1.2.0", "1.2", "2"),
+        Seq("1.2.0-beta", "1.1.23", "1.1", "1")
+      )
+    }
+
+    test(">=1") {
+      checkRange(
+        "[1,)",
+        Seq("1.0.1-beta", "1.0.0", "1.0", "1"),
+        Seq("1.0.0-beta", "0.9.9", "0.1", "0")
+      )
+    }
+
+    test(">1.2.3") {
+      checkRange(
+        "(1.2.3,)",
+        Seq("1.2.4", "1.2.4-alpha", "1.3", "2"),
+        Seq("1.2.3-alpha", "1.2.3", "1.2", "1")
+      )
+    }
+
+    test(">1.2") {
+      checkRange(
+        "(1.2.max,)",
+        Seq("1.3.0", "1.3.0-alpha", "1.3", "2"),
+        Seq(
+          "1.2.0-alpha",
+          "1.2.9",
+          "1.2",
+          "1"
+        )
+      )
+    }
+
+    test(">1") {
+      checkRange(
+        "(1.max,)",
+        Seq("2.0.0-alpha", "2.0.0", "2.0", "2"),
+        Seq(
+          "1.2.3-alpha",
+          "1.2.3",
+          "1.2",
+          "1"
+        )
+      )
+    }
+
+    test("1.2.3") {
+      checkRange(
+        "[1.2.3]",
+        Seq("1.2.3"),
+        Seq("1.2.3-alpha", "1.2", "1.2.4")
+      )
+    }
+
+    test("1.x") {
+      checkRange(
+        "[1,1.max]",
+        Seq("1.2.3-alpha", "1.0.0", "1.0.1", "1.1.1"),
+        Seq("1.0.0-alpha", "2.0.0-alpha", "2.0.0", "0.1.0")
+      )
+    }
+
+    test("1.2.x") {
+      checkRange(
+        "[1.2, 1.2.max]",
+        Seq("1.2.0", "1.2.3"),
+        Seq("1.2.0-alpha", "1.2.0-beta", "1.3.0-beta", "1.3.0", "1.1.1")
+      )
+    }
+
+    test("=1.2.3") {
+      checkRange(
+        "[1.2.3]",
+        Seq("1.2.3"),
+        Seq("1.2.3-alpha", "1.2", "1.2.4")
+      )
+    }
+
+    test("=1.2") {
+      checkRange(
+        "[1.2.0, 1.2.max]",
+        Seq("1.2.0", "1.2", "1.2.1", "1.2.4"),
+        Seq("1.1.0", "1.3.0", "1.2.0-alpha", "1.3.0-alpha")
+      )
+    }
+
+    test("=1") {
+      checkRange(
+        "[1.0.0, 1.max]",
+        Seq("1.0.0", "1.0", "1.0.1", "1.2.3"),
+        Seq("1.0.0-alpha", "2.0.0")
+      )
+    }
+
+    // test("1.2.3 || 2.0.0") {
+    //   checkRange(
+    //     "[1.2.3],[2.0.O]",
+    //     Seq("1.2.3","2.0.0"),
+    //     Seq("1.2","2.0.1")
+    //   )
+    // }
+
+    // test("<=1.2.3 || >=2.0.0 || 1.3.x") {
+    //   checkRange(
+    //     "(,1.2.3],[2.0.0,),[1.3.0,1.3.max]",
+    //     Seq("1.0","1.2.3","2.0.0","2.0","1.3.0","1.3.3"),
+    //     Seq("1.2.4","1.4.0")
+    //   )
+    // }
+
+    test(">=1.2.3 <2.0.0") {
+      checkRange(
+        "[1.2.3,2.0.0)",
+        Seq("1.2.3", "1.9.9"),
+        Seq("1.2", "2.0.0")
+      )
+    }
+
+    // test(">=1.2.3 <2.0.0 || >3.0.0 <=3.2.0") {
+    //   checkRange(
+    //     "[1.2.3,2.0.0),(3.0.0,3.2.0]",
+    //     Seq("1.2.3","1.9.9","3.0.1","3.2.0"),
+    //     Seq("1.2","2.0.0","3.0.0","3.2.1")
+    //   )
+    // }
+
+    test("1.2.3 - 2.0.0") {
+      checkRange(
+        "[1.2.3,2.0.0]",
+        Seq("1.2.3", "1.9.9", "2.0.0"),
+        Seq("1.2", "2.0.1")
+      )
+    }
+
+    test("1.2 - 2") {
+      checkRange(
+        "[1.2,2.max]",
+        Seq(
+          "1.2.0",
+          "1.9.9",
+          "2.0.0",
+          "2.0.1"
+        ),
+        Seq("1.1", "3.0.0")
+      )
+    }
+
+    test("1.2.3 - 2.0.0 1.5.0 - 2.4.0") {
+      checkRange(
+        "[1.5.0,2.0.0]",
+        Seq("1.5.0", "1.9.9", "2.0.0"),
+        Seq("1.2.3", "1.4", "2.0.1", "2.4.0")
+      )
+    }
+
+    // test("1.2.3 - 2.0 || 2.4.0 - 3") {
+    //   checkRange(
+    //     "[1.2.3,2.0.max],[2.4.0,3.max]",
+    //     Seq("1.2.3","1.5.0","2.0.0","2.4.0","2.9","3.0.0","2.0.1","3.0.1","3.1.0"),
+    //     Seq("2.1","2.3.9","4.0.0")
+    //   )
+    // }
+
+    test(">=1.x") {
+      checkRange(
+        "[1,)",
+        Seq("1.0.0", "1.0", "1"),
+        Seq("1.0.0-beta", "0.9.9", "0.1", "0")
+      )
+    }
+
+    test(">=1.2.3-beta") {
+      checkRange(
+        "[1.2.3-beta,)",
+        Seq(
+          "1.3-alpha",
+          "1.2.3",
+          "1.2.3-beta",
+          "1.2.3-beta-2",
+          // "1.2.3-beta-gamma",
+          "1.2.4",
+          "1.3"
+        ),
+        Seq("1.2.3-alpha", "1.2.2")
+      )
+    }
+
+    test(">=1.2.3-beta-2") {
+      checkRange(
+        "[1.2.3-beta-2,)",
+        Seq(
+          "1.3-alpha",
+          "1.2.3",
+          "1.2.3-beta-2",
+          "1.2.3-beta-2-3",
+          "1.2.3-beta-3",
+          // "1.2.3-beta-gamma",
+          "1.2.4",
+          "1.3"
+        ),
+        Seq("1.2.3-alpha-3", "1.2.3-beta-1", "1.2.3-beta", "1.2.2")
+      )
+    }
+  }
+
+  def checkRange(interval: String, contains: Seq[String], notContain: Seq[String]) = {
+    val vi = Parse.versionInterval(interval).get
+    contains.map(Version.apply).foreach(v => assert(vi.contains(v)))
+    notContain.map(Version.apply).foreach(v => assert(!vi.contains(v)))
+
+  }
+}


### PR DESCRIPTION
Fixes #2195 

A `VersionOverride` is a way to override the app descriptor based on the app version.
This change is introduced so that we can merge `scalac` and `scala3-compiler` into the same app descriptor:
```json
{
  "mainClass": "dotty.tools.dotc.Main",
  "repositories": [
    "central"
  ],
  "dependencies": [
    "org.scala-lang:scala3-compiler_3:latest.stable"
  ],
  "properties": {
    "scala.usejavacp": "true"
  },
  "versionOverrides": [
    {
      "versionRange": "(,2.max]",
      "mainClass": "scala.tools.nsc.Main",
      "repositories": [
        "central"
      ],
      "dependencies": [
        "org.scala-lang:scala-compiler:latest.stable"
      ],
      "properties": {
        "scala.usejavacp": "true"
      }
    }
  ]
}
```
The above app descriptor works this way:
1. If no version is specified, Coursier will install the latest stable Scala 3 compiler:

```bash
> ./mill -i cli.run install scalac
https://repo1.maven.org/maven2/org/scala-lang/scala3-compiler_3/maven-metadata.xml
  No new update since 2021-10-20 06:09:06
Wrote scalac
> scalac -version
Scala compiler version 3.1.0 -- Copyright 2002-2021, LAMP/EPFL
```
2. However, if the user specifies a version below `2.max`, Coursier will install the Scala 2 compiler whose maven coordinates and
main class are different:

```bash
> ./mill -i cli.run install scalac:2.13.5
Wrote scalac
> scalac -version
Scala compiler version 2.13.5 -- Copyright 2002-2020, LAMP/EPFL and Lightbend, Inc.
```
3. Also, `cs update scalac` will always overwrite `scalac` with the latest stable Scala 3 compiler.

