### PR TITLE
Set HTTP Accept header

### DIFF
--- a/modules/cache/jvm/src/main/scala/coursier/cache/CacheUrl.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/CacheUrl.scala
@@ -143,6 +143,9 @@ object CacheUrl {
         // Early in the development of coursier, I ran into some repositories (Sonatype ones?) not
         // returning the same content for user agent "Java/…".
         conn0.setRequestProperty("User-Agent", "Coursier/2.0")
+        // Some remote repositories (AWS CodeArtifact) return a "false" 404 if maven-metadata.xml is requested
+        // with default Accept header Java sets for HttpUrlConnection
+        conn0.setRequestProperty("Accept", "*/*")
 
         conn0 match {
           case conn1: HttpsURLConnection =>


### PR DESCRIPTION
Works around problems with remote repositories like AWS CodeArtifact that return 404 on `maven-metadata.xml` if requested with JVM's default `Accept` HTTP header (which is `text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2` – see [here](https://github.com/openjdk-mirror/jdk/blob/jdk8u/jdk8u/master/src/share/classes/sun/net/www/protocol/http/HttpURLConnection.java#L256)).