### PR TITLE
Review the docs to highlight the beginner use case.

### DIFF
--- a/doc/docs/cli-install.md
+++ b/doc/docs/cli-install.md
@@ -464,6 +464,9 @@ $ test-install-dir/ammonite
 ```
 The directory passed this way takes precedence over the ones above.
 
+One can run `cs install --setup` to [update](https://get-coursier.io/docs/cli-setup.html#how-it-sets-environment-variables-globally) profile files (Linux / macOS) or user environment variables (Windows),
+to add the installation directory to `PATH`.
+
 ## Application descriptor reference
 
 Application descriptors are parsed from [`RawAppDescriptor.scala`](https://github.com/coursier/coursier/blob/master/modules/install/src/main/scala/coursier/install/RawAppDescriptor.scala),

--- a/doc/docs/cli-installation.md
+++ b/doc/docs/cli-installation.md
@@ -2,51 +2,64 @@
 title: Installation
 ---
 
+These instructions will install the coursier CLI `cs` itself, as well as a typical Scala development environment.
+By default, they will install the following applications:
+
+- `cs` itself, to further manage your Scala environment
+- `scala`, the Scala 2 REPL
+- `scalac`, the Scala 2 compiler
+- `sbt` and `sbtn`, the [sbt build toold](https://www.scala-sbt.org/)
+- `ammonite`, [an enhanced REPL](https://ammonite.io/) for Scala 2
+- `scalafmt`, the [Scala code formatter](https://scalameta.org/scalafmt/)
+
+They will also install a JVM if none is found on the system.
+
+If you want more control over what gets installed and how, read about the [`setup`](cli-setup.md) command.
+
+After the setup, you can [start using Scala](https://docs.scala-lang.org/scala3/getting-started.html#create-a-hello-world-project-with-sbt), or install more applications with the [`install`](cli-install.md) command.
+
 ## Native launcher
 
 ### Linux & macOS
 
-On Linux and macOS, download and run the coursier launcher with
+On Linux and macOS, download and run the coursier installer with
 
 ```bash
 $ curl -fLo cs https://git.io/coursier-cli-"$(uname | tr LD ld)"
 $ chmod +x cs
-$ ./cs
+$ ./cs setup
 ```
-
-> Note: The above instructions explain how to install a local copy of `cs`. The next thing you may want to do is to add `cs` to your PATH. The easiest way to accomplish this is to let `cs` do it for you! The following adapted installation instructions show the complete process:
->
-> 
-> ```
-> $ curl -fLo cs https://git.io/coursier-cli-"$(uname | tr LD ld)"
-> $ chmod +x cs
-> $ ./cs install cs
-> $ ./cs install --setup
-> $ rm cs
-> ```
-> 
-> Apart from now having `cs` on your PATH, updating `cs` is now as simple as executing the following command:
-> 
-> ```
-> $ cs update cs
-> ```
 
 ### macOS - brew based installation
 
-Alternatively, the native launcher can be installed via [homebrew](https://brew.sh) with
+Alternatively, the coursier launcher can be installed via [homebrew](https://brew.sh) with
 ```bash
 $ brew install coursier/formulas/coursier
-$ cs
+$ cs setup
 ```
 
 ### Windows
 
-On Windows, use
+On Windows, [download and execute the Windows installer](https://git.io/coursier-cli-windows-exe).
+
+If you prefer a command line-based install, or if you would like to customize the setup options, use:
+
 ```bash
 > bitsadmin /transfer cs-cli https://git.io/coursier-cli-windows-exe "%cd%\cs.exe"
