### PR TITLE
Include pre-release versions in versions from listing

### DIFF
--- a/modules/core/shared/src/main/scala/coursier/maven/MavenRepository.scala
+++ b/modules/core/shared/src/main/scala/coursier/maven/MavenRepository.scala
@@ -245,17 +245,13 @@ object MavenRepository {
             case _              => true
           })
 
-          if (nonPreVersions.isEmpty)
-            Left(s"Found only pre-versions at $listingUrl")
-          else {
-            val latest = nonPreVersions.max
-            Right(Versions(
-              latest.repr,
-              latest.repr,
-              nonPreVersions.map(_.repr).toList,
-              None
-            ))
-          }
+          val latest = if (nonPreVersions.nonEmpty) nonPreVersions.max else parsedVersions.max
+          Right(Versions(
+            latest.repr,
+            latest.repr,
+            parsedVersions.map(_.repr).toList,
+            None
+          ))
         }
 
       EitherT(F.point(res.map((_, listingUrl))))

--- a/modules/core/shared/src/main/scala/coursier/maven/MavenRepository.scala
+++ b/modules/core/shared/src/main/scala/coursier/maven/MavenRepository.scala
@@ -245,10 +245,11 @@ object MavenRepository {
             case _              => true
           })
 
-          val latest = if (nonPreVersions.nonEmpty) nonPreVersions.max else parsedVersions.max
+          val latest  = parsedVersions.max
+          val release = if (nonPreVersions.nonEmpty) nonPreVersions.max else latest
           Right(Versions(
             latest.repr,
-            latest.repr,
+            release.repr,
             parsedVersions.map(_.repr).toList,
             None
           ))


### PR DESCRIPTION
This includes pre-release versions in `MavenRepository#versionsFromListing`. I've no idea why these versions are currently ignored and also haven't found any clue about that in the Git history.

Motivation for this change is https://github.com/typelevel/sbt-typelevel/issues/78. @armanbilge and I found that Scala Steward (which uses Coursier under the hood) does not create updates to pre-release versions of sbt plugins hosted on Maven Central. The reason is that there is no `maven-metadata.xml` for sbt plugins so that Coursier reads the versions from the directory listing but ignores pre-release versions then.