### PR TITLE
Beginner-oriented `bootstrap` help message

### DIFF
--- a/modules/cli/src/main/scala/coursier/cli/bootstrap/Bootstrap.scala
+++ b/modules/cli/src/main/scala/coursier/cli/bootstrap/Bootstrap.scala
@@ -36,6 +36,7 @@ import coursier.parse.{JavaOrScalaDependency, JavaOrScalaModule}
 import coursier.util.{Artifact, Sync, Task}
 
 import scala.concurrent.ExecutionContext
+import caseapp.core.help.HelpFormat
 
 object Bootstrap extends CoursierCommand[BootstrapOptions] {
 

--- a/modules/cli/src/main/scala/coursier/cli/bootstrap/Bootstrap.scala
+++ b/modules/cli/src/main/scala/coursier/cli/bootstrap/Bootstrap.scala
@@ -266,11 +266,11 @@ object Bootstrap extends CoursierCommand[BootstrapOptions] {
 
     val javaOptions =
       if (params.specific.assembly || params.specific.manifestJar)
-        params.specific.javaOptions ++ params.sharedLaunch.properties.map { case (k, v) =>
+        params.sharedLaunch.javaOptions ++ params.sharedLaunch.properties.map { case (k, v) =>
           s"-D$k=$v"
         }
       else
-        params.specific.javaOptions
+        params.sharedLaunch.javaOptions
 
     val params0 =
       if (params.sharedLaunch.resolve.dependency.native) {
@@ -353,7 +353,7 @@ object Bootstrap extends CoursierCommand[BootstrapOptions] {
             Some(
               coursier.launcher.Preamble()
                 .withJavaOpts(javaOptions)
-                .withJvmOptionFile(params.specific.jvmOptionFile)
+                .withJvmOptionFile(params.jvmOptionFile)
             )
           else
             None

--- a/modules/cli/src/main/scala/coursier/cli/bootstrap/Bootstrap.scala
+++ b/modules/cli/src/main/scala/coursier/cli/bootstrap/Bootstrap.scala
@@ -9,6 +9,7 @@ import coursier.cache.{Cache, CacheLogger}
 import coursier.cli.{CoursierCommand, CommandGroup}
 import coursier.cli.fetch.Fetch
 import coursier.cli.launch.{Launch, LaunchException}
+import coursier.cli.options.OptionGroup
 import coursier.cli.resolve.{Resolve, ResolveException}
 import coursier.cli.Util.ValidatedExitOnError
 import coursier.core.{
@@ -39,6 +40,9 @@ import scala.concurrent.ExecutionContext
 import caseapp.core.help.HelpFormat
 
 object Bootstrap extends CoursierCommand[BootstrapOptions] {
+  override def group: String = CommandGroup.launcher
+  override def helpFormat: HelpFormat =
+    HelpFormat.default().withSortedGroups(Some(OptionGroup.order))
 
   def task(
     params: BootstrapParams,
@@ -202,8 +206,6 @@ object Bootstrap extends CoursierCommand[BootstrapOptions] {
         .addDependencies(deps0: _*)
         .run()
   }
-
-  override def group: String = CommandGroup.launcher
 
   def run(options: BootstrapOptions, args: RemainingArgs): Unit = {
 

--- a/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapOptions.scala
@@ -1,6 +1,7 @@
 package coursier.cli.bootstrap
 
 import caseapp.{ArgsName, Group, HelpMessage, Parser, Recurse}
+import coursier.cli.options.OptionGroup
 import coursier.cli.install.SharedChannelOptions
 import coursier.cli.native.NativeLauncherOptions
 import coursier.cli.options.SharedLaunchOptions
@@ -21,7 +22,7 @@ final case class BootstrapOptions(
     nativeOptions: NativeLauncherOptions = NativeLauncherOptions(),
   @Recurse
     sharedLaunchOptions: SharedLaunchOptions = SharedLaunchOptions(),
-  @Group("Launch")
+  @Group(OptionGroup.launch)
     jvmOptionFile: Option[String] = None,
   @Recurse
     channelOptions: SharedChannelOptions = SharedChannelOptions(),

--- a/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapOptions.scala
@@ -1,6 +1,6 @@
 package coursier.cli.bootstrap
 
-import caseapp.{ArgsName, HelpMessage, Parser, Recurse}
+import caseapp.{ArgsName, Group, HelpMessage, Parser, Recurse}
 import coursier.cli.install.SharedChannelOptions
 import coursier.cli.native.NativeLauncherOptions
 import coursier.cli.options.SharedLaunchOptions
@@ -21,6 +21,8 @@ final case class BootstrapOptions(
     nativeOptions: NativeLauncherOptions = NativeLauncherOptions(),
   @Recurse
     sharedLaunchOptions: SharedLaunchOptions = SharedLaunchOptions(),
+  @Group("Launch")
+    jvmOptionFile: Option[String] = None,
   @Recurse
     channelOptions: SharedChannelOptions = SharedChannelOptions(),
   @Recurse
@@ -28,6 +30,7 @@ final case class BootstrapOptions(
 ) {
   def addApp(app: RawAppDescriptor): BootstrapOptions =
     copy(
+      jvmOptionFile = jvmOptionFile.orElse(app.jvmOptionFile),
       sharedLaunchOptions = sharedLaunchOptions.addApp(app),
       options = options.addApp(app, sharedLaunchOptions.resolveOptions.dependencyOptions.native)
     )

--- a/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapParams.scala
+++ b/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapParams.scala
@@ -12,10 +12,7 @@ final case class BootstrapParams(
   channel: SharedChannelParams,
   nativeShortVersionOpt: Option[String] = None,
   specific: BootstrapSpecificParams
-) {
-  lazy val fork: Boolean =
-    sharedLaunch.fork.getOrElse(SharedLaunchParams.defaultFork)
-}
+)
 
 object BootstrapParams {
   def apply(options: BootstrapOptions): ValidatedNel[String, BootstrapParams] = {

--- a/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapParams.scala
+++ b/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapParams.scala
@@ -7,6 +7,7 @@ import coursier.cli.params.SharedLaunchParams
 import coursier.launcher.Parameters.ScalaNative.ScalaNativeOptions
 
 final case class BootstrapParams(
+  jvmOptionFile: Option[String],
   sharedLaunch: SharedLaunchParams,
   nativeOptions: ScalaNativeOptions,
   channel: SharedChannelParams,
@@ -29,7 +30,9 @@ object BootstrapParams {
 
     (sharedLaunchV, nativeOptionsV, channelV, specificV).mapN {
       case (sharedLaunch, nativeOptions, channel, specific) =>
+        val jvmOptionFile = options.jvmOptionFile.map(_.trim).filter(_.nonEmpty)
         BootstrapParams(
+          jvmOptionFile,
           sharedLaunch,
           nativeOptions,
           channel,

--- a/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapSpecificOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapSpecificOptions.scala
@@ -2,74 +2,75 @@ package coursier.cli.bootstrap
 
 import caseapp.{ExtraName => Short, HelpMessage => Help, ValueDescription => Value, _}
 import coursier.install.RawAppDescriptor
+import coursier.cli.options.OptionGroup
 
 // format: off
 final case class BootstrapSpecificOptions(
-  @Group("Bootstrap")
+  @Group(OptionGroup.bootstrap)
   @Short("o")
     output: Option[String] = None,
-  @Group("Bootstrap")
+  @Group(OptionGroup.bootstrap)
   @Hidden
   @Short("f")
     force: Boolean = false,
-  @Group("Bootstrap")
+  @Group(OptionGroup.bootstrap)
   @Hidden
   @Help("Generate a standalone launcher, with all JARs included, instead of one downloading its dependencies on startup.")
   @Short("s")
     standalone: Option[Boolean] = None,
-  @Group("Bootstrap")
+  @Group(OptionGroup.bootstrap)
   @Hidden
   @Help("Generate an hybrid assembly / standalone launcher")
     hybrid: Option[Boolean] = None,
   @Recurse
     graalvmOptions: GraalvmOptions = GraalvmOptions(),
-  @Group("Bootstrap")
+  @Group(OptionGroup.bootstrap)
   @Hidden
   @Help("Include files in generated launcher even in non-standalone mode.")
     embedFiles: Boolean = true,
-  @Group("Bootstrap")
+  @Group(OptionGroup.bootstrap)
   @Hidden
   @Help("Generate an assembly rather than a bootstrap jar")
   @Short("a")
     assembly: Option[Boolean] = None,
-  @Group("Bootstrap")
+  @Group(OptionGroup.bootstrap)
   @Hidden
   @Help("Generate a JAR with the classpath as manifest rather than a bootstrap jar")
     manifestJar: Option[Boolean] = None,
-  @Group("Bootstrap")
+  @Group(OptionGroup.bootstrap)
   @Help("Generate a Windows bat file along the bootstrap JAR (default: true on Windows, false otherwise)")
     bat: Option[Boolean] = None,
-  @Group("Bootstrap")
+  @Group(OptionGroup.bootstrap)
   @Hidden
   @Help("Add assembly rule")
   @Value("append:$path|append-pattern:$pattern|exclude:$path|exclude-pattern:$pattern")
   @Short("R")
     assemblyRule: List[String] = Nil,
-  @Group("Bootstrap")
+  @Group(OptionGroup.bootstrap)
   @Hidden
   @Help("Add default rules to assembly rule list")
     defaultAssemblyRules: Boolean = true,
-  @Group("Bootstrap")
+  @Group(OptionGroup.bootstrap)
   @Hidden
   @Help("Manifest to use as a start when creating a manifest for assemblies")
     baseManifest: Option[String] = None,
-  @Group("Bootstrap")
+  @Group(OptionGroup.bootstrap)
   @Hidden
   @Help("Add preamble")
     preamble: Boolean = true,
-  @Group("Bootstrap")
+  @Group(OptionGroup.bootstrap)
   @Hidden
   @Help("Ensure that the output jar is deterministic, set the instant of the added files to Jan 1st 1970")
     deterministic: Boolean = false,
-  @Group("Bootstrap")
+  @Group(OptionGroup.bootstrap)
   @Hidden
   @Help("Use proguarded bootstrap")
     proguarded: Boolean = true,
-  @Group("Bootstrap")
+  @Group(OptionGroup.bootstrap)
   @Hidden
   @Help("Have the bootstrap or assembly disable jar checking via a hard-coded Java property (default: true for bootstraps with resources, false else)")
     disableJarChecking: Option[Boolean] = None,
-  @Group("Bootstrap")
+  @Group(OptionGroup.bootstrap)
   @Hidden
     jvmIndex: Option[String] = None
 ) {

--- a/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapSpecificOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapSpecificOptions.scala
@@ -28,12 +28,6 @@ final case class BootstrapSpecificOptions(
   @Help("Include files in generated launcher even in non-standalone mode.")
     embedFiles: Boolean = true,
   @Group("Bootstrap")
-  @Help("Add Java command-line options in the generated launcher.")
-  @Value("option")
-    javaOpt: List[String] = Nil,
-  @Group("Bootstrap")
-    jvmOptionFile: Option[String] = None,
-  @Group("Bootstrap")
   @Hidden
   @Help("Generate an assembly rather than a bootstrap jar")
   @Short("a")
@@ -99,7 +93,6 @@ final case class BootstrapSpecificOptions(
     ).count(identity)
     copy(
       output = output.orElse(app.name),
-      javaOpt = app.javaOptions ++ javaOpt,
       standalone = standalone
         .orElse(if (count == 0 && app.launcherType == "standalone") Some(true) else None),
       assembly = assembly
@@ -110,8 +103,7 @@ final case class BootstrapSpecificOptions(
             if (count == 0 && app.launcherType == "graalvm-native-image") Some(true)
             else None
           }
-      ),
-      jvmOptionFile = jvmOptionFile.orElse(app.jvmOptionFile)
+      )
     )
   }
 }

--- a/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapSpecificOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapSpecificOptions.scala
@@ -9,18 +9,22 @@ final case class BootstrapSpecificOptions(
   @Short("o")
     output: Option[String] = None,
   @Group("Bootstrap")
+  @Hidden
   @Short("f")
     force: Boolean = false,
   @Group("Bootstrap")
+  @Hidden
   @Help("Generate a standalone launcher, with all JARs included, instead of one downloading its dependencies on startup.")
   @Short("s")
     standalone: Option[Boolean] = None,
   @Group("Bootstrap")
+  @Hidden
   @Help("Generate an hybrid assembly / standalone launcher")
     hybrid: Option[Boolean] = None,
   @Recurse
     graalvmOptions: GraalvmOptions = GraalvmOptions(),
   @Group("Bootstrap")
+  @Hidden
   @Help("Include files in generated launcher even in non-standalone mode.")
     embedFiles: Boolean = true,
   @Group("Bootstrap")
@@ -30,39 +34,49 @@ final case class BootstrapSpecificOptions(
   @Group("Bootstrap")
     jvmOptionFile: Option[String] = None,
   @Group("Bootstrap")
+  @Hidden
   @Help("Generate an assembly rather than a bootstrap jar")
   @Short("a")
     assembly: Option[Boolean] = None,
   @Group("Bootstrap")
+  @Hidden
   @Help("Generate a JAR with the classpath as manifest rather than a bootstrap jar")
     manifestJar: Option[Boolean] = None,
   @Group("Bootstrap")
   @Help("Generate a Windows bat file along the bootstrap JAR (default: true on Windows, false otherwise)")
     bat: Option[Boolean] = None,
   @Group("Bootstrap")
+  @Hidden
   @Help("Add assembly rule")
   @Value("append:$path|append-pattern:$pattern|exclude:$path|exclude-pattern:$pattern")
   @Short("R")
     assemblyRule: List[String] = Nil,
   @Group("Bootstrap")
+  @Hidden
   @Help("Add default rules to assembly rule list")
     defaultAssemblyRules: Boolean = true,
   @Group("Bootstrap")
+  @Hidden
   @Help("Manifest to use as a start when creating a manifest for assemblies")
     baseManifest: Option[String] = None,
   @Group("Bootstrap")
+  @Hidden
   @Help("Add preamble")
     preamble: Boolean = true,
   @Group("Bootstrap")
+  @Hidden
   @Help("Ensure that the output jar is deterministic, set the instant of the added files to Jan 1st 1970")
     deterministic: Boolean = false,
   @Group("Bootstrap")
+  @Hidden
   @Help("Use proguarded bootstrap")
     proguarded: Boolean = true,
   @Group("Bootstrap")
+  @Hidden
   @Help("Have the bootstrap or assembly disable jar checking via a hard-coded Java property (default: true for bootstraps with resources, false else)")
     disableJarChecking: Option[Boolean] = None,
   @Group("Bootstrap")
+  @Hidden
     jvmIndex: Option[String] = None
 ) {
   // format: on

--- a/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapSpecificOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapSpecificOptions.scala
@@ -10,16 +10,13 @@ final case class BootstrapSpecificOptions(
   @Short("o")
     output: Option[String] = None,
   @Group(OptionGroup.bootstrap)
-  @Hidden
   @Short("f")
     force: Boolean = false,
   @Group(OptionGroup.bootstrap)
-  @Hidden
   @Help("Generate a standalone launcher, with all JARs included, instead of one downloading its dependencies on startup.")
   @Short("s")
     standalone: Option[Boolean] = None,
   @Group(OptionGroup.bootstrap)
-  @Hidden
   @Help("Generate an hybrid assembly / standalone launcher")
     hybrid: Option[Boolean] = None,
   @Recurse
@@ -29,12 +26,10 @@ final case class BootstrapSpecificOptions(
   @Help("Include files in generated launcher even in non-standalone mode.")
     embedFiles: Boolean = true,
   @Group(OptionGroup.bootstrap)
-  @Hidden
   @Help("Generate an assembly rather than a bootstrap jar")
   @Short("a")
     assembly: Option[Boolean] = None,
   @Group(OptionGroup.bootstrap)
-  @Hidden
   @Help("Generate a JAR with the classpath as manifest rather than a bootstrap jar")
     manifestJar: Option[Boolean] = None,
   @Group(OptionGroup.bootstrap)

--- a/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapSpecificParams.scala
+++ b/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapSpecificParams.scala
@@ -15,8 +15,6 @@ final case class BootstrapSpecificParams(
   force: Boolean,
   standalone: Boolean,
   embedFiles: Boolean,
-  javaOptions: Seq[String],
-  jvmOptionFile: Option[String],
   assembly: Boolean,
   manifestJar: Boolean,
   createBatFile: Boolean,
@@ -147,15 +145,11 @@ object BootstrapSpecificParams {
 
     (validateOutputType, rulesV, baseManifestOptV).mapN {
       (_, rules, baseManifestOpt) =>
-        val javaOptions   = options.javaOpt
-        val jvmOptionFile = options.jvmOptionFile.map(_.trim).filter(_.nonEmpty)
         BootstrapSpecificParams(
           output,
           options.force,
           standalone,
           options.embedFiles,
-          javaOptions,
-          jvmOptionFile,
           assembly,
           manifestJar,
           createBatFile,

--- a/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapSpecificParams.scala
+++ b/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapSpecificParams.scala
@@ -60,23 +60,25 @@ object BootstrapSpecificParams {
     options: BootstrapSpecificOptions,
     native: Boolean
   ): ValidatedNel[String, BootstrapSpecificParams] = {
-
-    val graalvmVersion = options.graalvmVersion
+    val graalvmVersion = options.graalvmOptions.graalvmVersion
       .map(_.trim)
       .filter(_.nonEmpty)
-      .filter(_ => !options.nativeImage.contains(false))
+      .filter(_ => !options.graalvmOptions.nativeImage.contains(false))
 
     val (graalvmJvmOptions, graalvmOptions) =
-      if (options.nativeImage.contains(false))
+      if (options.graalvmOptions.nativeImage.contains(false))
         (Nil, Nil)
       else
-        (options.graalvmJvmOption.filter(_.nonEmpty), options.graalvmOption.filter(_.nonEmpty))
+        (
+          options.graalvmOptions.graalvmJvmOption.filter(_.nonEmpty),
+          options.graalvmOptions.graalvmOption.filter(_.nonEmpty)
+        )
 
     val assembly    = options.assembly.getOrElse(false)
     val manifestJar = options.manifestJar.getOrElse(false)
     val standalone  = options.standalone.getOrElse(false)
     val hybrid      = options.hybrid.getOrElse(false)
-    val nativeImage = options.nativeImage.getOrElse(graalvmVersion.nonEmpty)
+    val nativeImage = options.graalvmOptions.nativeImage.getOrElse(graalvmVersion.nonEmpty)
 
     val validateOutputType = {
       val count = Seq(
@@ -164,7 +166,7 @@ object BootstrapSpecificParams {
           options.proguarded,
           hybrid,
           nativeImage,
-          options.intermediateAssembly,
+          options.graalvmOptions.intermediateAssembly,
           graalvmVersion,
           graalvmJvmOptions,
           graalvmOptions,

--- a/modules/cli/src/main/scala/coursier/cli/bootstrap/GraalvmOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/bootstrap/GraalvmOptions.scala
@@ -5,7 +5,7 @@ import caseapp.{ExtraName => Short, HelpMessage => Help, ValueDescription => Val
 // format: off
 final case class GraalvmOptions(
   @Group("Graalvm")
-  @Hidden
+  @Hidden // could be visible, but how well does it work?
   @Help("Generate a GraalVM native image")
     nativeImage: Option[Boolean] = None,
   @Group("Graalvm")

--- a/modules/cli/src/main/scala/coursier/cli/bootstrap/GraalvmOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/bootstrap/GraalvmOptions.scala
@@ -5,19 +5,24 @@ import caseapp.{ExtraName => Short, HelpMessage => Help, ValueDescription => Val
 // format: off
 final case class GraalvmOptions(
   @Group("Graalvm")
+  @Hidden
   @Help("Generate a GraalVM native image")
     nativeImage: Option[Boolean] = None,
   @Group("Graalvm")
+  @Hidden
   @Help("When generating a GraalVM native image, merge the classpath into an assembly prior to passing it to native-image")
     intermediateAssembly: Boolean = false,
   @Group("Graalvm")
+  @Hidden
   @Help("GraalVM version to use to generate native images")
   @Short("graalvm")
     graalvmVersion: Option[String] = None,
   @Group("Graalvm")
+  @Hidden
   @Short("graalvm-jvm-opt")
     graalvmJvmOption: List[String] = Nil,
   @Group("Graalvm")
+  @Hidden
   @Short("graalvm-opt")
     graalvmOption: List[String] = Nil
 )

--- a/modules/cli/src/main/scala/coursier/cli/bootstrap/GraalvmOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/bootstrap/GraalvmOptions.scala
@@ -1,0 +1,24 @@
+package coursier.cli.bootstrap
+
+import caseapp.{ExtraName => Short, HelpMessage => Help, ValueDescription => Value, _}
+
+// format: off
+final case class GraalvmOptions(
+  @Group("Graalvm")
+  @Help("Generate a GraalVM native image")
+    nativeImage: Option[Boolean] = None,
+  @Group("Graalvm")
+  @Help("When generating a GraalVM native image, merge the classpath into an assembly prior to passing it to native-image")
+    intermediateAssembly: Boolean = false,
+  @Group("Graalvm")
+  @Help("GraalVM version to use to generate native images")
+  @Short("graalvm")
+    graalvmVersion: Option[String] = None,
+  @Group("Graalvm")
+  @Short("graalvm-jvm-opt")
+    graalvmJvmOption: List[String] = Nil,
+  @Group("Graalvm")
+  @Short("graalvm-opt")
+    graalvmOption: List[String] = Nil
+)
+// format: on

--- a/modules/cli/src/main/scala/coursier/cli/install/SharedChannelOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/install/SharedChannelOptions.scala
@@ -1,25 +1,26 @@
 package coursier.cli.install
 
 import caseapp.{HelpMessage => Help, ValueDescription => Value, _}
+import coursier.cli.options.OptionGroup
 
 // format: off
 final case class SharedChannelOptions(
 
-  @Group("App channel")
+  @Group(OptionGroup.channel)
   @Help("Channel for apps")
   @Value("org:name")
     channel: List[String] = Nil,
 
-  @Group("App channel")
+  @Group(OptionGroup.channel)
   @Hidden
   @Help("Add default channels")
     defaultChannels: Boolean = true,
 
-  @Group("App channel")
+  @Group(OptionGroup.channel)
   @Help("Add contrib channel")
     contrib: Boolean = false,
 
-  @Group("App channel")
+  @Group(OptionGroup.channel)
   @Hidden
   @Help("Add channels read from the configuration directory")
     fileChannels: Boolean = true

--- a/modules/cli/src/main/scala/coursier/cli/launch/Launch.scala
+++ b/modules/cli/src/main/scala/coursier/cli/launch/Launch.scala
@@ -366,7 +366,7 @@ object Launch extends CoursierCommand[LaunchOptions] {
         mainClass0,
         userArgs,
         javaPath,
-        params.javaOptions,
+        params.shared.javaOptions,
         properties0,
         pythonEnv + extraEnv,
         params.shared.resolve.output.verbosity,

--- a/modules/cli/src/main/scala/coursier/cli/launch/LaunchOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/launch/LaunchOptions.scala
@@ -26,6 +26,9 @@ final case class LaunchOptions(
   @Recurse
     channelOptions: SharedChannelOptions = SharedChannelOptions(),
 
+  @Group("Launch")
+    fork: Option[Boolean] = None,
+  
   @Help("Add Java command-line options, when forking")
   @Value("option")
     javaOpt: List[String] = Nil,

--- a/modules/cli/src/main/scala/coursier/cli/launch/LaunchOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/launch/LaunchOptions.scala
@@ -28,10 +28,6 @@ final case class LaunchOptions(
 
   @Group("Launch")
     fork: Option[Boolean] = None,
-  
-  @Help("Add Java command-line options, when forking")
-  @Value("option")
-    javaOpt: List[String] = Nil,
 
   fetchCacheIKnowWhatImDoing: Option[String] = None,
 

--- a/modules/cli/src/main/scala/coursier/cli/launch/LaunchParams.scala
+++ b/modules/cli/src/main/scala/coursier/cli/launch/LaunchParams.scala
@@ -14,7 +14,6 @@ final case class LaunchParams(
   sharedJava: SharedJavaParams,
   channel: SharedChannelParams,
   fork: Boolean,
-  javaOptions: Seq[String],
   jep: Boolean,
   fetchCacheIKnowWhatImDoing: Option[String],
   execve: Option[Boolean]
@@ -51,7 +50,7 @@ object LaunchParams {
         options.fork.getOrElse(
           options.jep ||
           shared.python ||
-          options.javaOpt.nonEmpty ||
+          shared.javaOptions.nonEmpty ||
           sharedJava.jvm.nonEmpty ||
           SharedLaunchParams.defaultFork
         )
@@ -61,7 +60,6 @@ object LaunchParams {
         sharedJava,
         channel,
         fork,
-        options.javaOpt,
         options.jep,
         options.fetchCacheIKnowWhatImDoing,
         options.execve

--- a/modules/cli/src/main/scala/coursier/cli/native/NativeLauncherOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/native/NativeLauncherOptions.scala
@@ -9,48 +9,63 @@ import coursier.launcher.Parameters.ScalaNative.ScalaNativeOptions
 // format: off
 final case class NativeLauncherOptions(
   @Group("Native launcher")
+  @Hidden
   @Value("none|boehm|immix|default")
     nativeGc: Option[String] = None,
   
   @Group("Native launcher")
+  @Hidden
   @Value("release|debug")
     nativeMode: Option[String] = None,
 
   @Group("Native launcher")
+  @Hidden
     nativeLinkStubs: Boolean = true,
 
   @Group("Native launcher")
+  @Hidden
     nativeClang: Option[String] = None,
 
   @Group("Native launcher")
+  @Hidden
     nativeClangpp: Option[String] = None,
 
   @Group("Native launcher")
+  @Hidden
     nativeLinkingOption: List[String] = Nil,
   @Group("Native launcher")
+  @Hidden
     nativeDefaultLinkingOptions: Boolean = true,
   @Group("Native launcher")
+  @Hidden
     nativeUseLdflags: Boolean = true,
 
   @Group("Native launcher")
+  @Hidden
     nativeCompileOption: List[String] = Nil,
   @Group("Native launcher")
+  @Hidden
     nativeDefaultCompileOptions: Boolean = true,
 
   @Group("Native launcher")
+  @Hidden
     nativeTargetTriple: Option[String] = None,
 
   @Group("Native launcher")
+  @Hidden
     nativeLib: Option[String] = None,
 
   @Group("Native launcher")
+  @Hidden
     nativeVersion: Option[String] = None,
 
   @Group("Native launcher")
+  @Hidden
   @Help("Native compilation target directory")
   @Short("d")
     nativeWorkDir: Option[String] = None,
   @Group("Native launcher")
+  @Hidden
   @Help("Don't wipe native compilation target directory (for debug purposes)")
     nativeKeepWorkDir: Boolean = false
 

--- a/modules/cli/src/main/scala/coursier/cli/native/NativeLauncherOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/native/NativeLauncherOptions.scala
@@ -8,35 +8,49 @@ import coursier.launcher.Parameters.ScalaNative.ScalaNativeOptions
 
 // format: off
 final case class NativeLauncherOptions(
-
+  @Group("Native launcher")
   @Value("none|boehm|immix|default")
     nativeGc: Option[String] = None,
-
+  
+  @Group("Native launcher")
   @Value("release|debug")
     nativeMode: Option[String] = None,
 
-  nativeLinkStubs: Boolean = true,
+  @Group("Native launcher")
+    nativeLinkStubs: Boolean = true,
 
-  nativeClang: Option[String] = None,
+  @Group("Native launcher")
+    nativeClang: Option[String] = None,
 
-  nativeClangpp: Option[String] = None,
+  @Group("Native launcher")
+    nativeClangpp: Option[String] = None,
 
-  nativeLinkingOption: List[String] = Nil,
-  nativeDefaultLinkingOptions: Boolean = true,
-  nativeUseLdflags: Boolean = true,
+  @Group("Native launcher")
+    nativeLinkingOption: List[String] = Nil,
+  @Group("Native launcher")
+    nativeDefaultLinkingOptions: Boolean = true,
+  @Group("Native launcher")
+    nativeUseLdflags: Boolean = true,
 
-  nativeCompileOption: List[String] = Nil,
-  nativeDefaultCompileOptions: Boolean = true,
+  @Group("Native launcher")
+    nativeCompileOption: List[String] = Nil,
+  @Group("Native launcher")
+    nativeDefaultCompileOptions: Boolean = true,
 
-  nativeTargetTriple: Option[String] = None,
+  @Group("Native launcher")
+    nativeTargetTriple: Option[String] = None,
 
-  nativeLib: Option[String] = None,
+  @Group("Native launcher")
+    nativeLib: Option[String] = None,
 
-  nativeVersion: Option[String] = None,
+  @Group("Native launcher")
+    nativeVersion: Option[String] = None,
 
+  @Group("Native launcher")
   @Help("Native compilation target directory")
   @Short("d")
     nativeWorkDir: Option[String] = None,
+  @Group("Native launcher")
   @Help("Don't wipe native compilation target directory (for debug purposes)")
     nativeKeepWorkDir: Boolean = false
 

--- a/modules/cli/src/main/scala/coursier/cli/native/NativeLauncherOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/native/NativeLauncherOptions.scala
@@ -4,67 +4,68 @@ import java.nio.file.Paths
 
 import caseapp.{ExtraName => Short, HelpMessage => Help, ValueDescription => Value, _}
 import cats.data.{Validated, ValidatedNel}
+import coursier.cli.options.OptionGroup
 import coursier.launcher.Parameters.ScalaNative.ScalaNativeOptions
 
 // format: off
 final case class NativeLauncherOptions(
-  @Group("Native launcher")
+  @Group(OptionGroup.native)
   @Hidden
   @Value("none|boehm|immix|default")
     nativeGc: Option[String] = None,
   
-  @Group("Native launcher")
+  @Group(OptionGroup.native)
   @Hidden
   @Value("release|debug")
     nativeMode: Option[String] = None,
 
-  @Group("Native launcher")
+  @Group(OptionGroup.native)
   @Hidden
     nativeLinkStubs: Boolean = true,
 
-  @Group("Native launcher")
+  @Group(OptionGroup.native)
   @Hidden
     nativeClang: Option[String] = None,
 
-  @Group("Native launcher")
+  @Group(OptionGroup.native)
   @Hidden
     nativeClangpp: Option[String] = None,
 
-  @Group("Native launcher")
+  @Group(OptionGroup.native)
   @Hidden
     nativeLinkingOption: List[String] = Nil,
-  @Group("Native launcher")
+  @Group(OptionGroup.native)
   @Hidden
     nativeDefaultLinkingOptions: Boolean = true,
-  @Group("Native launcher")
+  @Group(OptionGroup.native)
   @Hidden
     nativeUseLdflags: Boolean = true,
 
-  @Group("Native launcher")
+  @Group(OptionGroup.native)
   @Hidden
     nativeCompileOption: List[String] = Nil,
-  @Group("Native launcher")
+  @Group(OptionGroup.native)
   @Hidden
     nativeDefaultCompileOptions: Boolean = true,
 
-  @Group("Native launcher")
+  @Group(OptionGroup.native)
   @Hidden
     nativeTargetTriple: Option[String] = None,
 
-  @Group("Native launcher")
+  @Group(OptionGroup.native)
   @Hidden
     nativeLib: Option[String] = None,
 
-  @Group("Native launcher")
+  @Group(OptionGroup.native)
   @Hidden
     nativeVersion: Option[String] = None,
 
-  @Group("Native launcher")
+  @Group(OptionGroup.native)
   @Hidden
   @Help("Native compilation target directory")
   @Short("d")
     nativeWorkDir: Option[String] = None,
-  @Group("Native launcher")
+  @Group(OptionGroup.native)
   @Hidden
   @Help("Don't wipe native compilation target directory (for debug purposes)")
     nativeKeepWorkDir: Boolean = false

--- a/modules/cli/src/main/scala/coursier/cli/options/ArtifactOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/ArtifactOptions.scala
@@ -7,33 +7,33 @@ import coursier.install.RawAppDescriptor
 // format: off
 final case class ArtifactOptions(
 
-  @Group("Fetch")
+  @Group(OptionGroup.fetch)
   @Hidden
   @Help("Classifiers that should be fetched")
   @Value("classifier1,classifier2,...")
   @Short("C")
     classifier: List[String] = Nil,
 
-  @Group("Fetch")
+  @Group(OptionGroup.fetch)
   @Help("Fetch source artifacts")
     sources: Boolean = false,
 
-  @Group("Fetch")
+  @Group(OptionGroup.fetch)
   @Help("Fetch javadoc artifacts")
     javadoc: Boolean = false,
 
-  @Group("Fetch")
+  @Group(OptionGroup.fetch)
   @Help("Fetch default artifacts (default: false if --sources or --javadoc or --classifier are passed, true else)")
     default: Option[Boolean] = None,
 
-  @Group("Fetch")
+  @Group(OptionGroup.fetch)
   @Hidden
   @Help("Artifact types that should be retained (e.g. jar, src, doc, etc.) - defaults to jar,bundle")
   @Value("type1,type2,...")
   @Short("A")
     artifactType: List[String] = Nil,
 
-  @Group("Fetch")
+  @Group(OptionGroup.fetch)
   @Hidden
   @Help("Fetch artifacts even if the resolution is errored")
     forceFetch: Boolean = false

--- a/modules/cli/src/main/scala/coursier/cli/options/ArtifactOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/ArtifactOptions.scala
@@ -8,6 +8,7 @@ import coursier.install.RawAppDescriptor
 final case class ArtifactOptions(
 
   @Group("Fetch")
+  @Hidden
   @Help("Classifiers that should be fetched")
   @Value("classifier1,classifier2,...")
   @Short("C")
@@ -26,12 +27,14 @@ final case class ArtifactOptions(
     default: Option[Boolean] = None,
 
   @Group("Fetch")
+  @Hidden
   @Help("Artifact types that should be retained (e.g. jar, src, doc, etc.) - defaults to jar,bundle")
   @Value("type1,type2,...")
   @Short("A")
     artifactType: List[String] = Nil,
 
   @Group("Fetch")
+  @Hidden
   @Help("Fetch artifacts even if the resolution is errored")
     forceFetch: Boolean = false
 

--- a/modules/cli/src/main/scala/coursier/cli/options/ArtifactOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/ArtifactOptions.scala
@@ -7,25 +7,31 @@ import coursier.install.RawAppDescriptor
 // format: off
 final case class ArtifactOptions(
 
+  @Group("Fetch")
   @Help("Classifiers that should be fetched")
   @Value("classifier1,classifier2,...")
   @Short("C")
     classifier: List[String] = Nil,
 
+  @Group("Fetch")
   @Help("Fetch source artifacts")
     sources: Boolean = false,
 
+  @Group("Fetch")
   @Help("Fetch javadoc artifacts")
     javadoc: Boolean = false,
 
+  @Group("Fetch")
   @Help("Fetch default artifacts (default: false if --sources or --javadoc or --classifier are passed, true else)")
     default: Option[Boolean] = None,
 
+  @Group("Fetch")
   @Help("Artifact types that should be retained (e.g. jar, src, doc, etc.) - defaults to jar,bundle")
   @Value("type1,type2,...")
   @Short("A")
     artifactType: List[String] = Nil,
 
+  @Group("Fetch")
   @Help("Fetch artifacts even if the resolution is errored")
     forceFetch: Boolean = false
 

--- a/modules/cli/src/main/scala/coursier/cli/options/CacheOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/CacheOptions.scala
@@ -27,7 +27,6 @@ final case class CacheOptions(
     mode: String = "",
 
   @Group(OptionGroup.cache)
-  @Hidden
   @Help("TTL duration (e.g. \"24 hours\")")
   @Value("duration")
   @Short("l")

--- a/modules/cli/src/main/scala/coursier/cli/options/CacheOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/CacheOptions.scala
@@ -20,23 +20,27 @@ final case class CacheOptions(
     cache: Option[String] = None,
 
   @Group("Cache")
+  @Hidden
   @Help("Download mode (default: missing, that is fetch things missing from cache)")
   @Value("offline|update-changing|update|missing|force")
   @Short("m")
     mode: String = "",
 
   @Group("Cache")
+  @Hidden
   @Help("TTL duration (e.g. \"24 hours\")")
   @Value("duration")
   @Short("l")
     ttl: Option[String] = None,
 
   @Group("Cache")
+  @Hidden
   @Help("Maximum number of parallel downloads (default: 6)")
   @Short("n")
     parallel: Int = 6,
 
   @Group("Cache")
+  @Hidden
   @Help("Checksum types to check - end with none to allow for no checksum validation if no checksum is available, example: SHA-256,SHA-1,none")
   @Value("checksum1,checksum2,...")
     checksum: List[String] = Nil,

--- a/modules/cli/src/main/scala/coursier/cli/options/CacheOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/CacheOptions.scala
@@ -15,62 +15,62 @@ import scala.concurrent.duration.Duration
 // format: off
 final case class CacheOptions(
 
-  @Group("Cache")
+  @Group(OptionGroup.cache)
   @Help("Cache directory (defaults to environment variable COURSIER_CACHE, or ~/.cache/coursier/v1 on Linux and ~/Library/Caches/Coursier/v1 on Mac)")
     cache: Option[String] = None,
 
-  @Group("Cache")
+  @Group(OptionGroup.cache)
   @Hidden
   @Help("Download mode (default: missing, that is fetch things missing from cache)")
   @Value("offline|update-changing|update|missing|force")
   @Short("m")
     mode: String = "",
 
-  @Group("Cache")
+  @Group(OptionGroup.cache)
   @Hidden
   @Help("TTL duration (e.g. \"24 hours\")")
   @Value("duration")
   @Short("l")
     ttl: Option[String] = None,
 
-  @Group("Cache")
+  @Group(OptionGroup.cache)
   @Hidden
   @Help("Maximum number of parallel downloads (default: 6)")
   @Short("n")
     parallel: Int = 6,
 
-  @Group("Cache")
+  @Group(OptionGroup.cache)
   @Hidden
   @Help("Checksum types to check - end with none to allow for no checksum validation if no checksum is available, example: SHA-256,SHA-1,none")
   @Value("checksum1,checksum2,...")
     checksum: List[String] = Nil,
 
-  @Group("Cache")
+  @Group(OptionGroup.cache)
   @Hidden
   @Help("Retry limit for Checksum error when fetching a file")
     retryCount: Int = 1,
 
-  @Group("Cache")
+  @Group(OptionGroup.cache)
   @Hidden
   @Help("Flag that specifies if a local artifact should be cached.")
   @Short("cfa")
     cacheFileArtifacts: Boolean = false,
 
-  @Group("Cache")
+  @Group(OptionGroup.cache)
   @Hidden
   @Help("Whether to follow http to https redirections")
     followHttpToHttpsRedirect: Boolean = true,
 
-  @Group("Cache")
+  @Group(OptionGroup.cache)
   @Help("Credentials to be used when fetching metadata or artifacts. Specify multiple times to pass multiple credentials. Alternatively, use the COURSIER_CREDENTIALS environment variable")
   @Value("host(realm) user:pass|host user:pass")
     credentials: List[String] = Nil,
 
-  @Group("Cache")
+  @Group(OptionGroup.cache)
   @Help("Path to credential files to read credentials from")
     credentialFile: List[String] = Nil,
 
-  @Group("Cache")
+  @Group(OptionGroup.cache)
   @Hidden
   @Help("Whether to read credentials from COURSIER_CREDENTIALS (env) or coursier.credentials (Java property), along those passed with --credentials and --credential-file")
     useEnvCredentials: Boolean = true

--- a/modules/cli/src/main/scala/coursier/cli/options/DependencyOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/DependencyOptions.scala
@@ -5,12 +5,15 @@ import caseapp.{ExtraName => Short, HelpMessage => Help, ValueDescription => Val
 // format: off
 final case class DependencyOptions(
 
+  @Group("Dependency")
+  @Hidden
   @Help("Exclude module")
   @Value("organization:name")
   @Short("E")
-  @Help("Global level exclude")
     exclude: List[String] = Nil,
 
+  @Group("Dependency")
+  @Hidden
   @Short("x")
   @Help("Path to the local exclusion file. " +
     "Syntax: <org:name>--<org:name>. `--` means minus. Example file content:\n\t" +
@@ -20,18 +23,26 @@ final case class DependencyOptions(
   )
     localExcludeFile: String = "",
 
+  @Group("Dependency")
+  @Hidden
   @Help("If --sbt-plugin options are passed: default sbt version  (short version X.Y is enough - note that for sbt 1.x, this should be passed 1.0)")
   @Value("sbt version")
     sbtVersion: String = "1.0",
 
+  @Group("Dependency")
+  @Hidden
   @Help("Add intransitive dependencies")
     intransitive: List[String] = Nil,
 
+  @Group("Dependency")
   @Help("Add sbt plugin dependencies")
     sbtPlugin: List[String] = Nil,
 
-  scalaJs: Boolean = false,
+  @Group("Dependency")
+  @Help("Enable Scala.js")
+    scalaJs: Boolean = false,
 
+  @Group("Dependency")
   @Help("Enable scala-native")
   @Short("S")
     native: Boolean = false

--- a/modules/cli/src/main/scala/coursier/cli/options/DependencyOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/DependencyOptions.scala
@@ -5,14 +5,14 @@ import caseapp.{ExtraName => Short, HelpMessage => Help, ValueDescription => Val
 // format: off
 final case class DependencyOptions(
 
-  @Group("Dependency")
+  @Group(OptionGroup.dependency)
   @Hidden
   @Help("Exclude module")
   @Value("organization:name")
   @Short("E")
     exclude: List[String] = Nil,
 
-  @Group("Dependency")
+  @Group(OptionGroup.dependency)
   @Hidden
   @Short("x")
   @Help("Path to the local exclusion file. " +
@@ -23,26 +23,26 @@ final case class DependencyOptions(
   )
     localExcludeFile: String = "",
 
-  @Group("Dependency")
+  @Group(OptionGroup.dependency)
   @Hidden
   @Help("If --sbt-plugin options are passed: default sbt version  (short version X.Y is enough - note that for sbt 1.x, this should be passed 1.0)")
   @Value("sbt version")
     sbtVersion: String = "1.0",
 
-  @Group("Dependency")
+  @Group(OptionGroup.dependency)
   @Hidden
   @Help("Add intransitive dependencies")
     intransitive: List[String] = Nil,
 
-  @Group("Dependency")
+  @Group(OptionGroup.dependency)
   @Help("Add sbt plugin dependencies")
     sbtPlugin: List[String] = Nil,
 
-  @Group("Dependency")
+  @Group(OptionGroup.dependency)
   @Help("Enable Scala.js")
     scalaJs: Boolean = false,
 
-  @Group("Dependency")
+  @Group(OptionGroup.dependency)
   @Help("Enable scala-native")
   @Short("S")
     native: Boolean = false

--- a/modules/cli/src/main/scala/coursier/cli/options/OptionGroup.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/OptionGroup.scala
@@ -1,0 +1,31 @@
+package coursier.cli.options
+
+object OptionGroup {
+  val help       = "Help"
+  val verbosity  = "Verbosity"
+  val bootstrap  = "Bootstrap"
+  val native     = "Native launcher"
+  val graalvm    = "Graalvm"
+  val launch     = "Launch"
+  val channel    = "App channel"
+  val fetch      = "Fetch"
+  val repository = "Repository"
+  val dependency = "Dependency"
+  val resolution = "Resolution"
+  val cache      = "Cache"
+
+  val order: Seq[String] = Seq(
+    help,
+    verbosity,
+    bootstrap,
+    native,
+    graalvm,
+    launch,
+    channel,
+    fetch,
+    repository,
+    dependency,
+    resolution,
+    cache
+  )
+}

--- a/modules/cli/src/main/scala/coursier/cli/options/OutputOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/OutputOptions.scala
@@ -5,27 +5,27 @@ import caseapp.{ExtraName => Short, HelpMessage => Help, _}
 // format: off
 final case class OutputOptions(
 
-  @Group("Output")
+  @Group("Verbosity")
   @Help("Quiet output")
   @Short("q")
     quiet: Int @@ Counter = Tag.of(0),
 
-  @Group("Output")
+  @Group("Verbosity")
   @Help("Increase verbosity (specify several times to increase more)")
   @Short("v")
     verbose: Int @@ Counter = Tag.of(0),
 
-  @Group("Output")
+  @Group("Verbosity")
   @Help("Force display of progress bars")
   @Short("P")
     progress: Boolean = false,
 
-  @Group("Output")
+  @Group("Verbosity")
   @Hidden
   @Help("Log changing artifacts")
     logChanging: Boolean = false,
 
-  @Group("Output")
+  @Group("Verbosity")
   @Hidden
   @Help("Log app channel or JVM index version")
   @Short("log-index-version")

--- a/modules/cli/src/main/scala/coursier/cli/options/OutputOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/OutputOptions.scala
@@ -5,27 +5,27 @@ import caseapp.{ExtraName => Short, HelpMessage => Help, _}
 // format: off
 final case class OutputOptions(
 
-  @Group("Verbosity")
+  @Group(OptionGroup.verbosity)
   @Help("Quiet output")
   @Short("q")
     quiet: Int @@ Counter = Tag.of(0),
 
-  @Group("Verbosity")
+  @Group(OptionGroup.verbosity)
   @Help("Increase verbosity (specify several times to increase more)")
   @Short("v")
     verbose: Int @@ Counter = Tag.of(0),
 
-  @Group("Verbosity")
+  @Group(OptionGroup.verbosity)
   @Help("Force display of progress bars")
   @Short("P")
     progress: Boolean = false,
 
-  @Group("Verbosity")
+  @Group(OptionGroup.verbosity)
   @Hidden
   @Help("Log changing artifacts")
     logChanging: Boolean = false,
 
-  @Group("Verbosity")
+  @Group(OptionGroup.verbosity)
   @Hidden
   @Help("Log app channel or JVM index version")
   @Short("log-index-version")

--- a/modules/cli/src/main/scala/coursier/cli/options/RepositoryOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/RepositoryOptions.scala
@@ -6,23 +6,23 @@ import coursier.cli.install.SharedChannelOptions
 // format: off
 final case class RepositoryOptions(
 
-  @Group("Repository")
+  @Group(OptionGroup.repository)
   @HelpMessage("Repository - for multiple repositories, separate with comma and/or add this option multiple times (e.g. -r central,ivy2local -r sonatype:snapshots, or equivalently -r central,ivy2local,sonatype:snapshots)")
   @ValueDescription("maven|sonatype:$repo|ivy2local|bintray:$org/$repo|bintray-ivy:$org/$repo|typesafe:ivy-$repo|typesafe:$repo|sbt-plugin:$repo|scala-integration|scala-nightlies|ivy:$pattern|jitpack|clojars|jcenter|apache:$repo")
   @ExtraName("r")
     repository: List[String] = Nil,
 
-  @Group("Repository")
+  @Group(OptionGroup.repository)
   @Hidden
   @HelpMessage("Do not add default repositories (~/.ivy2/local, and Central)")
     noDefault: Boolean = false,
 
-  @Group("Repository")
+  @Group(OptionGroup.repository)
   @Hidden
   @HelpMessage("Modify names in Maven repository paths for sbt plugins")
     sbtPluginHack: Boolean = true,
 
-  @Group("Repository")
+  @Group(OptionGroup.repository)
   @Hidden
   @HelpMessage("Drop module attributes starting with 'info.' - these are sometimes used by projects built with sbt")
     dropInfoAttr: Boolean = false

--- a/modules/cli/src/main/scala/coursier/cli/options/ResolutionOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/ResolutionOptions.scala
@@ -51,6 +51,7 @@ final case class ResolutionOptions(
     scalaVersion: Option[String] = None,
 
   @Group(OptionGroup.resolution)
+  @Hidden
   @Help("Ensure the scala version used by the scala-library/reflect/compiler JARs is coherent")
     forceScalaVersion: Option[Boolean] = None,
 
@@ -71,6 +72,7 @@ final case class ResolutionOptions(
     rules: List[String] = Nil,
 
   @Group(OptionGroup.resolution)
+  @Hidden
   @Help("Choose reconciliation strategy")
   @Value("organization:name:(basic|relaxed)")
     reconciliation: List[String] = Nil,

--- a/modules/cli/src/main/scala/coursier/cli/options/ResolutionOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/ResolutionOptions.scala
@@ -9,58 +9,73 @@ import coursier.parse.{DependencyParser, ModuleParser, ReconciliationParser, Rul
 
 // format: off
 final case class ResolutionOptions(
-
+  @Group("Resolution")
   @Help("Keep optional dependencies (Maven)")
     keepOptional: Boolean = false,
 
+  @Group("Resolution")
   @Help("Maximum number of resolution iterations (specify a negative value for unlimited, default: 100)")
   @Short("N")
     maxIterations: Int = ResolutionProcess.defaultMaxIterations,
 
+  @Group("Resolution")
   @Help("Force module version")
   @Value("organization:name:forcedVersion")
   @Short("V")
     forceVersion: List[String] = Nil,
 
+  @Group("Resolution")
   @Help("Set property in POM files, if it's not already set")
   @Value("name=value")
     pomProperty: List[String] = Nil,
 
+  @Group("Resolution")
   @Help("Force property in POM files")
   @Value("name=value")
     forcePomProperty: List[String] = Nil,
 
+  @Group("Resolution")
   @Help("Enable profile")
   @Value("profile")
     profile: List[String] = Nil,
 
+  @Group("Resolution")
   @Help("Default scala version")
   @Short("e")
   @Short("scala")
     scalaVersion: Option[String] = None,
 
+  @Group("Resolution")
   @Help("Ensure the scala version used by the scala-library/reflect/compiler JARs is coherent")
     forceScalaVersion: Option[Boolean] = None,
 
+  @Group("Resolution")
   @Help("Adjust the scala version for fully cross-versioned dependencies")
     overrideFullSuffix: Option[Boolean] = None,
 
+  @Group("Resolution")
   @Help("Swap the mainline Scala JARs by Typelevel ones")
     typelevel: Boolean = false,
 
+  @Group("Resolution")
   @Help("Enforce resolution rules")
   @Short("rule")
     rules: List[String] = Nil,
 
+  @Group("Resolution")
   @Help("Choose reconciliation strategy")
   @Value("organization:name:(basic|relaxed)")
     reconciliation: List[String] = Nil,
 
-  strict: Option[Boolean] = None,
+  @Group("Resolution")
+    strict: Option[Boolean] = None,
 
-  strictInclude: List[String] = Nil,
-  strictExclude: List[String] = Nil,
+  @Group("Resolution")
+    strictInclude: List[String] = Nil,
+  @Group("Resolution")
+    strictExclude: List[String] = Nil,
 
+  @Group("Resolution")
   @Help("Default configuration (default(compile) by default)")
   @Value("configuration")
   @Short("c")

--- a/modules/cli/src/main/scala/coursier/cli/options/ResolutionOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/ResolutionOptions.scala
@@ -10,10 +10,12 @@ import coursier.parse.{DependencyParser, ModuleParser, ReconciliationParser, Rul
 // format: off
 final case class ResolutionOptions(
   @Group("Resolution")
+  @Hidden
   @Help("Keep optional dependencies (Maven)")
     keepOptional: Boolean = false,
 
   @Group("Resolution")
+  @Hidden
   @Help("Maximum number of resolution iterations (specify a negative value for unlimited, default: 100)")
   @Short("N")
     maxIterations: Int = ResolutionProcess.defaultMaxIterations,
@@ -25,16 +27,19 @@ final case class ResolutionOptions(
     forceVersion: List[String] = Nil,
 
   @Group("Resolution")
+  @Hidden
   @Help("Set property in POM files, if it's not already set")
   @Value("name=value")
     pomProperty: List[String] = Nil,
 
   @Group("Resolution")
+  @Hidden
   @Help("Force property in POM files")
   @Value("name=value")
     forcePomProperty: List[String] = Nil,
 
   @Group("Resolution")
+  @Hidden
   @Help("Enable profile")
   @Value("profile")
     profile: List[String] = Nil,
@@ -50,14 +55,17 @@ final case class ResolutionOptions(
     forceScalaVersion: Option[Boolean] = None,
 
   @Group("Resolution")
+  @Hidden
   @Help("Adjust the scala version for fully cross-versioned dependencies")
     overrideFullSuffix: Option[Boolean] = None,
 
   @Group("Resolution")
+  @Hidden
   @Help("Swap the mainline Scala JARs by Typelevel ones")
     typelevel: Boolean = false,
 
   @Group("Resolution")
+  @Hidden
   @Help("Enforce resolution rules")
   @Short("rule")
     rules: List[String] = Nil,
@@ -68,14 +76,18 @@ final case class ResolutionOptions(
     reconciliation: List[String] = Nil,
 
   @Group("Resolution")
+  @Hidden
     strict: Option[Boolean] = None,
 
   @Group("Resolution")
+  @Hidden
     strictInclude: List[String] = Nil,
   @Group("Resolution")
+  @Hidden
     strictExclude: List[String] = Nil,
 
   @Group("Resolution")
+  @Hidden
   @Help("Default configuration (default(compile) by default)")
   @Value("configuration")
   @Short("c")

--- a/modules/cli/src/main/scala/coursier/cli/options/ResolutionOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/ResolutionOptions.scala
@@ -9,84 +9,84 @@ import coursier.parse.{DependencyParser, ModuleParser, ReconciliationParser, Rul
 
 // format: off
 final case class ResolutionOptions(
-  @Group("Resolution")
+  @Group(OptionGroup.resolution)
   @Hidden
   @Help("Keep optional dependencies (Maven)")
     keepOptional: Boolean = false,
 
-  @Group("Resolution")
+  @Group(OptionGroup.resolution)
   @Hidden
   @Help("Maximum number of resolution iterations (specify a negative value for unlimited, default: 100)")
   @Short("N")
     maxIterations: Int = ResolutionProcess.defaultMaxIterations,
 
-  @Group("Resolution")
+  @Group(OptionGroup.resolution)
   @Help("Force module version")
   @Value("organization:name:forcedVersion")
   @Short("V")
     forceVersion: List[String] = Nil,
 
-  @Group("Resolution")
+  @Group(OptionGroup.resolution)
   @Hidden
   @Help("Set property in POM files, if it's not already set")
   @Value("name=value")
     pomProperty: List[String] = Nil,
 
-  @Group("Resolution")
+  @Group(OptionGroup.resolution)
   @Hidden
   @Help("Force property in POM files")
   @Value("name=value")
     forcePomProperty: List[String] = Nil,
 
-  @Group("Resolution")
+  @Group(OptionGroup.resolution)
   @Hidden
   @Help("Enable profile")
   @Value("profile")
     profile: List[String] = Nil,
 
-  @Group("Resolution")
+  @Group(OptionGroup.resolution)
   @Help("Default scala version")
   @Short("e")
   @Short("scala")
     scalaVersion: Option[String] = None,
 
-  @Group("Resolution")
+  @Group(OptionGroup.resolution)
   @Help("Ensure the scala version used by the scala-library/reflect/compiler JARs is coherent")
     forceScalaVersion: Option[Boolean] = None,
 
-  @Group("Resolution")
+  @Group(OptionGroup.resolution)
   @Hidden
   @Help("Adjust the scala version for fully cross-versioned dependencies")
     overrideFullSuffix: Option[Boolean] = None,
 
-  @Group("Resolution")
+  @Group(OptionGroup.resolution)
   @Hidden
   @Help("Swap the mainline Scala JARs by Typelevel ones")
     typelevel: Boolean = false,
 
-  @Group("Resolution")
+  @Group(OptionGroup.resolution)
   @Hidden
   @Help("Enforce resolution rules")
   @Short("rule")
     rules: List[String] = Nil,
 
-  @Group("Resolution")
+  @Group(OptionGroup.resolution)
   @Help("Choose reconciliation strategy")
   @Value("organization:name:(basic|relaxed)")
     reconciliation: List[String] = Nil,
 
-  @Group("Resolution")
+  @Group(OptionGroup.resolution)
   @Hidden
     strict: Option[Boolean] = None,
 
-  @Group("Resolution")
+  @Group(OptionGroup.resolution)
   @Hidden
     strictInclude: List[String] = Nil,
-  @Group("Resolution")
+  @Group(OptionGroup.resolution)
   @Hidden
     strictExclude: List[String] = Nil,
 
-  @Group("Resolution")
+  @Group(OptionGroup.resolution)
   @Hidden
   @Help("Default configuration (default(compile) by default)")
   @Value("configuration")

--- a/modules/cli/src/main/scala/coursier/cli/options/SharedLaunchOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/SharedLaunchOptions.scala
@@ -14,7 +14,6 @@ final case class SharedLaunchOptions(
     mainClass: String = "",
 
   @Group(OptionGroup.launch)
-  @Hidden
   @Help("Extra JARs to be added to the classpath of the launched application. Directories accepted too.")
     extraJars: List[String] = Nil,
 

--- a/modules/cli/src/main/scala/coursier/cli/options/SharedLaunchOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/SharedLaunchOptions.scala
@@ -8,21 +8,26 @@ import coursier.install.RawAppDescriptor
 // format: off
 final case class SharedLaunchOptions(
 
+  @Group("Launch")
   @Short("M")
   @Short("main")
     mainClass: String = "",
 
+  @Group("Launch")
   @Help("Extra JARs to be added to the classpath of the launched application. Directories accepted too.")
     extraJars: List[String] = Nil,
 
+  @Group("Launch")
   @Help("Set Java properties before launching the app")
   @Value("key=value")
   @Short("D")
     property: List[String] = Nil,
 
-  fork: Option[Boolean] = None,
+  @Group("Launch")
+    fork: Option[Boolean] = None,
 
-  python: Option[Boolean] = None,
+  @Group("Launch")
+    python: Option[Boolean] = None,
 
   @Recurse
     sharedLoaderOptions: SharedLoaderOptions = SharedLoaderOptions(),

--- a/modules/cli/src/main/scala/coursier/cli/options/SharedLaunchOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/SharedLaunchOptions.scala
@@ -8,28 +8,28 @@ import coursier.install.RawAppDescriptor
 // format: off
 final case class SharedLaunchOptions(
 
-  @Group("Launch")
+  @Group(OptionGroup.launch)
   @Short("M")
   @Short("main")
     mainClass: String = "",
 
-  @Group("Launch")
+  @Group(OptionGroup.launch)
   @Hidden
   @Help("Extra JARs to be added to the classpath of the launched application. Directories accepted too.")
     extraJars: List[String] = Nil,
 
-  @Group("Launch")
+  @Group(OptionGroup.launch)
   @Help("Set Java properties before launching the app")
   @Value("key=value")
   @Short("D")
     property: List[String] = Nil,
   
-  @Group("Launch")
+  @Group(OptionGroup.launch)
   @Help("Add Java command-line options")
   @Value("option")
     javaOpt: List[String] = Nil,
 
-  @Group("Launch")
+  @Group(OptionGroup.launch)
   @Hidden
     python: Option[Boolean] = None,
 

--- a/modules/cli/src/main/scala/coursier/cli/options/SharedLaunchOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/SharedLaunchOptions.scala
@@ -26,10 +26,6 @@ final case class SharedLaunchOptions(
 
   @Group("Launch")
   @Hidden
-    fork: Option[Boolean] = None,
-
-  @Group("Launch")
-  @Hidden
     python: Option[Boolean] = None,
 
   @Recurse

--- a/modules/cli/src/main/scala/coursier/cli/options/SharedLaunchOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/SharedLaunchOptions.scala
@@ -14,6 +14,7 @@ final case class SharedLaunchOptions(
     mainClass: String = "",
 
   @Group("Launch")
+  @Hidden
   @Help("Extra JARs to be added to the classpath of the launched application. Directories accepted too.")
     extraJars: List[String] = Nil,
 
@@ -24,9 +25,11 @@ final case class SharedLaunchOptions(
     property: List[String] = Nil,
 
   @Group("Launch")
+  @Hidden
     fork: Option[Boolean] = None,
 
   @Group("Launch")
+  @Hidden
     python: Option[Boolean] = None,
 
   @Recurse

--- a/modules/cli/src/main/scala/coursier/cli/options/SharedLaunchOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/SharedLaunchOptions.scala
@@ -23,6 +23,11 @@ final case class SharedLaunchOptions(
   @Value("key=value")
   @Short("D")
     property: List[String] = Nil,
+  
+  @Group("Launch")
+  @Help("Add Java command-line options")
+  @Value("option")
+    javaOpt: List[String] = Nil,
 
   @Group("Launch")
   @Hidden
@@ -49,6 +54,7 @@ final case class SharedLaunchOptions(
           app.mainClass.fold("")(_.stripSuffix("?")) // FIXME '?' suffix means optional main class
         else
           mainClass,
+      javaOpt = app.javaOptions ++ javaOpt,
       property = app.properties.props.map { case (k, v) => s"$k=$v" }.toList ++ property,
       python = python.orElse(if (app.jna.contains("python")) Some(true) else None)
     )

--- a/modules/cli/src/main/scala/coursier/cli/options/SharedLoaderOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/SharedLoaderOptions.scala
@@ -8,20 +8,20 @@ import coursier.install.RawAppDescriptor
 final case class SharedLoaderOptions(
 
   // deprecated, use shared instead
-  @Group("Launch")
+  @Group(OptionGroup.launch)
   @Hidden
   @Value("target:dependency")
   @Short("I")
   @Help("(deprecated) dependencies to be put in shared class loaders")
     isolated: List[String] = Nil,
 
-  @Group("Launch")
+  @Group(OptionGroup.launch)
   @Hidden
   @Value("dependency[@target]")
   @Help("Dependencies to be put in shared class loaders")
     shared: List[String] = Nil,
 
-  @Group("Launch")
+  @Group(OptionGroup.launch)
   @Hidden
   @Help("Comma-separated isolation targets")
   @Short("i")

--- a/modules/cli/src/main/scala/coursier/cli/options/SharedLoaderOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/SharedLoaderOptions.scala
@@ -8,15 +8,21 @@ import coursier.install.RawAppDescriptor
 final case class SharedLoaderOptions(
 
   // deprecated, use shared instead
+  @Group("Launch")
+  @Hidden
   @Value("target:dependency")
   @Short("I")
   @Help("(deprecated) dependencies to be put in shared class loaders")
     isolated: List[String] = Nil,
 
+  @Group("Launch")
+  @Hidden
   @Value("dependency[@target]")
   @Help("Dependencies to be put in shared class loaders")
     shared: List[String] = Nil,
 
+  @Group("Launch")
+  @Hidden
   @Help("Comma-separated isolation targets")
   @Short("i")
   @Short("isolateTarget") // former deprecated name

--- a/modules/cli/src/main/scala/coursier/cli/params/SharedLaunchParams.scala
+++ b/modules/cli/src/main/scala/coursier/cli/params/SharedLaunchParams.scala
@@ -16,7 +16,6 @@ final case class SharedLaunchParams(
   mainClassOpt: Option[String],
   properties: Seq[(String, String)],
   extraJars: Seq[Path],
-  fork: Option[Boolean],
   pythonOpt: Option[Boolean]
 ) {
   def fetch(channel: SharedChannelParams): FetchParams =
@@ -89,7 +88,6 @@ object SharedLaunchParams {
           mainClassOpt,
           properties,
           extraJars,
-          options.fork,
           options.python
         )
     }

--- a/modules/cli/src/main/scala/coursier/cli/params/SharedLaunchParams.scala
+++ b/modules/cli/src/main/scala/coursier/cli/params/SharedLaunchParams.scala
@@ -14,6 +14,7 @@ final case class SharedLaunchParams(
   artifact: ArtifactParams,
   sharedLoader: SharedLoaderParams,
   mainClassOpt: Option[String],
+  javaOptions: Seq[String],
   properties: Seq[(String, String)],
   extraJars: Seq[Path],
   pythonOpt: Option[Boolean]
@@ -86,6 +87,7 @@ object SharedLaunchParams {
           artifact,
           sharedLoader,
           mainClassOpt,
+          options.javaOpt,
           properties,
           extraJars,
           options.python

--- a/modules/cli/src/main/scala/coursier/cli/resolve/SharedResolveOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/resolve/SharedResolveOptions.scala
@@ -14,6 +14,7 @@ import coursier.install.RawAppDescriptor
 @ArgsName("org:name:version|app-name[:version]*")
 final case class SharedResolveOptions(
   @Group("Resolution") // with ResolutionOptions
+  @Hidden
   @Help("Keep dependencies or artifacts in classpath order (that is, dependencies before dependees)")
     classpathOrder: Option[Boolean] = None,
 

--- a/modules/cli/src/main/scala/coursier/cli/resolve/SharedResolveOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/resolve/SharedResolveOptions.scala
@@ -13,7 +13,7 @@ import coursier.install.RawAppDescriptor
 // format: off
 @ArgsName("org:name:version|app-name[:version]*")
 final case class SharedResolveOptions(
-
+  @Group("Resolution") // with ResolutionOptions
   @Help("Keep dependencies or artifacts in classpath order (that is, dependencies before dependees)")
     classpathOrder: Option[Boolean] = None,
 

--- a/modules/cli/src/main/scala/coursier/cli/resolve/SharedResolveOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/resolve/SharedResolveOptions.scala
@@ -4,6 +4,7 @@ import caseapp.{ExtraName => Short, HelpMessage => Help, ValueDescription => Val
 import coursier.cli.options.{
   CacheOptions,
   DependencyOptions,
+  OptionGroup,
   OutputOptions,
   RepositoryOptions,
   ResolutionOptions
@@ -13,7 +14,7 @@ import coursier.install.RawAppDescriptor
 // format: off
 @ArgsName("org:name:version|app-name[:version]*")
 final case class SharedResolveOptions(
-  @Group("Resolution") // with ResolutionOptions
+  @Group(OptionGroup.resolution) // with ResolutionOptions
   @Hidden
   @Help("Keep dependencies or artifacts in classpath order (that is, dependencies before dependees)")
     classpathOrder: Option[Boolean] = None,

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -2,7 +2,7 @@ import mill._, scalalib._
 
 object Deps {
   def argonautShapeless = ivy"com.github.alexarchambault::argonaut-shapeless_6.2::1.2.0"
-  def caseApp           = ivy"com.github.alexarchambault::case-app:2.1.0-M8"
+  def caseApp           = ivy"com.github.alexarchambault::case-app:2.1.0-M9"
   def catsCore          = ivy"org.typelevel::cats-core:2.6.1"
   def catsEffect        = ivy"org.typelevel::cats-effect::2.5.4"
   def collectionCompat  = ivy"org.scala-lang.modules::scala-collection-compat::2.6.0"


### PR DESCRIPTION
- Put every option in a group
- Hide advanced options:
Only a small subset is shown. A beginner must be able to learn quickly from the help message so that they can use the command in the most common scenarios.
- Remove `fork` from `SharedLaunchOptions` and move it to `LaunchOptions` because it is not used in `Bootstrap`
- Move `javaOpt` from `LaunchOptions` and `BootstrapOptions` down to `SharedLaunchOptions`.
- Sort option groups

Requires https://github.com/alexarchambault/case-app/pull/339

The final result is:

```
$ cs bootstrap -h
Usage: coursier bootstrap [options] [org:name:version*|app-name[:version]]
Create a binary launcher from a dependency or an application descriptor.
The generated launcher can then be used without cs being installed.

Examples:
$ cs bootstrap org.scalameta::scalafmt-cli:2.4.2 -o scalafmt
$ cs bootstrap scalafmt -o scalafmt

Help options:
  --usage                   Print usage and exit
  -h, -help, --help         Print help message and exit
  --help-full, --full-help  Print help message, including hidden options, and exit

Verbosity options:
  -q, --quiet     Quiet output
  -v, --verbose   Increase verbosity (specify several times to increase more)
  -P, --progress  Force display of progress bars

Bootstrap options:
  -o, --output string?
  --bat                 Generate a Windows bat file along the bootstrap JAR (default: true on Windows, false otherwise)

Launch options:
  -M, --main, --main-class string
  -D, --property key=value         Set Java properties before launching the app
  --java-opt option                Add Java command-line options
  --jvm-option-file string?

App channel options:
  --channel org:name  Channel for apps
  --contrib           Add contrib channel

Fetch options:
  --sources  Fetch source artifacts
  --javadoc  Fetch javadoc artifacts
  --default  Fetch default artifacts (default: false if --sources or --javadoc or --classifier are passed, true else)

Repository options:
  -r, --repository maven|sonatype:$repo|ivy2local|bintray:$org/$repo|bintray-ivy:$org/$repo|typesafe:ivy-$repo|typesafe:$repo|sbt-plugin:$repo|scala-integration|scala-nightlies|ivy:$pattern|jitpack|clojars|jcenter|apache:$repo  Repository - for multiple repositories, separate with comma and/or add this option multiple times (e.g. -r central,ivy2local -r sonatype:snapshots, or equivalently -r central,ivy2local,sonatype:snapshots)

Dependency options:
  --sbt-plugin string*  Add sbt plugin dependencies
  --scala-js            Enable Scala.js
  -S, --native          Enable scala-native

Resolution options:
  -V, --force-version organization:name:forcedVersion  Force module version
  -e, --scala, --scala-version string?           Default scala version
  --force-scala-version                          Ensure the scala version used by the scala-library/reflect/compiler JARs is coherent
  --reconciliation organization:name:(basic|relaxed)  Choose reconciliation strategy

Cache options:
  --cache string?                                Cache directory (defaults to environment variable COURSIER_CACHE, or ~/.cache/coursier/v1 on Linux and ~/Library/Caches/Coursier/v1 on Mac)
  --credentials host(realm) user:pass|host user:pass  Credentials to be used when fetching metadata or artifacts. Specify multiple times to pass multiple credentials. Alternatively, use the COURSIER_CREDENTIALS environment variable
  --credential-file string*                      Path to credential files to read credentials from
```

And the full help is:
<details><summary>Full help</summary>

```
$ cs bootstrap --full-help
Usage: coursier bootstrap [options] [org:name:version*|app-name[:version]]
Create a binary launcher from a dependency or an application descriptor.
The generated launcher can then be used without cs being installed.

Examples:
$ cs bootstrap org.scalameta::scalafmt-cli:2.4.2 -o scalafmt
$ cs bootstrap scalafmt -o scalafmt

Help options:
  --usage                   Print usage and exit
  -h, -help, --help         Print help message and exit
  --help-full, --full-help  Print help message, including hidden options, and exit

Verbosity options:
  -q, --quiet                                    Quiet output
  -v, --verbose                                  Increase verbosity (specify several times to increase more)
  -P, --progress                                 Force display of progress bars
  --log-changing                                 (hidden) Log changing artifacts
  --log-index-version, --log-channel-version, --log-jvm-index-version  (hidden) Log app channel or JVM index version

Bootstrap options:
  -o, --output string?
  -f, --force                                    (hidden)
  -s, --standalone                               (hidden) Generate a standalone launcher, with all JARs included, instead of one downloading its dependencies on startup.
  --hybrid                                       (hidden) Generate an hybrid assembly / standalone launcher
  --embed-files                                  (hidden) Include files in generated launcher even in non-standalone mode.
  -a, --assembly                                 (hidden) Generate an assembly rather than a bootstrap jar
  --manifest-jar                                 (hidden) Generate a JAR with the classpath as manifest rather than a bootstrap jar
  --bat                                          Generate a Windows bat file along the bootstrap JAR (default: true on Windows, false otherwise)
  -R, --assembly-rule append:$path|append-pattern:$pattern|exclude:$path|exclude-pattern:$pattern  (hidden) Add assembly rule
  --default-assembly-rules                       (hidden) Add default rules to assembly rule list
  --base-manifest string?                        (hidden) Manifest to use as a start when creating a manifest for assemblies
  --preamble                                     (hidden) Add preamble
  --deterministic                                (hidden) Ensure that the output jar is deterministic, set the instant of the added files to Jan 1st 1970
  --proguarded                                   (hidden) Use proguarded bootstrap
  --disable-jar-checking                         (hidden) Have the bootstrap or assembly disable jar checking via a hard-coded Java property (default: true for bootstraps with resources, false else)
  --jvm-index string?                            (hidden)

Native launcher options:
  --native-gc none|boehm|immix|default  (hidden)
  --native-mode release|debug           (hidden)
  --native-link-stubs                   (hidden)
  --native-clang string?                (hidden)
  --native-clangpp string?              (hidden)
  --native-linking-option string*       (hidden)
  --native-default-linking-options      (hidden)
  --native-use-ldflags                  (hidden)
  --native-compile-option string*       (hidden)
  --native-default-compile-options      (hidden)
  --native-target-triple string?        (hidden)
  --native-lib string?                  (hidden)
  --native-version string?              (hidden)
  -d, --native-work-dir string?         (hidden) Native compilation target directory
  --native-keep-work-dir                (hidden) Don't wipe native compilation target directory (for debug purposes)

Graalvm options:
  --native-image                                 (hidden) Generate a GraalVM native image
  --intermediate-assembly                        (hidden) When generating a GraalVM native image, merge the classpath into an assembly prior to passing it to native-image
  --graalvm, --graalvm-version string?           (hidden) GraalVM version to use to generate native images
  --graalvm-jvm-opt, --graalvm-jvm-option string*  (hidden)
  --graalvm-opt, --graalvm-option string*        (hidden)

Launch options:
  -M, --main, --main-class string
  --extra-jars string*                           (hidden) Extra JARs to be added to the classpath of the launched application. Directories accepted too.
  -D, --property key=value                       Set Java properties before launching the app
  --java-opt option                              Add Java command-line options
  --python                                       (hidden)
  -I, --isolated target:dependency               (hidden) (deprecated) dependencies to be put in shared class loaders
  --shared dependency[@target]                   (hidden) Dependencies to be put in shared class loaders
  -i, --shared-target, --isolate-target string*  (hidden) Comma-separated isolation targets
  --jvm-option-file string?

App channel options:
  --channel org:name  Channel for apps
  --default-channels  (hidden) Add default channels
  --contrib           Add contrib channel
  --file-channels     (hidden) Add channels read from the configuration directory

Fetch options:
  -C, --classifier classifier1,classifier2,...  (hidden) Classifiers that should be fetched
  --sources                                     Fetch source artifacts
  --javadoc                                     Fetch javadoc artifacts
  --default                                     Fetch default artifacts (default: false if --sources or --javadoc or --classifier are passed, true else)
  -A, --artifact-type type1,type2,...           (hidden) Artifact types that should be retained (e.g. jar, src, doc, etc.) - defaults to jar,bundle
  --force-fetch                                 (hidden) Fetch artifacts even if the resolution is errored

Repository options:
  -r, --repository maven|sonatype:$repo|ivy2local|bintray:$org/$repo|bintray-ivy:$org/$repo|typesafe:ivy-$repo|typesafe:$repo|sbt-plugin:$repo|scala-integration|scala-nightlies|ivy:$pattern|jitpack|clojars|jcenter|apache:$repo  Repository - for multiple repositories, separate with comma and/or add this option multiple times (e.g. -r central,ivy2local -r sonatype:snapshots, or equivalently -r central,ivy2local,sonatype:snapshots)
  --no-default                                   (hidden) Do not add default repositories (~/.ivy2/local, and Central)
  --sbt-plugin-hack                              (hidden) Modify names in Maven repository paths for sbt plugins
  --drop-info-attr                               (hidden) Drop module attributes starting with 'info.' - these are sometimes used by projects built with sbt

Dependency options:
  -E, --exclude organization:name  (hidden) Exclude module
  -x, --local-exclude-file string  (hidden) Path to the local exclusion file. Syntax: <org:name>--<org:name>. `--` means minus. Example file content:
                com.twitter.penguin:korean-text--com.twitter:util-tunable-internal_2.11
                org.apache.commons:commons-math--com.twitter.search:core-query-nodes
        Behavior: If root module A excludes module X, but root module B requires X, module X will still be fetched.
  --sbt-version sbt version        (hidden) If --sbt-plugin options are passed: default sbt version  (short version X.Y is enough - note that for sbt 1.x, this should be passed 1.0)
  --intransitive string*           (hidden) Add intransitive dependencies
  --sbt-plugin string*             Add sbt plugin dependencies
  --scala-js                       Enable Scala.js
  -S, --native                     Enable scala-native

Resolution options:
  --classpath-order                              (hidden) Keep dependencies or artifacts in classpath order (that is, dependencies before dependees)
  --keep-optional                                (hidden) Keep optional dependencies (Maven)
  -N, --max-iterations int                       (hidden) Maximum number of resolution iterations (specify a negative value for unlimited, default: 100)
  -V, --force-version organization:name:forcedVersion  Force module version
  --pom-property name=value                      (hidden) Set property in POM files, if it's not already set
  --force-pom-property name=value                (hidden) Force property in POM files
  --profile profile                              (hidden) Enable profile
  -e, --scala, --scala-version string?           Default scala version
  --force-scala-version                          Ensure the scala version used by the scala-library/reflect/compiler JARs is coherent
  --override-full-suffix                         (hidden) Adjust the scala version for fully cross-versioned dependencies
  --typelevel                                    (hidden) Swap the mainline Scala JARs by Typelevel ones
  --rule, --rules string*                        (hidden) Enforce resolution rules
  --reconciliation organization:name:(basic|relaxed)  Choose reconciliation strategy
  --strict                                       (hidden)
  --strict-include string*                       (hidden)
  --strict-exclude string*                       (hidden)
  -c, --default-configuration configuration      (hidden) Default configuration (default(compile) by default)

Cache options:
  --cache string?                                Cache directory (defaults to environment variable COURSIER_CACHE, or ~/.cache/coursier/v1 on Linux and ~/Library/Caches/Coursier/v1 on Mac)
  -m, --mode offline|update-changing|update|missing|force  (hidden) Download mode (default: missing, that is fetch things missing from cache)
  -l, --ttl duration                             (hidden) TTL duration (e.g. "24 hours")
  -n, --parallel int                             (hidden) Maximum number of parallel downloads (default: 6)
  --checksum checksum1,checksum2,...             (hidden) Checksum types to check - end with none to allow for no checksum validation if no checksum is available, example: SHA-256,SHA-1,none
  --retry-count int                              (hidden) Retry limit for Checksum error when fetching a file
  --cfa, --cache-file-artifacts                  (hidden) Flag that specifies if a local artifact should be cached.
  --follow-http-to-https-redirect                (hidden) Whether to follow http to https redirections
  --credentials host(realm) user:pass|host user:pass  Credentials to be used when fetching metadata or artifacts. Specify multiple times to pass multiple credentials. Alternatively, use the COURSIER_CREDENTIALS environment variable
  --credential-file string*                      Path to credential files to read credentials from
  --use-env-credentials                          (hidden) Whether to read credentials from COURSIER_CREDENTIALS (env) or coursier.credentials (Java property), along those passed with --credentials and --credential-file
```
</details>