### PR TITLE
Use `3` for Scala 3 Binary Version in Complete

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "tests/metadata"]
 	path = modules/tests/metadata
-	url = https://github.com/coursier/test-metadata.git
+	url = https://github.com/LaurenceWarne/test-metadata.git
+	branch = update-for-scala3-tests
 [submodule "modules/directories"]
 	path = modules/directories
 	url = https://github.com/coursier/directories-jvm.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,6 @@
 [submodule "tests/metadata"]
 	path = modules/tests/metadata
-	url = https://github.com/LaurenceWarne/test-metadata.git
-	branch = update-for-scala3-tests
+	url = https://github.com/coursier/test-metadata.git
 [submodule "modules/directories"]
 	path = modules/directories
 	url = https://github.com/coursier/directories-jvm.git

--- a/modules/coursier/shared/src/main/scala/coursier/complete/Complete.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/complete/Complete.scala
@@ -88,6 +88,7 @@ object Complete {
   def scalaBinaryVersion(scalaVersion: String): String =
     if (scalaVersion.contains("-M") || scalaVersion.contains("-RC"))
       scalaVersion
+    else if (scalaVersion.startsWith("3")) "3"
     else
       scalaVersion.split('.').take(2).mkString(".")
 


### PR DESCRIPTION
Hi, I saw that that `3.x` is used by `Complete` when setting the binary version based on the full version for (non `-M`, `-RC`) Scala 3 versions, this PR changes it so `3` is always used to be in line with https://docs.scala-lang.org/scala3/reference/language-versions/binary-compatibility.html (and so completion results are a lot better when just using `withScalaVersion` :slightly_smiling_face:).