### PR TITLE
Group commands in help message

### DIFF
--- a/modules/cli/src/main/scala/coursier/cli/CommandGroup.scala
+++ b/modules/cli/src/main/scala/coursier/cli/CommandGroup.scala
@@ -1,0 +1,11 @@
+package coursier.cli
+
+object CommandGroup {
+  val install: String  = "Install application"
+  val channel: String  = "Application channel"
+  val java: String     = "Java"
+  val launcher: String = "Launcher"
+  val resolve: String  = "Resolution"
+
+  val order: Seq[String] = Seq(install, channel, java, launcher, resolve)
+}

--- a/modules/cli/src/main/scala/coursier/cli/Coursier.scala
+++ b/modules/cli/src/main/scala/coursier/cli/Coursier.scala
@@ -13,6 +13,7 @@ import java.util.Scanner
 
 import scala.util.control.NonFatal
 import scala.util.Properties
+import caseapp.core.help.HelpFormat
 
 object Coursier extends CommandsEntryPoint {
 
@@ -119,4 +120,8 @@ object Coursier extends CommandsEntryPoint {
       sys.exit(1)
     }
   }
+
+  override def helpFormat: HelpFormat =
+    HelpFormat.default()
+      .withSortedCommandGroups(Some(CommandGroup.order))
 }

--- a/modules/cli/src/main/scala/coursier/cli/bootstrap/Bootstrap.scala
+++ b/modules/cli/src/main/scala/coursier/cli/bootstrap/Bootstrap.scala
@@ -6,7 +6,7 @@ import java.util.concurrent.ExecutorService
 
 import caseapp.core.RemainingArgs
 import coursier.cache.{Cache, CacheLogger}
-import coursier.cli.CoursierCommand
+import coursier.cli.{CoursierCommand, CommandGroup}
 import coursier.cli.fetch.Fetch
 import coursier.cli.launch.{Launch, LaunchException}
 import coursier.cli.resolve.{Resolve, ResolveException}
@@ -201,6 +201,8 @@ object Bootstrap extends CoursierCommand[BootstrapOptions] {
         .addDependencies(deps0: _*)
         .run()
   }
