### PR TITLE
Set user agent to 'Coursier/2.0'

### DIFF
--- a/modules/cache/jvm/src/main/scala/coursier/cache/CacheUrl.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/CacheUrl.scala
@@ -142,7 +142,7 @@ object CacheUrl {
 
         // Early in the development of coursier, I ran into some repositories (Sonatype ones?) not
         // returning the same content for user agent "Java/…".
-        conn0.setRequestProperty("User-Agent", "")
+        conn0.setRequestProperty("User-Agent", "Coursier/2.0")
 
         conn0 match {
           case conn1: HttpsURLConnection =>


### PR DESCRIPTION
I guess the version should stay at '2.0' for the time being - not to leak the full coursier version, or details about the OS, all around.