### PR TITLE
Disable nailgun tests on Mac CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,6 @@ jobs:
         jvm: ${{ matrix.JDK }}
     - run: sudo apt-get install -y nailgun
       if: runner.os == 'Linux'
-    - run: brew install nailgun
-      if: runner.os == 'macOS'
     # - run: .github/scripts/scala-native-setup.sh
     #   if: runner.os != 'Windows'
     - run: ./mill -i jvmTests "$SCALA_VERSION"

--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -24,8 +24,6 @@ jobs:
           jvm: 8
       - run: sudo apt-get install -y nailgun
         if: runner.os == 'Linux'
-      - run: brew install nailgun
-        if: runner.os == 'macOS'
       - run: .github/scripts/maybe-with-graalvm-home.sh nativeTests
         shell: bash
 

--- a/modules/cli-tests/src/test/scala/coursier/clitests/PackBootstrapTests.scala
+++ b/modules/cli-tests/src/test/scala/coursier/clitests/PackBootstrapTests.scala
@@ -33,7 +33,9 @@ object PackBootstrapTests extends BootstrapTests {
       None
   override lazy val enableNailgunTest: Boolean =
     // TODO Re-enable that on Windows using snailgun?
-    !System.getProperty("os.name").toLowerCase(java.util.Locale.ROOT).contains("windows") &&
+    !Properties.isWin &&
     // running into weird class loading errors with nailgun and JDK >= 11
-    sys.props.get("java.version").exists(_.startsWith("1."))
+    sys.props.get("java.version").exists(_.startsWith("1.")) &&
+    // Disabling nailgun mac test on CI (seems we can't install nailgun with brew anymore on GitHub Mac runners)
+    (!Properties.isMac || System.getenv("CI") == null)
 }


### PR DESCRIPTION
Seems it can't be installed any more there:
```text
Error: nailgun has been disabled because it does not build!
Error: Process completed with exit code 1.
```