### PR TITLE
drop `jabba` and `cs-maven` from pre-installed JVM indexes

### DIFF
--- a/doc/docs/cli-java.md
+++ b/doc/docs/cli-java.md
@@ -68,9 +68,8 @@ openjdk:1.14.0
 
 ## JVM index
 
-Currently, the `java` and `java-home` commands rely on
-[the index](https://github.com/shyiko/jabba/blob/master/index.json)
-from the command-line tool [jabba](https://github.com/shyiko/jabba).
+By default `java` and `java-home` commands rely on
+[coursier index](https://github.com/coursier/jvm-index).
 This index is regularly updated, and lists a large variety of JVMs
 for Linux / macOS / Windows.
 
@@ -85,8 +84,12 @@ To list the JVM that can be installed from it, run
 $ cs java --available
 ```
 
-If needed, that index could be complemented or replaced by
-[an index of our own](https://github.com/coursier/jvm-index) at some point.
+It's also possible to specify another source for JVM index providing it to
+`--jvm-index` option. For example,
+
+```bash
+cs java --available --jvm-index https://url/of/your/index.json
+```
 
 ## Short JVM names
 

--- a/doc/docs/cli-overview.md
+++ b/doc/docs/cli-overview.md
@@ -150,7 +150,7 @@ OpenJDK 64-Bit Server VM AdoptOpenJDK (build 11.0.6+10, mixed mode)
 ```
 will automatically download the latest AdoptOpenJDK 11 (in the coursier cache), unpack it (in the [managed JVM directory](https://get-coursier.io/docs/cli-java.html#managed-jvm-directory)), and run it with `-version`.
 
-It uses the [index](https://github.com/shyiko/jabba/blob/8c8e6be29610a3d5ea505087a791e9a57f6e48a6/index.json) of jabba to know where to download JVM archives, and assumes AdoptOpenJDK if only a version is passed.
+It uses the [index](https://github.com/coursier/jvm-index) of to know where to download JVM archives, and assumes AdoptOpenJDK if only a version is passed.
 
 The `java-home` command prints the Java home of a JVM, like
 ```bash


### PR DESCRIPTION
Both have not been updated for a while therefore there is no need to keep extra code to support them. Moreover, dropping `jabba` fixes https://github.com/coursier/coursier/issues/2487 because downloaded index was modified by `JvmIndex.jabbaIndexGraalvmJava8Hack` function with no respect to index source - so not only `jabba` index was modified by it. For example, for coursier index
https://github.com/coursier/jvm-index it messed up graalvm versions badly and caused the lost of latest graalvm versions.