### PR TITLE
Deduplicate strings in `JsonElem`

### DIFF
--- a/modules/cli/src/main/scala/coursier/cli/util/JsonReport.scala
+++ b/modules/cli/src/main/scala/coursier/cli/util/JsonReport.scala
@@ -182,8 +182,8 @@ final case class JsonElem(
   // whose values are frequently duplicated across instances of `JsonElem` and their
   // transitive `Dependencies`. Here we cast these values to `Symbol`, which is an
   // interned collection, effectively deduping the string values in memory.
-  lazy val reconciledVersion: String = Symbol(resolution.reconciledVersions
-    .getOrElse(dep.module, dep.version)).name
+  lazy val reconciledVersion: String =
+    Symbol(resolution.reconciledVersions.getOrElse(dep.module, dep.version)).name
 
   // These are used to printing json output
   lazy val reconciledVersionStr = Symbol(s"${dep.mavenPrefix}:$reconciledVersion").name

--- a/modules/cli/src/main/scala/coursier/cli/util/JsonReport.scala
+++ b/modules/cli/src/main/scala/coursier/cli/util/JsonReport.scala
@@ -179,11 +179,11 @@ final case class JsonElem(
     )
 
   lazy val reconciledVersion: String = resolution.reconciledVersions
-    .getOrElse(dep.module, dep.version)
+    .getOrElse(dep.module, dep.version).intern
 
   // These are used to printing json output
-  val reconciledVersionStr = s"${dep.mavenPrefix}:$reconciledVersion"
-  val requestedVersionStr  = s"${dep.module}:${dep.version}"
+  lazy val reconciledVersionStr = s"${dep.mavenPrefix}:$reconciledVersion".intern
+  val requestedVersionStr  = s"${dep.module}:${dep.version}".intern
 
   lazy val exclusions: Set[String] = dep.exclusions.map {
     case (org, name) =>

--- a/modules/cli/src/main/scala/coursier/cli/util/JsonReport.scala
+++ b/modules/cli/src/main/scala/coursier/cli/util/JsonReport.scala
@@ -183,7 +183,7 @@ final case class JsonElem(
   // transitive `Dependencies`. Here we cast these values to `Symbol`, which is an
   // interned collection, effectively deduping the string values in memory.
   lazy val reconciledVersion: String = Symbol(resolution.reconciledVersions
-    .getOrElse(dep.module, dep.version).intern).name
+    .getOrElse(dep.module, dep.version)).name
 
   // These are used to printing json output
   lazy val reconciledVersionStr = Symbol(s"${dep.mavenPrefix}:$reconciledVersion").name

--- a/modules/cli/src/main/scala/coursier/cli/util/JsonReport.scala
+++ b/modules/cli/src/main/scala/coursier/cli/util/JsonReport.scala
@@ -178,12 +178,16 @@ final case class JsonElem(
         .headOption
     )
 
-  lazy val reconciledVersion: String = resolution.reconciledVersions
-    .getOrElse(dep.module, dep.version).intern
+  // `reconciledVersion`, `reconciledVersionStr`, `requestedVersionStr` are fields
+  // whose values are frequently duplicated across instances of `JsonElem` and their
+  // transitive `Dependencies`. Here we cast these values to `Symbol`, which is an
+  // interned collection, effectively deduping the string values in memory.
+  lazy val reconciledVersion: String = Symbol(resolution.reconciledVersions
+    .getOrElse(dep.module, dep.version).intern).name
 
   // These are used to printing json output
-  lazy val reconciledVersionStr = s"${dep.mavenPrefix}:$reconciledVersion".intern
-  val requestedVersionStr  = s"${dep.module}:${dep.version}".intern
+  lazy val reconciledVersionStr = Symbol(s"${dep.mavenPrefix}:$reconciledVersion").name
+  val requestedVersionStr       = Symbol(s"${dep.module}:${dep.version}").name
 
   lazy val exclusions: Set[String] = dep.exclusions.map {
     case (org, name) =>


### PR DESCRIPTION
I ran into an issue where `coursier fetch --json-output-file ...` was failing with `java.lang.OutOfMemoryError`. This failure persisted even with heap sizes of 8 GB. Analysis of a heap dump showed that 66% of the heap consisted of duplicate strings. In my particular case, 9% of the heap was taken up by 149,403 copies of the string
`"org.scala-lang:scala-library:2.12.12"`, and another 9% was copies of the string `"org.scala-lang:scala-library:2.12.8"`. It appeared that most of these strings were held by the `reconciledVersionStr` and `requestedVersionStr` fields of `JsonElem`.

This PR adds `intern` calls to the allocations of `reconciledVersion`, `reconciledVersionStr`, and `requestedVersionStr` on `JsonElem`, causing these string allocations to be effectively deduplicated in to the JVM string pool. After this change, my same fetch command was able to complete running with a much smaller heap, `-Xmx256m`.

This PR also adds `lazy` to `reconciledVersionStr`, as the eager evaluation of `reconciledVersionStr` effectively forced `reconciledVersion` to be non-lazy as well.