-> .\cs --help
+> .\cs setup
 ```
 Note that this must be run with `cmd.exe`, not `PowerShell`.
+
+### Check your setup
+
+Check your setup with
+
+```bash
+$ scala -version
+Scala code runner version 2.13.7 -- Copyright 2002-2021, LAMP/EPFL and Lightbend, Inc.
+```
+
+If that does not work, you may need to log out and log back in (or reboot) in order for the changes to take effect.
 
 ## JAR-based launcher
 

--- a/doc/docs/cli-overview.md
+++ b/doc/docs/cli-overview.md
@@ -2,143 +2,94 @@
 title: Overview
 ---
 
-The CLI of coursier has a number of commands to deal with dependencies and artifacts:
-- `complete` [allows one to complete Maven coordinates](#complete),
-- `resolve` [lists the transitive dependencies](#resolve) of one or more dependencies,
-- `fetch` [fetches the artifacts](#fetch) of one or more dependencies,
-- `launch` [runs applications based on Maven / Ivy dependencies](#launch),
-- `bootstrap` [generates convenient launchers to run them](#bootstrap),
-- `install` [installs applications based on Maven / Ivy dependencies](#install),
-- `java` and `java-home` [install, run, and get the home directory of JVMs](#java),
-- `setup` [checks if your system has a JVM and the standard Scala applications](#setup), and installs them if needed.
+The CLI of coursier is the Scala application and artifact manager.
+It can install Scala applications and setup your Scala development environment.
+It can also download and cache artifacts from the web.
 
 See [Installation](cli-installation.md) for how to install the
 CLI of coursier.
+
+Once installed, the CLI of coursier provides a number of services:
+- manage the installed Scala applications: [`install`, `list`, `update`, `uninstall`](#install), [`setup`](#setup)
+- configure *channels* to install Scala applications from: `channel`, [`search`](#search)
+- launchers for Scala applications: [`launch`](#launch), [`bootstrap`](#bootstrap)
+- manage the installed JVMs: [`java`, `java-home`](#java)
+- directly manipulate Maven dependencies: [`fetch`](#fetch), [`resolve`](#resolve)
 
 This page succinctly describes each of these commands. More
 details about each them are then given in the dedicated
 documentation page of each command (see links on the left).
 
-## Available commands
+## Getting started
 
-### `complete`
+[Install `cs` and your Scala development environment](cli-installation.md)
 
-`complete` allows one to complete Maven coordinates.
+## Main available commands
 
-For example, let's display all published versions of the `HikariCP` library:
+### `install`
 
-```bash
-$ cs complete com.zaxxer:HikariCP:
-1.1.3
-1.1.4
-
-<elided>
-
-3.3.1
-3.4.0
-3.4.1
-3.4.2
-3.4.3
-3.4.4
-3.4.5
-```
-
-As another example, let's see which versions of the Scala compiler are available:
+The `install` command installs Scala applications in the
+[installation directory](https://get-coursier.io/docs/cli-install.html#installation-directory)
+configured when installing `cs` (`~/.local/share/coursier/bin` by default on Linux):
 
 ```bash
-$ cs complete org.scala-lang:scala-compiler:
-2.3.1
-2.3.3
-2.4.0-RC1
-2.4.0-RC2
-2.4.0
-2.5.0-RC1
-2.5.0-RC2
-2.5.0
-2.5.1
-
-<elided>
-
-2.12.0
-2.12.1
-2.12.2
-2.12.3
-2.12.4
-2.12.5
-2.12.6
-2.12.7
-2.12.8
-2.12.9
-2.12.10
-2.12.11
-2.12.12
-2.13.0-M1
-2.13.0-M2
-2.13.0-M3
-2.13.0-M3-f73b161
-2.13.0-M4
-2.13.0-M4-pre-20d3c21
-2.13.0-M5
-2.13.0-M5-5eef812
-2.13.0-M5-6e0cba7
-2.13.0-M5-1775dba
-2.13.0-RC1
-2.13.0-RC2
-2.13.0-RC3
-2.13.0
-2.13.1
-2.13.2
-2.13.3
-2.13.4
+$ cs install scalafmt
+$ scalafmt --version
+scalafmt 3.0.6
 ```
 
-
-### `resolve`
-
-`resolve` lists the transitive dependencies of
-one or more other dependencies. Use like
-```bash
-$ cs resolve io.circe::circe-generic:0.12.3
-com.chuusai:shapeless_2.13:2.3.3:default
-io.circe:circe-core_2.13:0.12.3:default
-io.circe:circe-generic_2.13:0.12.3:default
-io.circe:circe-numbers_2.13:0.12.3:default
-org.scala-lang:scala-library:2.13.0:default
-org.typelevel:cats-core_2.13:2.0.0:default
-org.typelevel:cats-kernel_2.13:2.0.0:default
-org.typelevel:cats-macros_2.13:2.0.0:default
-```
-
-Note that this only relies on metadata files (POMs in particular),
-and doesn't download any JAR.
-
-`resolve` has more options, to [print trees](cli-resolve.md#tree),
-[find which dependency brings another one](cli-resolve.md#what-depends-on),
-etc. See [the dedicated page](cli-resolve.md) for more details.
-
-### `fetch`
-
-`fetch` fetches the JARs of one or more dependencies.
+You may give a specific version number as follows:
 
 ```bash
