### PR TITLE
Add main and command descriptions in help message

### DIFF
--- a/modules/cli/src/main/scala/coursier/cli/Coursier.scala
+++ b/modules/cli/src/main/scala/coursier/cli/Coursier.scala
@@ -21,6 +21,11 @@ object Coursier extends CommandsEntryPoint {
 
   lazy val progName = (new Argv0).get("coursier")
 
+  override val description =
+    """|Coursier is the Scala application and artifact manager.
+       |It can install Scala applications and setup your Scala development environment.
+       |It can also download and cache artifacts from the web.""".stripMargin
+
   val commands = Seq(
     bootstrap.Bootstrap,
     channel.Channel,

--- a/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapOptions.scala
@@ -1,13 +1,21 @@
 package coursier.cli.bootstrap
 
-import caseapp.{ArgsName, Parser, Recurse}
+import caseapp.{ArgsName, HelpMessage, Parser, Recurse}
 import coursier.cli.install.SharedChannelOptions
 import coursier.cli.native.NativeLauncherOptions
 import coursier.cli.options.SharedLaunchOptions
 import coursier.install.RawAppDescriptor
 
 // format: off
-@ArgsName("org:name:version|app-name[:version]*")
+@ArgsName("org:name:version*|app-name[:version]")
+@HelpMessage(
+  "Create a binary launcher from a dependency or an application descriptor.\n" +
+  "The generated launcher can then be used without cs being installed.\n" +
+  "\n" +
+  "Examples:\n" +
+  "$ cs bootstrap org.scalameta::scalafmt-cli:2.4.2 -o scalafmt\n" +
+  "$ cs bootstrap scalafmt -o scalafmt\n"
+)
 final case class BootstrapOptions(
   @Recurse
     nativeOptions: NativeLauncherOptions = NativeLauncherOptions(),

--- a/modules/cli/src/main/scala/coursier/cli/channel/ChannelOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/channel/ChannelOptions.scala
@@ -1,9 +1,17 @@
 package coursier.cli.channel
 
-import caseapp.{ExtraName => Short, HelpMessage => Help, _}
+import caseapp.{ExtraName => Short, HelpMessage => Help, Recurse}
 import coursier.cli.options.OutputOptions
 
 // format: off
+@Help(
+  "Manage additional channels, used by coursier to resolve application descriptors.\n" +
+  "Those channels are stored in coursier configuration files.\n" +
+  "\n" +
+  "Examples:\n" +
+  "$ cs channel --add io.get-coursier:apps-contrib\n" +
+  "$ cs channel --list\n"
+)
 final case class ChannelOptions(
   @Short("a")
   @Help("adds given URL based channels")

--- a/modules/cli/src/main/scala/coursier/cli/complete/CompleteOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/complete/CompleteOptions.scala
@@ -4,6 +4,15 @@ import caseapp.{ExtraName => Short, HelpMessage => Help, _}
 import coursier.cli.options.{CacheOptions, OutputOptions, RepositoryOptions}
 
 // format: off
+@ArgsName("org[:name[:version]]")
+@Help(
+  "Auto-complete Maven coordinates.\n" +
+  "\n" + 
+  "Examples:\n" +
+  "$ cs complete-dep com.type\n" +
+  "$ cs complete-dep org.scala-lang:\n" +
+  "$ cs complete-dep org.scala-lang:scala-compiler:2.13.\n"
+)
 final case class CompleteOptions(
 
   @Recurse

--- a/modules/cli/src/main/scala/coursier/cli/fetch/FetchOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/fetch/FetchOptions.scala
@@ -7,7 +7,13 @@ import coursier.cli.resolve.SharedResolveOptions
 import coursier.install.RawAppDescriptor
 
 // format: off
-@ArgsName("org:name:version|app-name[:version]*")
+@ArgsName("org:name:version*|app-name[:version]")
+@Help(
+  "Transitively fetch the JARs of one or more dependencies or an application.\n" +
+  "\n" +
+  "Examples:\n" +
+  "$ cs fetch io.circe::circe-generic:0.12.3\n"
+)
 final case class FetchOptions(
 
   @Help("Print java -cp compatible output")

--- a/modules/cli/src/main/scala/coursier/cli/get/GetOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/get/GetOptions.scala
@@ -2,10 +2,12 @@ package coursier.cli.get
 
 import caseapp.core.help.Help
 import caseapp.core.parser.Parser
-import caseapp.{Name, Recurse}
+import caseapp.{ArgsName, HelpMessage, Name, Recurse}
 import coursier.cli.options.{CacheOptions, OutputOptions}
 
 // format: off
+@ArgsName("url*")
+@HelpMessage("Download and cache a file from its URL.")
 final case class GetOptions(
   @Recurse
     cache: CacheOptions,

--- a/modules/cli/src/main/scala/coursier/cli/install/InstallOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/install/InstallOptions.scala
@@ -5,6 +5,15 @@ import coursier.cli.jvm.SharedJavaOptions
 import coursier.cli.options.{CacheOptions, EnvOptions, OutputOptions, RepositoryOptions}
 
 // format: off
+@ArgsName("app-name[:version]*")
+@HelpMessage(
+  "Install an application from its descriptor.\n" +
+  "\n" +
+  "Examples:\n" +
+  "$ cs install scalafmt\n" +
+  "$ cs install --channel io.get-coursier:apps-contrib proguard\n" +
+  "$ cs install --contrib proguard\n"
+)
 final case class InstallOptions(
 
   @Recurse

--- a/modules/cli/src/main/scala/coursier/cli/install/ListOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/install/ListOptions.scala
@@ -1,8 +1,14 @@
 package coursier.cli.install
 
-import caseapp.{ExtraName => Short, Parser}
+import caseapp.{ExtraName => Short, HelpMessage, Parser}
 
 // format: off
+@HelpMessage(
+  "List all currently installed applications.\n" +
+  "\n" +
+  "Example:\n" +
+  "$ cs list\n"
+)
 final case class ListOptions(
   @Short("dir")
     installDir: Option[String] = None,

--- a/modules/cli/src/main/scala/coursier/cli/install/UninstallOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/install/UninstallOptions.scala
@@ -3,6 +3,16 @@ package coursier.cli.install
 import caseapp.{ExtraName => Short, HelpMessage => Help, _}
 
 // format: off
+@ArgsName("app-name*")
+@Help(
+  "Uninstall one or more applications.\n" +
+  "The given name must be the application executable name, which may differ from the descriptor name.\n" +
+  "\n" +
+  "Examples:\n" +
+  "$ cs uninstall amm\n" +
+  "$ cs uninstall bloop scalafix\n" +
+  "$ cs uninstall --all\n"
+)
 final case class UninstallOptions(
 
   @Short("dir")

--- a/modules/cli/src/main/scala/coursier/cli/install/UpdateOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/install/UpdateOptions.scala
@@ -1,10 +1,19 @@
 package coursier.cli.install
 
-import caseapp.{ExtraName => Short, HelpMessage => Help, ValueDescription => Value, _}
+import caseapp.{ArgsName, ExtraName => Short, HelpMessage => Help, ValueDescription => Value, _}
 import coursier.cli.jvm.SharedJavaOptions
 import coursier.cli.options.{CacheOptions, OutputOptions, RepositoryOptions}
 
 // format: off
+@ArgsName("app-name*")
+@Help(
+  "Update one or more applications.\n" +
+  "\n" +
+  "Examples:\n" +
+  "$ cs update\n" +
+  "$ cs update amm\n" +
+  "$ cs update sbt sbtn\n"
+)
 final case class UpdateOptions(
 
   @Recurse

--- a/modules/cli/src/main/scala/coursier/cli/jvm/JavaHomeOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/jvm/JavaHomeOptions.scala
@@ -2,9 +2,18 @@ package coursier.cli.jvm
 
 import coursier.cli.options.{CacheOptions, EnvOptions, OutputOptions, RepositoryOptions}
 import caseapp.core.parser.Parser
-import caseapp.Recurse
+import caseapp.{HelpMessage, Recurse}
 
 // format: off
+@HelpMessage(
+  "Print the home directory of a particular JVM.\n" +
+  "Install the requested JVM if it is not already installed.\n" +
+  "\n" +
+  "Examples:\n" +
+  "$ cs java-home\n" +
+  "$ cs java-home --jvm adopt:13.0-2\n" +
+  "$ cs java-home --jvm 11\n"
+)
 final case class JavaHomeOptions(
   @Recurse
     sharedJavaOptions: SharedJavaOptions = SharedJavaOptions(),

--- a/modules/cli/src/main/scala/coursier/cli/jvm/JavaOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/jvm/JavaOptions.scala
@@ -1,10 +1,20 @@
 package coursier.cli.jvm
 
 import caseapp.core.parser.Parser
-import caseapp.Recurse
+import caseapp.{HelpMessage, Recurse}
 import coursier.cli.options.{CacheOptions, EnvOptions, OutputOptions, RepositoryOptions}
 
 // format: off
+@HelpMessage(
+  "Manage installed JVMs and run java.\n" +
+  "\n" +
+  "Examples:\n" +
+  "$ cs java --available\n" +
+  "$ cs java --installed\n" +
+  "$ cs java --jvm adopt:13.0-2 -version\n" +
+  "$ cs java --jvm 11 --env\n" +
+  "$ cs java --jvm adopt:11 --setup\n"
+)
 final case class JavaOptions(
   available: Boolean = false,
   @Recurse

--- a/modules/cli/src/main/scala/coursier/cli/launch/LaunchOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/launch/LaunchOptions.scala
@@ -7,7 +7,14 @@ import coursier.cli.options.SharedLaunchOptions
 import coursier.install.RawAppDescriptor
 
 // format: off
-@ArgsName("org:name:version|app-name[:version]*")
+@ArgsName("org:name:version*|app-name[:version]")
+@Help(
+  "Launch an application from a dependency or an application descriptor.\n" +
+  "\n" +
+  "Examples:\n" +
+  "$ cs launch org.scalameta:scalafmt-cli:2.4.2 -- --version\n" +
+  "$ cs scalafmt -- --version\n"
+)
 final case class LaunchOptions(
 
   @Recurse

--- a/modules/cli/src/main/scala/coursier/cli/publish/options/PublishOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/publish/options/PublishOptions.scala
@@ -4,6 +4,7 @@ import caseapp._
 import coursier.cli.options.CacheOptions
 
 // format: off
+@HelpMessage("[Experimental] Publish an artifact to a maven repository.")
 final case class PublishOptions(
 
   @Recurse

--- a/modules/cli/src/main/scala/coursier/cli/resolve/ResolveOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/resolve/ResolveOptions.scala
@@ -12,7 +12,15 @@ import coursier.cli.options.{
 import coursier.install.RawAppDescriptor
 
 // format: off
-@ArgsName("org:name:version|app-name[:version]*")
+@ArgsName("org:name:version*|app-name[:version]")
+@Help(
+  "Resolve and print the transitive dependencies of one or more dependencies or an application.\n" +
+  "Print the maven coordinates, does not download the artifacts.\n" +
+  "\n" +
+  "Examples:\n" +
+  "$ cs resolve org.http4s:http4s-dsl_2.12:0.18.21\n" +
+  "$ cs resolve --tree org.http4s:http4s-dsl_2.12:0.18.21"
+)
 final case class ResolveOptions(
 
   @Help("Print the duration of each iteration of the resolution (if negative, doesn't print per iteration benchmark -> less overhead)")

--- a/modules/cli/src/main/scala/coursier/cli/search/SearchOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/search/SearchOptions.scala
@@ -5,6 +5,14 @@ import coursier.cli.install.SharedChannelOptions
 import coursier.cli.options.{CacheOptions, OutputOptions, RepositoryOptions}
 
 // format: off
+@ArgsName("query*")
+@Help(
+  "Search application names from known channels.\n" +
+  "\n" +
+  "Examples:\n" +
+  "$ cs search scala\n" +
+  "$ cs search fmt fix\n"
+)
 final case class SearchOptions(
 
   @Recurse

--- a/modules/cli/src/main/scala/coursier/cli/setup/SetupOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/setup/SetupOptions.scala
@@ -1,12 +1,21 @@
 package coursier.cli.setup
 
 import caseapp.core.parser.Parser
-import caseapp.{Name => Short, Recurse}
+import caseapp.{HelpMessage, Name => Short, Recurse}
 import coursier.cli.install.{SharedChannelOptions, SharedInstallOptions}
 import coursier.cli.jvm.SharedJavaOptions
 import coursier.cli.options.{CacheOptions, EnvOptions, OutputOptions, RepositoryOptions}
 
 // format: off
+@HelpMessage(
+  "Setup a machine for Scala development.\n" +
+  "Install Coursier itself and standard Scala tooling.\n" +
+  "Also install a JVM if necessary.\n" +
+  "\n" +
+  "Examples:\n" +
+  "$ cs setup\n" +
+  "$ cs setup --jvm 11 --apps bloop,scalafix\n"
+)
 final case class SetupOptions(
   @Recurse
     sharedJavaOptions: SharedJavaOptions = SharedJavaOptions(),


### PR DESCRIPTION
The `cs -h` message looks like this:
```
Usage: coursier <COMMAND>
Coursier is the Scala application and artifact manager.
It can install Scala applications and setup your Scala development environment.
It can also download and cache artifacts from the web.



Commands:
  bootstrap                          Create a binary launcher from a dependency or an application descriptor.
  channel                            Manage additional channels, used by coursier to resolve application descriptors.
  complete-dep, complete-dependency  Auto-complete Maven coordinates.
  fetch                              Transitively fetch the JARs of one or more dependencies or an application.
  get                                Download and cache a file from its URL.
  install                            Install an application from its descriptor.
  java                               Manage installed JVMs and run java.
  java-home                          Print the home directory of a particular JVM.
  launch                             Launch an application from a dependency or an application descriptor.
  list                               List all currently installed application
  publish                            [Experimental] Publish an artifact to a maven repository.
  resolve                            Resolve and print the transitive dependencies of one or more dependencies or an application.
  search                             Search application names from known channels.
  setup                              Setup a machine for Scala development.
  uninstall                          Uninstall one or more applications.
  update                             Update one or more applications.
```

As an example the `cs bootstrap -h` message looks like this:
```
Usage: coursier bootstrap [options] [org:name:version*|app-name[:version]]
Create a binary launcher from a dependency or an application descriptor.
The generated launcher can then be used without cs being installed.

Examples:
$ cs bootstrap org.scalameta::scalafmt-cli:2.4.2 -o scalafmt
$ cs bootstrap scalafmt -o scalafmt

App channel options:
  --channel org:name  Channel for apps
  --contrib           Add contrib channel

<elided>
```