### PR TITLE
Hide NativeAPI service to apps launched by bootstraps

### DIFF
--- a/modules/bootstrap-launcher/src/main/java/coursier/bootstrap/launcher/Bootstrap.java
+++ b/modules/bootstrap-launcher/src/main/java/coursier/bootstrap/launcher/Bootstrap.java
@@ -55,7 +55,7 @@ public class Bootstrap {
 
         ClassLoader classLoader = classLoaders.createClassLoader(contextLoader);
 
-        boolean isSimpleLoader = classLoader.getParent().equals(contextLoader) && (classLoader instanceof URLClassLoader);
+        boolean isSimpleLoader = classLoader.getParent().getParent().equals(contextLoader) && (classLoader instanceof URLClassLoader);
         String previousJavaClassPath = null;
 
         if (isSimpleLoader) {

--- a/modules/bootstrap-launcher/src/main/java/coursier/bootstrap/launcher/ClassLoaders.java
+++ b/modules/bootstrap-launcher/src/main/java/coursier/bootstrap/launcher/ClassLoaders.java
@@ -81,7 +81,8 @@ class ClassLoaders {
         List<URL> urls = getURLs(strUrls);
         List<URL> localURLs = download.getLocalURLs(urls);
 
-        ClassLoader parentClassLoader = readBaseLoaders(contextLoader);
+        ClassLoader hideStuffClassLoader = new HideNativeApiClassLoader(contextLoader);
+        ClassLoader parentClassLoader = readBaseLoaders(hideStuffClassLoader);
 
         return new URLClassLoader(localURLs.toArray(new URL[0]), parentClassLoader);
     }

--- a/modules/bootstrap-launcher/src/main/java/coursier/bootstrap/launcher/HideNativeApiClassLoader.java
+++ b/modules/bootstrap-launcher/src/main/java/coursier/bootstrap/launcher/HideNativeApiClassLoader.java
@@ -1,0 +1,30 @@
+package coursier.bootstrap.launcher;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Enumeration;
+
+class HideNativeApiClassLoader extends ClassLoader {
+
+  HideNativeApiClassLoader(ClassLoader parent) {
+    super(parent);
+  }
+
+  private static final String toHide = "META-INF/services/coursier.jniutils.NativeApi";
+
+  @Override
+  public URL getResource(String name) {
+    if (name.equals(toHide))
+      return null;
+    return super.getResource(name);
+  }
+
+  @Override
+  public Enumeration<URL> getResources(String name) throws IOException {
+    if (name.equals(toHide))
+      return Collections.emptyEnumeration();
+    return super.getResources(name);
+  }
+
+}

--- a/modules/cli-tests/src/main/scala/coursier/clitests/BootstrapTests.scala
+++ b/modules/cli-tests/src/main/scala/coursier/clitests/BootstrapTests.scala
@@ -195,7 +195,7 @@ abstract class BootstrapTests extends TestSuite {
         "disabled"
     }
 
-    test("java.class.path property") {
+    test("java class path property") {
       TestUtil.withTempDir { tmpDir =>
         LauncherTestUtil.run(
           args =


### PR DESCRIPTION
This fixes errors such as this one, that can be seen when using jni-utils from an app launched by a coursier bootstrap:
```text
java.util.ServiceConfigurationError: coursier.jniutils.NativeApi: coursier.bootstrap.launcher.jniutils.BootstrapNativeApi not a subtype
    java.base/java.util.ServiceLoader.fail(ServiceLoader.java:593)
    java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNextService(ServiceLoader.java:14)
    java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNext(ServiceLoader.java:13)
    java.base/java.util.ServiceLoader$2.hasNext(ServiceLoader.java:1309)
    java.base/java.util.ServiceLoader$3.hasNext(ServiceLoader.java:1393)
    coursier.jniutils.NativeApi.get(NativeApi.java:32)
    …
```