### PR TITLE
Print the installed location in `coursier java --available` and restore `--installed` option

### DIFF
--- a/modules/cli/src/main/scala/coursier/cli/jvm/Java.scala
+++ b/modules/cli/src/main/scala/coursier/cli/jvm/Java.scala
@@ -59,12 +59,12 @@ object Java extends CoursierCommand[JavaOptions] {
                 version <- versionMap.keysIterator.toVector.map(Version(_)).sorted.map(_.repr)
               } yield s"$name:$version"
 
-              if (params.available) {
+              if (params.available)
                 Task.delay {
                   for (id <- available)
                     System.out.println(id)
                 }
-              } else {
+              else {
                 assert(params.installed)
 
                 val resultsTask = Task.gather.gather {
@@ -81,7 +81,7 @@ object Java extends CoursierCommand[JavaOptions] {
           }
           maybeError <- maybeErrorTask match {
             case Left(err) => Task.point(Left(err))
-            case Right(t) => t.map(Right(_))
+            case Right(t)  => t.map(Right(_))
           }
         } yield maybeError
 

--- a/modules/cli/src/main/scala/coursier/cli/jvm/JavaOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/jvm/JavaOptions.scala
@@ -24,7 +24,9 @@ import caseapp.Group
 )
 final case class JavaOptions(
   @Group(OptionGroup.java)
-  available: Boolean = false,
+    available: Boolean = false,
+  @Group(OptionGroup.java)
+    installed: Boolean = false,
   @Recurse
     sharedJavaOptions: SharedJavaOptions = SharedJavaOptions(),
   @Recurse

--- a/modules/cli/src/main/scala/coursier/cli/jvm/JavaParams.scala
+++ b/modules/cli/src/main/scala/coursier/cli/jvm/JavaParams.scala
@@ -38,7 +38,7 @@ object JavaParams {
     val checkArgsV =
       if (anyArg && flags.exists(identity))
         Validated.invalidNel(
-          s"Error: unexpected arguments passed along --env, --setup, --available or installed."
+          s"Error: unexpected arguments passed along --env, --setup, --available or --installed."
         )
       else
         Validated.validNel(())

--- a/modules/cli/src/main/scala/coursier/cli/jvm/JavaParams.scala
+++ b/modules/cli/src/main/scala/coursier/cli/jvm/JavaParams.scala
@@ -6,6 +6,7 @@ import coursier.cli.params.{CacheParams, EnvParams, OutputParams, RepositoryPara
 
 final case class JavaParams(
   available: Boolean,
+  installed: Boolean,
   shared: SharedJavaParams,
   repository: RepositoryParams,
   cache: CacheParams,
@@ -23,12 +24,13 @@ object JavaParams {
 
     val flags = Seq(
       options.available,
+      options.installed,
       envV.toOption.fold(false)(_.anyFlag)
     )
     val flagsV =
       if (flags.count(identity) > 1)
         Validated.invalidNel(
-          "Error: can only specify one of --env, --setup, --available."
+          "Error: can only specify one of --env, --setup, --available or --installed."
         )
       else
         Validated.validNel(())
@@ -36,7 +38,7 @@ object JavaParams {
     val checkArgsV =
       if (anyArg && flags.exists(identity))
         Validated.invalidNel(
-          s"Error: unexpected arguments passed along --env, --setup, or --available"
+          s"Error: unexpected arguments passed along --env, --setup, --available or installed."
         )
       else
         Validated.validNel(())
@@ -45,6 +47,7 @@ object JavaParams {
       (shared, cache, output, env, repo, _, _) =>
         JavaParams(
           options.available,
+          options.installed,
           shared,
           repo,
           cache,


### PR DESCRIPTION
Hi, trying coursier lately i realized `coursier jvm --installed` mentioned in ~~not too old~~[master](https://github.com/coursier/coursier/blob/master/doc/docs/cli-java.md#managed-jvms) docs was not working anymore:

```
D:\ws>coursier java --installed
Unrecognized option: --installed
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

so i started to work in add it. Later i realized the feature was removed on purpose and commented in the pr which did it: https://github.com/coursier/coursier/pull/2188#issuecomment-1079935827

Well as i dont know what were the reasons to remove it i am opening the pr knowing it could be ignored/discarded.

However, printing the installed location in `--available` seems pretty useful to me too and it could be added independently. `--installed` will be matter of doing `coursier jvm --installed | grep installed`

Maybe it would close #2300

Thanks in advance!