+
+  override def group: String = CommandGroup.launcher
 
   def run(options: BootstrapOptions, args: RemainingArgs): Unit = {
 

--- a/modules/cli/src/main/scala/coursier/cli/channel/Channel.scala
+++ b/modules/cli/src/main/scala/coursier/cli/channel/Channel.scala
@@ -5,12 +5,14 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 
 import caseapp.core.RemainingArgs
-import coursier.cli.CoursierCommand
+import coursier.cli.{CoursierCommand, CommandGroup}
 import coursier.cli.params.OutputParams
 import coursier.cli.Util.ValidatedExitOnError
 import coursier.paths.Util.createDirectories
 
 object Channel extends CoursierCommand[ChannelOptions] {
+
+  override def group: String = CommandGroup.channel
 
   def run(options: ChannelOptions, args: RemainingArgs): Unit = {
     val params = ChannelParam(options, args.all.nonEmpty).exitOnError()

--- a/modules/cli/src/main/scala/coursier/cli/complete/Complete.scala
+++ b/modules/cli/src/main/scala/coursier/cli/complete/Complete.scala
@@ -7,8 +7,8 @@ import coursier.util.Sync
 import scala.concurrent.ExecutionContext
 
 object Complete extends CoursierCommand[CompleteOptions] {
-
-  override def group: String = CommandGroup.resolve
+  override def hidden: Boolean = true
+  override def group: String   = CommandGroup.resolve
 
   override def names = List(
     List("complete-dep"),

--- a/modules/cli/src/main/scala/coursier/cli/complete/Complete.scala
+++ b/modules/cli/src/main/scala/coursier/cli/complete/Complete.scala
@@ -1,12 +1,15 @@
 package coursier.cli.complete
 
 import caseapp.core.RemainingArgs
-import coursier.cli.CoursierCommand
+import coursier.cli.{CoursierCommand, CommandGroup}
 import coursier.util.Sync
 
 import scala.concurrent.ExecutionContext
 
 object Complete extends CoursierCommand[CompleteOptions] {
+
+  override def group: String = CommandGroup.resolve
+
   override def names = List(
     List("complete-dep"),
     List("complete-dependency")

--- a/modules/cli/src/main/scala/coursier/cli/fetch/Fetch.scala
+++ b/modules/cli/src/main/scala/coursier/cli/fetch/Fetch.scala
@@ -7,7 +7,7 @@ import java.util.concurrent.ExecutorService
 
 import caseapp._
 import cats.data.Validated
-import coursier.cli.CoursierCommand
+import coursier.cli.{CoursierCommand, CommandGroup}
 import coursier.cli.resolve.{Output, Resolve, ResolveException}
 import coursier.core.Resolution
 import coursier.install.Channels
@@ -80,6 +80,8 @@ object Fetch extends CoursierCommand[FetchOptions] {
       artifactFiles.collect { case (a, Some(f)) => a -> f }
     )
   }
+
+  override def group: String = CommandGroup.resolve
 
   def run(options: FetchOptions, args: RemainingArgs): Unit = {
 

--- a/modules/cli/src/main/scala/coursier/cli/get/Get.scala
+++ b/modules/cli/src/main/scala/coursier/cli/get/Get.scala
@@ -8,6 +8,7 @@ import coursier.util.{Artifact, Sync, Task}
 import scala.concurrent.ExecutionContext
 
 object Get extends CoursierCommand[GetOptions] {
+  override def hidden: Boolean = true
   def run(options: GetOptions, args: RemainingArgs): Unit = {
 
     val params = GetParams(options).toEither match {

--- a/modules/cli/src/main/scala/coursier/cli/install/Install.scala
+++ b/modules/cli/src/main/scala/coursier/cli/install/Install.scala
@@ -7,7 +7,7 @@ import java.time.Instant
 
 import caseapp.core.RemainingArgs
 import coursier.cli.channel.Channel
-import coursier.cli.CoursierCommand
+import coursier.cli.{CoursierCommand, CommandGroup}
 import coursier.cli.setup.MaybeSetupPath
 import coursier.cli.Util.ValidatedExitOnError
 import coursier.install.{Channels, InstallDir, RawSource}
@@ -19,6 +19,8 @@ import coursier.util.Sync
 import scala.concurrent.duration.Duration
 
 object Install extends CoursierCommand[InstallOptions] {
+
+  override def group: String = CommandGroup.install
 
   def run(options: InstallOptions, args: RemainingArgs): Unit = {
 

--- a/modules/cli/src/main/scala/coursier/cli/install/List.scala
+++ b/modules/cli/src/main/scala/coursier/cli/install/List.scala
@@ -1,10 +1,13 @@
 package coursier.cli.install
 
 import caseapp.core.RemainingArgs
-import coursier.cli.CoursierCommand
+import coursier.cli.{CoursierCommand, CommandGroup}
 import coursier.install.InstallDir
 
 object List extends CoursierCommand[ListOptions] {
+
+  override def group: String = CommandGroup.install
+
   def run(options: ListOptions, args: RemainingArgs): Unit = {
     val params     = ListParams(options)
     val installDir = InstallDir(params.installPath, new NoopCache)

--- a/modules/cli/src/main/scala/coursier/cli/install/Uninstall.scala
+++ b/modules/cli/src/main/scala/coursier/cli/install/Uninstall.scala
@@ -1,7 +1,7 @@
 package coursier.cli.install
 
 import caseapp.core.RemainingArgs
-import coursier.cli.CoursierCommand
+import coursier.cli.{CoursierCommand, CommandGroup}
 import coursier.cli.Util.ValidatedExitOnError
 import coursier.install.InstallDir
 import coursier.cache.Cache
@@ -14,6 +14,8 @@ import java.io.File
 import scala.concurrent.ExecutionContext
 
 object Uninstall extends CoursierCommand[UninstallOptions] {
+
+  override def group: String = CommandGroup.install
 
   def run(options: UninstallOptions, args: RemainingArgs): Unit = {
 

--- a/modules/cli/src/main/scala/coursier/cli/install/Update.scala
+++ b/modules/cli/src/main/scala/coursier/cli/install/Update.scala
@@ -3,7 +3,7 @@ package coursier.cli.install
 import java.time.Instant
 
 import caseapp.core.RemainingArgs
-import coursier.cli.CoursierCommand
+import coursier.cli.{CoursierCommand, CommandGroup}
 import coursier.install.{Channels, InstallDir}
 import coursier.install.error.InstallDirException
 import coursier.util.{Sync, Task}
@@ -11,6 +11,9 @@ import coursier.util.{Sync, Task}
 import scala.concurrent.duration.Duration
 
 object Update extends CoursierCommand[UpdateOptions] {
+
+  override def group: String = CommandGroup.install
+
   def run(options: UpdateOptions, args: RemainingArgs): Unit = {
 
     val params = UpdateParams(options).toEither match {

--- a/modules/cli/src/main/scala/coursier/cli/jvm/Java.scala
+++ b/modules/cli/src/main/scala/coursier/cli/jvm/Java.scala
@@ -3,7 +3,7 @@ package coursier.cli.jvm
 import java.io.File
 
 import caseapp.core.RemainingArgs
-import coursier.cli.CoursierCommand
+import coursier.cli.{CoursierCommand, CommandGroup}
 import coursier.cli.params.EnvParams
 import coursier.cli.setup.MaybeInstallJvm
 import coursier.cli.Util.ValidatedExitOnError
@@ -16,6 +16,9 @@ import scala.concurrent.duration.Duration
 
 object Java extends CoursierCommand[JavaOptions] {
   override def stopAtFirstUnrecognized = true
+
+  override def group: String = CommandGroup.java
+
   def run(options: JavaOptions, args: RemainingArgs): Unit = {
 
     // that should probably be fixed by case-app

--- a/modules/cli/src/main/scala/coursier/cli/jvm/JavaHome.scala
+++ b/modules/cli/src/main/scala/coursier/cli/jvm/JavaHome.scala
@@ -3,7 +3,7 @@ package coursier.cli.jvm
 import java.io.File
 
 import caseapp.core.RemainingArgs
-import coursier.cli.CoursierCommand
+import coursier.cli.{CoursierCommand, CommandGroup}
 import coursier.cli.setup.MaybeInstallJvm
 import coursier.cli.Util.ValidatedExitOnError
 import coursier.env.{EnvironmentUpdate, EnvVarUpdater, ProfileUpdater, WindowsEnvVarUpdater}
@@ -14,6 +14,8 @@ import coursier.util.{Sync, Task}
 import scala.concurrent.duration.Duration
 
 object JavaHome extends CoursierCommand[JavaHomeOptions] {
+
+  override def group: String = CommandGroup.java
 
   def run(options: JavaHomeOptions, args: RemainingArgs): Unit = {
 

--- a/modules/cli/src/main/scala/coursier/cli/launch/Launch.scala
+++ b/modules/cli/src/main/scala/coursier/cli/launch/Launch.scala
@@ -8,7 +8,7 @@ import java.util.concurrent.ExecutorService
 
 import caseapp.core.RemainingArgs
 import cats.data.Validated
-import coursier.cli.CoursierCommand
+import coursier.cli.{CoursierCommand, CommandGroup}
 import coursier.cli.fetch.Fetch
 import coursier.cli.params.{ArtifactParams, SharedLaunchParams, SharedLoaderParams}
 import coursier.cli.resolve.{Resolve, ResolveException}
@@ -508,6 +508,8 @@ object Launch extends CoursierCommand[LaunchOptions] {
         )
       }
     } yield (mainClass0, f)
+
+  override def group: String = CommandGroup.launcher
 
   def run(options: LaunchOptions, args: RemainingArgs): Unit = {
 

--- a/modules/cli/src/main/scala/coursier/cli/publish/Publish.scala
+++ b/modules/cli/src/main/scala/coursier/cli/publish/Publish.scala
@@ -24,6 +24,7 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext}
 
 object Publish extends CoursierCommand[PublishOptions] {
+  override def hidden: Boolean = true
 
   val defaultChecksums = Seq(ChecksumType.MD5, ChecksumType.SHA1)
 

--- a/modules/cli/src/main/scala/coursier/cli/resolve/Resolve.scala
+++ b/modules/cli/src/main/scala/coursier/cli/resolve/Resolve.scala
@@ -8,7 +8,7 @@ import caseapp._
 import coursier.Resolution
 import coursier.cache.Cache
 import coursier.cache.loggers.RefreshLogger
-import coursier.cli.CoursierCommand
+import coursier.cli.{CoursierCommand, CommandGroup}
 import coursier.cli.install.Install
 import coursier.cli.util.MonadlessTask._
 import coursier.core.{Dependency, Module, Repository}
@@ -392,6 +392,8 @@ object Resolve extends CoursierCommand[ResolveOptions] {
       (withApp(options, desc), desc.dependencies ++ deps)
     }
   }
+
+  override def group: String = CommandGroup.resolve
 
   def run(options: ResolveOptions, args: RemainingArgs): Unit = {
 

--- a/modules/cli/src/main/scala/coursier/cli/search/Search.scala
+++ b/modules/cli/src/main/scala/coursier/cli/search/Search.scala
@@ -1,12 +1,14 @@
 package coursier.cli.search
 
 import caseapp.core.RemainingArgs
-import coursier.cli.CoursierCommand
+import coursier.cli.{CoursierCommand, CommandGroup}
 import coursier.cli.Util.ValidatedExitOnError
 import coursier.install.Channels
 import coursier.util.Sync
 
 object Search extends CoursierCommand[SearchOptions] {
+
+  override def group: String = CommandGroup.channel
 
   override def run(options: SearchOptions, args: RemainingArgs): Unit = {
     val params = SearchParams(options, args.all.nonEmpty).exitOnError()

--- a/modules/cli/src/main/scala/coursier/cli/setup/Setup.scala
+++ b/modules/cli/src/main/scala/coursier/cli/setup/Setup.scala
@@ -4,7 +4,7 @@ import java.io.File
 import java.util.Locale
 
 import caseapp.core.RemainingArgs
-import coursier.cli.CoursierCommand
+import coursier.cli.{CoursierCommand, CommandGroup}
 import coursier.cli.Util.ValidatedExitOnError
 import coursier.env.{EnvironmentUpdate, ProfileUpdater, WindowsEnvVarUpdater}
 import coursier.install.{Channels, InstallDir}
@@ -16,6 +16,8 @@ import coursier.util.{Sync, Task}
 import scala.concurrent.duration.Duration
 
 object Setup extends CoursierCommand[SetupOptions] {
+
+  override def group: String = CommandGroup.install
 
   def run(options: SetupOptions, args: RemainingArgs): Unit = {
 


### PR DESCRIPTION
In combination with https://github.com/coursier/coursier/pull/2250 it looks like this:

```
Usage: coursier <COMMAND>
Coursier is the Scala application and artifact manager.
It can install Scala applications and setup your Scala development environment.
It can also download and cache artifacts from the web.



Other commands:
  get      Download and cache a file from its URL.
  publish  [Experimental] Publish an artifact to a maven repository.

Application channel commands:
  channel  Manage additional channels, used by coursier to resolve application descriptors.
  search   Search application names from known channels.

Install application commands:
  install    Install an application from its descriptor.
  list       List all currently installed applications.
  setup      Setup a machine for Scala development.
  uninstall  Uninstall one or more applications.
  update     Update one or more applications.

Java commands:
  java       Manage installed JVMs and run java.
  java-home  Print the home directory of a particular JVM.

Launcher commands:
  bootstrap  Create a binary launcher from a dependency or an application descriptor.
  launch     Launch an application from a dependency or an application descriptor.

Resolution commands:
  complete-dep, complete-dependency  Auto-complete Maven coordinates.
  fetch                              Transitively fetch the JARs of one or more dependencies or an application.
  resolve                            Resolve and print the transitive dependencies of one or more dependencies or an application.
```

Unfortunately the `Other commands` group is first. Is there a way to control the order of the groups?