### PR TITLE
install bash completion too

### DIFF
--- a/.github/scripts/coursier.rb.template
+++ b/.github/scripts/coursier.rb.template
@@ -6,7 +6,7 @@ class Coursier < Formula
   version "@LAUNCHER_VERSION@"
   sha256 "@LAUNCHER_SHA256@"
 
-  option "without-zsh-completions", "Disable zsh completion installation"
+  option "without-shell-completions", "Disable shell completion installation"
 
   # https://stackoverflow.com/questions/10665072/homebrew-formula-download-two-url-packages/26744954#26744954
   resource "jar-launcher" do
@@ -20,10 +20,9 @@ class Coursier < Formula
     bin.install "cs-x86_64-apple-darwin" => "cs"
     resource("jar-launcher").stage { bin.install "coursier" }
 
-    unless build.without? "zsh-completions"
+    unless build.without? "shell-completions"
       chmod 0555, bin/"coursier"
-      output = Utils.safe_popen_read("#{bin}/coursier", "completions", "zsh")
-      (zsh_completion/"_coursier").write output
+      generate_completions_from_executable(bin/"coursier", "completions", shells: [:bash, :zsh])
     end
   end
 


### PR DESCRIPTION
- Installs bash completion script in addition to zsh completion when installed by homebrew.
- Change option name to avoid the installation from "--without-zsh-completions" to "--without-shell-completions"