### PR TITLE
Add PowerShell and fix CMD install instructions

### DIFF
--- a/doc/docs/cli-installation.md
+++ b/doc/docs/cli-installation.md
@@ -54,12 +54,21 @@ On Windows, [download and execute the Windows installer](https://github.com/cour
 
 If you prefer a command line-based install, or if you would like to customize the setup options, use:
 
+```pwsh
+# PowerShell
+Invoke-WebRequest -Uri "https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-win32.zip" -OutFile "cs-x86_64-pc-win32.zip"
+Expand-Archive -Path "cs-x86_64-pc-win32.zip"
+Rename-Item -Path "cs-x86_64-pc-win32.exe" -NewName "cs.exe"
+Remove-Item -Path "cs-x86_64-pc-win32.zip"
+.\cs --help
+```
+
 ```bat
-# CMD
-> curl -fLo cs-x86_64-pc-win32.zip https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-win32.zip
-> tar -xf cs-x86_64-pc-win32.zip
-> move cs-x86_64-pc-win32.exe cs.exe
-> .\cs --help
+:: CMD
+curl -fLo cs-x86_64-pc-win32.zip https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-win32.zip
+tar -xf cs-x86_64-pc-win32.zip
+move cs-x86_64-pc-win32.exe cs.exe
+.\cs --help
 ```
 
 ### Check your setup


### PR DESCRIPTION
My only worry with this is #2031 and #2118. I have not tested these instructions on a machine lacking `COURSIER_CACHE`, `COURSIER_BIN_DIR`, and `COURSIER_JVM_CACHE`.

[My own instructions for installing Coursier](https://b.s5.pm/os/2021/08/28/windows-setup.html#java--scala) specify that those environment variables are needed, however I don't know what has changed since that was written.