### PR TITLE
fix: make sure JAVA_HOME is used in bootstrapped file

### DIFF
--- a/modules/launcher/src/main/scala/coursier/launcher/Preamble.scala
+++ b/modules/launcher/src/main/scala/coursier/launcher/Preamble.scala
@@ -41,9 +41,13 @@ import scala.io.{Codec, Source}
       .sorted
       // escaping possibly a bit loose :-|
       .map { case (k, v) => s"""export $k="$v"""" }
+
     val lines = command match {
       case None =>
-        val javaCmd = Seq("java") ++
+        val setJavaCmd =
+          """[ -x "$JAVA_HOME/bin/java" ] && JAVA_CMD="$JAVA_HOME/bin/java" || JAVA_CMD=java"""
+
+        val javaCmd = Seq("$JAVA_CMD") ++
           // escaping possibly a bit loose :-|
           javaOpts.map(s => "'" + s.replace("'", "\\'") + "'") ++
           jvmOptionFile.toSeq.map(_ => "${extra_jvm_opts[@]}") ++
@@ -55,6 +59,7 @@ import scala.io.{Codec, Source}
           setVars ++
           Seq(Preamble.shArgsPartitioner(jarPath.getOrElse("$0"))) ++
           jvmOptionFile.toSeq.map(f => Preamble.bashJvmOptFile(f)) ++
+          Seq(setJavaCmd) ++
           Seq("exec " + javaCmd.mkString(" "))
 
       case Some(c) =>


### PR DESCRIPTION
I came across this for some Metals users that use coursier to bootstrap
a metals executable. The executable just calls `java` and doesn't
respect `JAVA_HOME`. This change makes sure that in the shell script if
`JAVA_HOME` is set, it's used and if not we fall back to `java`.

Closes #2048