### PR TITLE
Remove Homebrew's deprecated `:bottle unneeded`

### DIFF
--- a/.github/scripts/coursier.rb.template
+++ b/.github/scripts/coursier.rb.template
@@ -5,7 +5,6 @@ class Coursier < Formula
   url "@LAUNCHER_URL@"
   version "@LAUNCHER_VERSION@"
   sha256 "@LAUNCHER_SHA256@"
-  bottle :unneeded
 
   option "without-zsh-completions", "Disable zsh completion installation"
 


### PR DESCRIPTION
Closes coursier#2241 

Fixes this Homebrew warning:

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the coursier/formulas tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/coursier/homebrew-formulas/coursier.rb:8
```

According to this discussion, the call can just be removed:
Homebrew/discussions#2311 (comment)