-$ cs fetch io.circe::circe-generic:0.12.3
-/path/to/coursier/cache/https/repo1.maven.org/maven2/io/circe/circe-generic_2.13/0.12.3/circe-generic_2.13-0.12.3.jar
-/path/to/coursier/cache/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.0/scala-library-2.13.0.jar
-/path/to/coursier/cache/https/repo1.maven.org/maven2/io/circe/circe-core_2.13/0.12.3/circe-core_2.13-0.12.3.jar
-/path/to/coursier/cache/https/repo1.maven.org/maven2/com/chuusai/shapeless_2.13/2.3.3/shapeless_2.13-2.3.3.jar
-/path/to/coursier/cache/https/repo1.maven.org/maven2/io/circe/circe-numbers_2.13/0.12.3/circe-numbers_2.13-0.12.3.jar
-/path/to/coursier/cache/https/repo1.maven.org/maven2/org/typelevel/cats-core_2.13/2.0.0/cats-core_2.13-2.0.0.jar
-/path/to/coursier/cache/https/repo1.maven.org/maven2/org/typelevel/cats-macros_2.13/2.0.0/cats-macros_2.13-2.0.0.jar
-/path/to/coursier/cache/https/repo1.maven.org/maven2/org/typelevel/cats-kernel_2.13/2.0.0/cats-kernel_2.13-2.0.0.jar
+$ cs install scalafmt:2.4.2
+$ scalafmt --version
+scalafmt 2.4.2
 ```
 
-`fetch` has more options, to [join its output with the path separator](cli-fetch.md#classpath-format),
-fetch [source JARs](cli-fetch.md#source-jars), fetch [javadoc](cli-fetch.md#javadoc), etc. See
-[the dedicated page](cli-fetch.md) for more details.
+If the installation directory is not already on your `PATH`, you may add it for the current session with
+```bash
+$ eval "$(cs install --env)" # add installation directory in PATH in the current session
+```
+
+See [the dedicated page](cli-install.md) for more details about `install`.
+It also presents the related commands `list`, `update` and `uninstall`.
+
+### `search`
+
+If you are not sure what the exact name of the application you want to install is, use the `search` command:
+
+```bash
+$ cs search fmt
+scalafmt
+```
 
 ### `launch`
 
-`launch` launches applications from one or more dependencies.
+`launch` launches applications from their name, or directly from one or more Maven dependencies.
+The applications need not be installed with `install`.
+
+```bash
+$ cs launch scalafmt -- --help
+scalafmt 3.0.6
+Usage: scalafmt [options] [<file>...]
+
+  -h, --help               prints this usage text
+  -v, --version            print version
+…
+```
+
+Like the `install` command, `launch` accepts an optional version number.
+A typical use case is to start a Scala REPL with a specific Scala version:
+
+```bash
+$ cs launch scala:2.12.15
+Welcome to Scala 2.12.15 (OpenJDK 64-Bit Server VM, Java 1.8.0_292).
+Type in expressions for evaluation. Or try :help.
+
+scala>
+```
+
+In order to launch an application that does not have a published [application descriptor](cli-install.md#application-descriptors), `launch` accepts Maven coordinates as well:
 
 ```bash
 $ cs launch org.scalameta::scalafmt-cli:2.4.2 -- --help
@@ -158,7 +109,8 @@ Arguments can be passed to the application after `--`.
 
 ### `bootstrap`
 
-`bootstrap` creates binary launchers from one or more dependencies.
+`bootstrap` creates standalone binary launchers from one or more dependencies.
+The produced launches do not need `cs` to be installed, so they can be shared, notably as part of a repository.
 
 ```bash
 $ cs bootstrap org.scalameta::scalafmt-cli:2.4.2 -o scalafmt
@@ -166,27 +118,19 @@ $ ./scalafmt --version
 scalafmt 2.4.2
 ```
 
