### PR TITLE
Case-insensitive OS activation

### DIFF
--- a/modules/core/shared/src/main/scala/coursier/core/Activation.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Activation.scala
@@ -75,16 +75,19 @@ object Activation {
     def isEmpty: Boolean =
       arch.isEmpty && families.isEmpty && name.isEmpty && version.isEmpty
 
+    def archMatch(current: Option[String]): Boolean =
+      archNormalized.forall(current.contains)
+
     def isActive(osInfo: Os): Boolean =
-      archNormalized.forall(osInfo.archNormalized.contains) &&
-        familiesNormalized.forall { f =>
-          if (Os.knownFamilies(f))
-            osInfo.familiesNormalized.contains(f)
-          else
-            osInfo.nameNormalized.exists(_.contains(f))
-        } &&
-        nameNormalized.forall(osInfo.nameNormalized.contains) &&
-        versionNormalized.forall(osInfo.versionNormalized.contains)
+      archMatch(osInfo.archNormalized) &&
+      familiesNormalized.forall { f =>
+        if (Os.knownFamilies(f))
+          osInfo.familiesNormalized.contains(f)
+        else
+          osInfo.nameNormalized.exists(_.contains(f))
+      } &&
+      nameNormalized.forall(osInfo.nameNormalized.contains) &&
+      versionNormalized.forall(osInfo.versionNormalized.contains)
   }
 
   object Os {

--- a/modules/core/shared/src/main/scala/coursier/core/Activation.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Activation.scala
@@ -2,6 +2,8 @@ package coursier.core
 
 import dataclass.data
 
+import java.util.Locale
+
 // Maven-specific
 @data class Activation(
   properties: Seq[(String, Option[String])],
@@ -60,25 +62,29 @@ object Activation {
     name: Option[String],
     version: Option[String] // FIXME Could this be an interval?
   ) {
+    private lazy val archNormalized = arch
+      .map(_.toLowerCase(Locale.US))
+      .map {
+        case "x86-64" => "x86_64" // seems required by org.nd4j:nd4j-native:0.5.0
+        case arch     => arch
+      }
+    private lazy val familiesNormalized = families.map(_.toLowerCase(Locale.US))
+    private lazy val nameNormalized     = name.map(_.toLowerCase(Locale.US))
+    private lazy val versionNormalized  = version.map(_.toLowerCase(Locale.US))
+
     def isEmpty: Boolean =
       arch.isEmpty && families.isEmpty && name.isEmpty && version.isEmpty
 
-    def archMatch(current: Option[String]): Boolean =
-      arch.forall(current.toSeq.contains) || {
-        // seems required by org.nd4j:nd4j-native:0.5.0
-        arch.toSeq.contains("x86-64") && current.toSeq.contains("x86_64")
-      }
-
     def isActive(osInfo: Os): Boolean =
-      archMatch(osInfo.arch) &&
-      families.forall { f =>
-        if (Os.knownFamilies(f))
-          osInfo.families.contains(f)
-        else
-          osInfo.name.exists(_.contains(f))
-      } &&
-      name.forall(osInfo.name.toSeq.contains) &&
-      version.forall(osInfo.version.toSeq.contains)
+      archNormalized.forall(osInfo.archNormalized.contains) &&
+        familiesNormalized.forall { f =>
+          if (Os.knownFamilies(f))
+            osInfo.familiesNormalized.contains(f)
+          else
+            osInfo.nameNormalized.exists(_.contains(f))
+        } &&
+        nameNormalized.forall(osInfo.nameNormalized.contains) &&
+        versionNormalized.forall(osInfo.versionNormalized.contains)
   }
 
   object Os {

--- a/modules/core/shared/src/main/scala/coursier/maven/Pom.scala
+++ b/modules/core/shared/src/main/scala/coursier/maven/Pom.scala
@@ -100,10 +100,10 @@ object Pom {
     val osNodeOpt = node.children.collectFirst { case n if n.label == "os" => n }
 
     val os = Activation.Os(
-      osNodeOpt.flatMap(n => text(n, "arch", "").toOption.map(_.toLowerCase)),
-      osNodeOpt.flatMap(n => text(n, "family", "").toOption.map(_.toLowerCase)).toSet,
-      osNodeOpt.flatMap(n => text(n, "name", "").toOption.map(_.toLowerCase)),
-      osNodeOpt.flatMap(n => text(n, "version", "").toOption.map(_.toLowerCase))
+      osNodeOpt.flatMap(n => text(n, "arch", "").toOption),
+      osNodeOpt.flatMap(n => text(n, "family", "").toOption).toSet,
+      osNodeOpt.flatMap(n => text(n, "name", "").toOption),
+      osNodeOpt.flatMap(n => text(n, "version", "").toOption)
     )
 
     val jdk = text(node, "jdk", "").toOption.flatMap { s =>

--- a/modules/core/shared/src/main/scala/coursier/maven/Pom.scala
+++ b/modules/core/shared/src/main/scala/coursier/maven/Pom.scala
@@ -100,10 +100,10 @@ object Pom {
     val osNodeOpt = node.children.collectFirst { case n if n.label == "os" => n }
 
     val os = Activation.Os(
-      osNodeOpt.flatMap(n => text(n, "arch", "").toOption),
-      osNodeOpt.flatMap(n => text(n, "family", "").toOption).toSet,
-      osNodeOpt.flatMap(n => text(n, "name", "").toOption),
-      osNodeOpt.flatMap(n => text(n, "version", "").toOption)
+      osNodeOpt.flatMap(n => text(n, "arch", "").toOption.map(_.toLowerCase)),
+      osNodeOpt.flatMap(n => text(n, "family", "").toOption.map(_.toLowerCase)).toSet,
+      osNodeOpt.flatMap(n => text(n, "name", "").toOption.map(_.toLowerCase)),
+      osNodeOpt.flatMap(n => text(n, "version", "").toOption.map(_.toLowerCase))
     )
 
     val jdk = text(node, "jdk", "").toOption.flatMap { s =>

--- a/modules/tests/shared/src/test/scala/coursier/test/PomParsingTests.scala
+++ b/modules/tests/shared/src/test/scala/coursier/test/PomParsingTests.scala
@@ -335,6 +335,30 @@ object PomParsingTests extends TestSuite {
 
       assert(result == expected)
     }
+
+    test("caseInsensitiveOperatingSystemActivation") {
+      val profileNode = """
+        <profile>
+          <id>profile1</id>
+          <activation>
+            <os>
+              <family>Windows</family>
+              <arch>amd64</arch>
+            </os>
+          </activation>
+        </profile>
+                       """
+      val profile     = Pom.profile(xmlParseDom(profileNode).toOption.get).right.get
+      val windowsOs = core.Activation.Os.fromProperties(Map(
+        "os.name"        -> "Windows 10",
+        "os.arch"        -> "amd64",
+        "os.version"     -> "10.0",
+        "path.separator" -> ";"
+      ))
+      val isActive = profile.activation.os.isActive(windowsOs)
+
+      assert(isActive)
+    }
   }
 
 }


### PR DESCRIPTION
This profile does not activate due to the capital W in Windows:
```xml
<activation>
  <os>
    <family>Windows</family>
    <arch>amd64</arch>
  </os>
</activation>
```

For my use-case, jvmbrotli uses profiles to pull in its jni libs for each operating system:
https://github.com/nixxcode/jvm-brotli/blob/06a73890dec39b060c80d021a45e80c8ae1a8c32/jvmbrotli/pom.xml#L18-L33

This works for `<family>unix</family>` and `<family>mac</family>` but not `<family>Windows</family>` due to the capitalization:
https://github.com/dwickern/sbt-web-brotli/runs/4423716589?check_suite_focus=true
