### PR TITLE
fix: ensure env creds from file are read correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,3 @@ processed-docs/
 .bloop/
 
 bin/
-
-target/


### PR DESCRIPTION
I _think_ this might address the issues I'm having in https://github.com/coursier/coursier/issues/1826 and also in https://github.com/VirtusLab/scala-cli/discussions/300. If I'm understanding the code right the filter here was _always_ filtering out the value since reading in from `COURSIER_CREDENTIALS` shouldn't really ever start with `file:` or `/`. So if anyone ever set this, it would be filtered out and then just be a `None` here when trying to get the default credentials. This small fix removes the filter so it falls into the flatmap cases where _then_ we can check for a file and also for just values like we want.

~I didn't actually get the test this locally,  I tried figuring out how to get the cli published and usable, but couldn't figure it out. What is the mill equivalent how to get a cli to test like you had [outlined here for sbt](https://get-coursier.io/docs/dev-cli)~

Actually I realized I could do this  `./mill -i cli.run resolve <my-private-artifact>`

\o/ this works!!!! I've been wanting to get this to work for such a long time. I've been having to pass in `--credentials` all the time, and now I don't have to. This should also greatly help with `scala-cli`.

Closes #1826 