+On Linux, `bootstrap` does *not* create Windows `.bat` files by default.
+If you use it to produce shareable scripts, it is recommended to add the `--bat` option in order for Windows users not be stuck:
+
+```bash
+$ cs bootstrap --bat org.scalameta::scalafmt-cli:2.4.2 -o scalafmt
+$ ls
+scalafmt scalafmt.bat
+```
+
 `bootstrap` can generate a [variety of launchers](cli-bootstrap.md#launcher-types),
 including native ones like [GraalVM native images](cli-bootstrap.md#graalvm-native-image)
 or [Scala Native executables](cli-bootstrap.md#scala-native).
 See [the dedicated page](cli-bootstrap.md) for more details.
-
-### `install`
-
-The `install` command creates launchers for applications in the
-[installation directory](https://get-coursier.io/docs/cli-install.html#installation-directory)
-(`~/.local/share/coursier/bin` on Linux):
-```bash
-$ eval "$(cs install --env)" # add installation directory in PATH in the current session
-$ cs install scalafmt
-$ scalafmt --version
-scalafmt 2.4.2
-```
-
-One can run `cs install --setup` to [update](https://get-coursier.io/docs/cli-setup.html#how-it-sets-environment-variables-globally) profile files (Linux / macOS) or user environment variables (Windows),
-to add the installation directory to `PATH`.
-
-See [the dedicated page](cli-install.md) for more details.
 
 ### `java`
 
@@ -232,9 +176,53 @@ These two commands only write things in the coursier cache, and the [managed JVM
 
 The [dedicated page](cli-java.md) gives more details about the `java` and `java-home` commands.
 
+### `resolve`
+
+`resolve` lists the transitive dependencies of
+one or more other dependencies. Use like
+```bash
+$ cs resolve io.circe::circe-generic:0.12.3
+com.chuusai:shapeless_2.13:2.3.3:default
+io.circe:circe-core_2.13:0.12.3:default
+io.circe:circe-generic_2.13:0.12.3:default
+io.circe:circe-numbers_2.13:0.12.3:default
+org.scala-lang:scala-library:2.13.0:default
+org.typelevel:cats-core_2.13:2.0.0:default
+org.typelevel:cats-kernel_2.13:2.0.0:default
+org.typelevel:cats-macros_2.13:2.0.0:default
+```
+
+Note that this only relies on metadata files (POMs in particular),
+and doesn't download any JAR.
+
+`resolve` has more options, to [print trees](cli-resolve.md#tree),
+[find which dependency brings another one](cli-resolve.md#what-depends-on),
+etc. See [the dedicated page](cli-resolve.md) for more details.
+
+### `fetch`
+
+`fetch` fetches the JARs of one or more dependencies.
+
+```bash
+$ cs fetch io.circe::circe-generic:0.12.3
+/path/to/coursier/cache/https/repo1.maven.org/maven2/io/circe/circe-generic_2.13/0.12.3/circe-generic_2.13-0.12.3.jar
+/path/to/coursier/cache/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.0/scala-library-2.13.0.jar
+/path/to/coursier/cache/https/repo1.maven.org/maven2/io/circe/circe-core_2.13/0.12.3/circe-core_2.13-0.12.3.jar
+/path/to/coursier/cache/https/repo1.maven.org/maven2/com/chuusai/shapeless_2.13/2.3.3/shapeless_2.13-2.3.3.jar
+/path/to/coursier/cache/https/repo1.maven.org/maven2/io/circe/circe-numbers_2.13/0.12.3/circe-numbers_2.13-0.12.3.jar
+/path/to/coursier/cache/https/repo1.maven.org/maven2/org/typelevel/cats-core_2.13/2.0.0/cats-core_2.13-2.0.0.jar
+/path/to/coursier/cache/https/repo1.maven.org/maven2/org/typelevel/cats-macros_2.13/2.0.0/cats-macros_2.13-2.0.0.jar
+/path/to/coursier/cache/https/repo1.maven.org/maven2/org/typelevel/cats-kernel_2.13/2.0.0/cats-kernel_2.13-2.0.0.jar
+```
+
+`fetch` has more options, to [join its output with the path separator](cli-fetch.md#classpath-format),
+fetch [source JARs](cli-fetch.md#source-jars), fetch [javadoc](cli-fetch.md#javadoc), etc. See
+[the dedicated page](cli-fetch.md) for more details.
+
 ### `setup`
 
-`setup` ensures that:
+`setup` is the command used to install a Scala development environment.
+It ensures that:
 - a JVM is installed on your machine,
 - the installation directory of the [`install`](#install) command is in your `PATH`,
 - the standard Scala applications are installed on your system.

--- a/doc/docs/overview.md
+++ b/doc/docs/overview.md
@@ -31,7 +31,7 @@ It handles many features of the Maven model, and is able to fetch metadata and
 artifacts from both Maven and Ivy repositories. It handles parallel downloads
 out-of-the-box without resorting to global locks.
 
-The core features of courser can be used [as a **library** via its API](api.md), on the JVM or [from Scala.js](api-scala-js.md).
+The core features of coursier can be used [as a **library** via its API](api.md), on the JVM or [from Scala.js](api-scala-js.md).
 See [Users](overview-in-the-wild.md) for an overview of third-party projects that do this.
 
 *This is the documentation for version @VERSION@*.

--- a/doc/docs/overview.md
+++ b/doc/docs/overview.md
@@ -5,7 +5,25 @@ hide_title: true
 
 # coursier
 
-*coursier* is a dependency resolver / fetcher *à la* Maven / Ivy, entirely
+Coursier is the Scala application and artifact manager.
+It can install Scala applications and setup your Scala development environment.
+It can also download and cache artifacts from the web.
+
+## Getting started
+
+[Install `cs` and your Scala development environment](cli-installation.md)
+
+Once installed, the main usage of coursier is through its **command-line** tool `cs`.
+Its features include:
+
+- [install additional Scala applications](cli-install.md)
+- [launch Scala applications](cli-launch.md)
+- [create standalone launchers for Scala applications](cli-bootstrap.md)
+- [and others](cli-overview.md)
+
+## Under the hood
+
+Under the hood, coursier is a dependency resolver / fetcher *à la* Maven / Ivy, entirely
 rewritten from scratch in Scala. It aims at being fast and easy to embed
 in other contexts. Its core embraces functional programming principles.
 
@@ -13,13 +31,8 @@ It handles many features of the Maven model, and is able to fetch metadata and
 artifacts from both Maven and Ivy repositories. It handles parallel downloads
 out-of-the-box without resorting to global locks.
 
-It can be used
-- via its [**command-line** tool](cli-overview.md), that allows to
-  - [easily list the transitive dependencies of applications or libraries](cli-resolve.md),
-  - [download and list their artifacts](cli-fetch.md),
-  - [run applications published via Maven / Ivy repositories](cli-launch.md),
-  - [and many other things](cli-overview.md).
-- [as a **library** via its API](api.md), on the JVM or [from Scala.js](api-scala-js.md) - see [Users](overview-in-the-wild.md) for an overview of projects that do this.
+The core features of courser can be used [as a **library** via its API](api.md), on the JVM or [from Scala.js](api-scala-js.md).
+See [Users](overview-in-the-wild.md) for an overview of third-party projects that do this.
 
 *This is the documentation for version @VERSION@*.
 

--- a/doc/website/sidebars.json
+++ b/doc/website/sidebars.json
@@ -1,26 +1,28 @@
 {
   "docs": {
     "Intro": [
-      "overview",
+      "overview"
+    ],
+    "Command-line": [
+      "cli-overview",
+      "cli-installation",
+      "cli-examples",
+      "cli-install",
+      "cli-launch",
+      "cli-bootstrap",
+      "cli-java",
+      "cli-resolve",
+      "cli-fetch",
+      "cli-complete",
+      "cli-setup"
+    ],
+    "Motivation": [
       "overview-motivations",
       "overview-in-the-wild"
     ],
     "sbt plugins": [
       "sbt-coursier",
       "sbt-pgp-coursier"
-    ],
-    "Command-line": [
-      "cli-overview",
-      "cli-installation",
-      "cli-examples",
-      "cli-complete",
-      "cli-resolve",
-      "cli-fetch",
-      "cli-launch",
-      "cli-bootstrap",
-      "cli-install",
-      "cli-java",
-      "cli-setup"
     ],
     "API": [
       "api",


### PR DESCRIPTION
This complements recent changes in the `--help` menus.

The documentation used to highlight the artifact resolver use case of coursier first and foremost. We now highlight the beginner use case of setting up and installing applications instead.