### PR TITLE
Ensure we generate Java 8 compatible byte code

### DIFF
--- a/.github/scripts/maybe-with-graalvm-home.sh
+++ b/.github/scripts/maybe-with-graalvm-home.sh
@@ -3,10 +3,8 @@ set -e
 
 if [[ "$OSTYPE" == "msys" ]]; then
   ./mill.bat -i ci.copyJvm --dest jvm
-  export JAVA_HOME="$(pwd -W | sed 's,/,\\,g')\\jvm"
-  export GRAALVM_HOME="$JAVA_HOME"
-  export PATH="$(pwd)/jvm/bin:$PATH"
-  echo "PATH=$PATH"
+  export GRAALVM_HOME="$(pwd -W | sed 's,/,\\,g')\\jvm"
+  echo "GRAALVM_HOME=$GRAALVM_HOME"
 
   ./mill.bat -i "$@"
 else

--- a/project/modules/shared.sc
+++ b/project/modules/shared.sc
@@ -32,7 +32,7 @@ lazy val buildVersion = {
   }
 }
 
-trait CoursierPublishModule extends PublishModule {
+trait CoursierPublishModule extends PublishModule with JavaModule {
   import mill.scalalib.publish._
   def pomSettings = PomSettings(
     description = artifactName(),
@@ -45,6 +45,9 @@ trait CoursierPublishModule extends PublishModule {
     )
   )
   def publishVersion = T(buildVersion)
+  def javacOptions = T {
+    super.javacOptions() ++ Seq("-source", "8", "-target", "8")
+  }
 }
 
 trait CsTests extends TestModule {


### PR DESCRIPTION
The `2.1.0-M4` Windows native launcher is built with Java 17 all the way up, which makes its bootstraps fail to run with Java 8 or 11.

These changes should ensure:
- we always generate Java 8 compatible byte code
- we use the same JVM as on Linux and macOS to build the Windows native launcher

Fixes https://github.com/coursier/coursier/issues/2354.