### PR TITLE
Support `--architecture` flag for Java commands

### DIFF
--- a/modules/cli/src/main/scala/coursier/cli/jvm/SharedJavaOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/jvm/SharedJavaOptions.scala
@@ -18,6 +18,9 @@ final case class SharedJavaOptions(
     update: Boolean = false,
 
   @Group(OptionGroup.java)
-    jvmIndex: Option[String] = None
+    jvmIndex: Option[String] = None,
+
+  @Group(OptionGroup.java)
+    architecture: Option[String] = None
 )
 // format: on

--- a/modules/cli/src/main/scala/coursier/cli/jvm/SharedJavaParams.scala
+++ b/modules/cli/src/main/scala/coursier/cli/jvm/SharedJavaParams.scala
@@ -15,6 +15,7 @@ final case class SharedJavaParams(
   allowSystemJvm: Boolean,
   requireSystemJvm: Boolean,
   update: Boolean,
+  architecture: Option[String],
   jvmChannelOpt: Option[JvmChannel]
 ) {
   def id: String =
@@ -28,8 +29,12 @@ final case class SharedJavaParams(
   ): (JvmCache, coursier.jvm.JavaHome) = {
     def jvmCacheOf(cache: Cache[Task]) = {
       val archiveCache = ArchiveCache().withCache(cache)
-      val c = JvmCache()
+      val baseCache = JvmCache()
         .withArchiveCache(archiveCache)
+      val c = architecture match {
+        case None       => baseCache
+        case Some(arch) => baseCache.withArchitecture(arch)
+      }
       jvmChannelOpt match {
         case None             => c.withDefaultIndex
         case Some(jvmChannel) => c.withIndexChannel(repositories, jvmChannel)
@@ -114,6 +119,7 @@ object SharedJavaParams {
           allowSystem,
           requireSystem,
           options.update,
+          options.architecture,
           indexChannelOpt
         )
     }


### PR DESCRIPTION
Previously, it was not possible to use `coursier java-home` to download
an x86_64 architecture JDK on an Apple M1 computer. This may be a
niche use-case, but we can't use any existing aarch64 JDK 8
distributions in the https://github.com/sourcegraph/scip-java build
because none of them give access to the `com.sun` APIs as far as I can
tell. With this commit, we can use `--architecture amd64 --jvm 8` to
populate the boot classpath of our javac compiler plugin so that
`com.sun` APIs are available during compile time.