### PR TITLE
Improve performance for DependencySet.add

### DIFF
--- a/modules/core/shared/src/main/scala/coursier/core/DependencySet.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/DependencySet.scala
@@ -61,16 +61,19 @@ final class DependencySet private (
         // Optimized map value addition. Only mutate map if we made a change
         m.get(dep0) match {
           case None =>
-            m = m + (dep0 -> Sets.empty[Dependency].add(dep, _.exclusions.size, (a, b) => a.exclusions.subsetOf(b.exclusions)))
+            m = m + (dep0 -> Sets.empty[Dependency].add(
+              dep,
+              _.exclusions.size,
+              (a, b) => a.exclusions.subsetOf(b.exclusions)
+            ))
           case Some(groupSet) =>
             val groupSet0 = groupSet.add(
               dep,
               _.exclusions.size,
               (a, b) => a.exclusions.subsetOf(b.exclusions)
             )
-            if (groupSet ne groupSet0) {
+            if (groupSet ne groupSet0)
               m = m + (dep0 -> groupSet0)
-            }
         }
       }
       new DependencySet(set ++ dependencies, m)

--- a/modules/core/shared/src/main/scala/coursier/core/DependencySet.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/DependencySet.scala
@@ -55,20 +55,25 @@ final class DependencySet private (
     if (dependencies.isEmpty)
       this
     else {
-      val m = new mutable.HashMap[Dependency, Sets[Dependency]]
-      m ++= grouped
+      var m = grouped
       for (dep <- dependencies) {
         val dep0 = dep.clearExclusions
-        val l = m
-          .getOrElse(dep0, Sets.empty[Dependency])
-          .add(
-            dep,
-            _.exclusions.size,
-            (a, b) => a.exclusions.subsetOf(b.exclusions)
-          )
-        m(dep0) = l
+        // Optimized map value addition. Only mutate map if we made a change
+        m.get(dep0) match {
+          case None =>
+            m = m + (dep0 -> Sets.empty[Dependency].add(dep, _.exclusions.size, (a, b) => a.exclusions.subsetOf(b.exclusions)))
+          case Some(groupSet) =>
+            val groupSet0 = groupSet.add(
+              dep,
+              _.exclusions.size,
+              (a, b) => a.exclusions.subsetOf(b.exclusions)
+            )
+            if (groupSet ne groupSet0) {
+              m = m + (dep0 -> groupSet0)
+            }
+        }
       }
-      new DependencySet(set ++ dependencies, m.toMap)
+      new DependencySet(set ++ dependencies, m)
     }
 
   def remove(dependencies: Iterable[Dependency]): DependencySet =
@@ -78,8 +83,7 @@ final class DependencySet private (
     if (dependencies.isEmpty)
       this
     else {
-      val m = new mutable.HashMap[Dependency, Sets[Dependency]]
-      m ++= grouped
+      var m = grouped
       for (dep <- dependencies) {
         val dep0 = dep.clearExclusions
         // getOrElse useful if we're passed duplicated stuff in dependencies


### PR DESCRIPTION
Analysis with jprofiler showed ~1/5th of time spent in DependencySet.add for an `sbt update` i was running (see profile picture).

![Screenshot from 2022-05-22 19-34-12](https://user-images.githubusercontent.com/10679/169708144-89fada59-e591-4044-8d23-3d873f9947d4.png)

This is caused by DependencySet.addNoCheck completely rebuilding the 'grouped' HashMap from scratch. Using immutable collections in this PR brought `sbt update` to 111s from 131s prior for my local workload

