### PR TITLE
Set a non-empty User-Agent

### DIFF
--- a/modules/cache/jvm/src/main/scala/coursier/cache/CacheUrl.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/CacheUrl.scala
@@ -142,7 +142,7 @@ object CacheUrl {
 
         // Early in the development of coursier, I ran into some repositories (Sonatype ones?) not
         // returning the same content for user agent "Java/…".
-        conn0.setRequestProperty("User-Agent", "")
+        conn0.setRequestProperty("User-Agent", "Coursier")
 
         conn0 match {
           case conn1: HttpsURLConnection =>

--- a/modules/cache/jvm/src/main/scala/coursier/cache/CacheUrl.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/CacheUrl.scala
@@ -140,10 +140,6 @@ object CacheUrl {
         // handling those ourselves, so that we can update credentials upon redirection
         conn0.setInstanceFollowRedirects(false)
 
-        // Early in the development of coursier, I ran into some repositories (Sonatype ones?) not
-        // returning the same content for user agent "Java/…".
-        conn0.setRequestProperty("User-Agent", "Coursier")
-
         conn0 match {
           case conn1: HttpsURLConnection =>
             for (f <- sslSocketFactoryOpt)


### PR DESCRIPTION
Some repositories have a policy that rejects requests with an empty User-Agent value.

This change sets the User-Agent to a valid non-empty value.