### PR TITLE
Fix bootstrap credentials retrieval when in environment variable

### DIFF
--- a/modules/bootstrap-launcher/src/it/scala/coursier/bootstrap/launcher/DownloadTests.scala
+++ b/modules/bootstrap-launcher/src/it/scala/coursier/bootstrap/launcher/DownloadTests.scala
@@ -64,7 +64,8 @@ object DownloadTests extends TestSuite {
         assert(remoteUrls.size == localUrls.size)
         assert(
           localUrls
-            .map(url => Paths.get(url.toURI).toFile).forall(_.exists)
+            .map(url => Paths.get(url.toURI).toFile)
+            .forall(_.exists())
         )
       }
     }
@@ -82,7 +83,8 @@ object DownloadTests extends TestSuite {
         assert(remoteUrls.size == localUrls.size)
         assert(
           localUrls
-            .map(url => Paths.get(url.toURI).toFile).forall(_.exists)
+            .map(url => Paths.get(url.toURI).toFile)
+            .forall(_.exists())
         )
       }
     }
@@ -105,7 +107,8 @@ object DownloadTests extends TestSuite {
         assert(remoteUrls.size == localUrls.size)
         assert(
           localUrls
-            .map(url => Paths.get(url.toURI).toFile).forall(_.exists)
+            .map(url => Paths.get(url.toURI).toFile)
+            .forall(_.exists())
         )
       }
     }

--- a/modules/bootstrap-launcher/src/it/scala/coursier/bootstrap/launcher/DownloadTests.scala
+++ b/modules/bootstrap-launcher/src/it/scala/coursier/bootstrap/launcher/DownloadTests.scala
@@ -64,8 +64,7 @@ object DownloadTests extends TestSuite {
         assert(remoteUrls.size == localUrls.size)
         assert(
           localUrls
-            .map(url => Paths.get(url.toURI).toFile)
-            .foldLeft(true)(_ && _.exists)
+            .map(url => Paths.get(url.toURI).toFile).forall(_.exists)
         )
       }
     }
@@ -83,13 +82,12 @@ object DownloadTests extends TestSuite {
         assert(remoteUrls.size == localUrls.size)
         assert(
           localUrls
-            .map(url => Paths.get(url.toURI).toFile)
-            .foldLeft(true)(_ && _.exists)
+            .map(url => Paths.get(url.toURI).toFile).forall(_.exists)
         )
       }
     }
 
-    test("priavte URL with configured credentials") {
+    test("private URL with configured credentials") {
       withTmpDir { dir =>
         val remoteUrls = Seq(
           new URL(s"$testRepository/com/abc/test/0.1/test-0.1.pom")
@@ -107,8 +105,7 @@ object DownloadTests extends TestSuite {
         assert(remoteUrls.size == localUrls.size)
         assert(
           localUrls
-            .map(url => Paths.get(url.toURI).toFile)
-            .foldLeft(true)(_ && _.exists)
+            .map(url => Paths.get(url.toURI).toFile).forall(_.exists)
         )
       }
     }

--- a/modules/bootstrap-launcher/src/main/java/coursier/bootstrap/launcher/credentials/Credentials.java
+++ b/modules/bootstrap-launcher/src/main/java/coursier/bootstrap/launcher/credentials/Credentials.java
@@ -39,7 +39,6 @@ public abstract class Credentials implements Serializable {
       return credentials;
     } else {
       return credentialPropOpt()
-        .filter(Credentials::isPropFile)
         .map(s -> {
           if (isPropFile(s)) {
             try {


### PR DESCRIPTION
Hello, 

I have tried to use `cs bootstrap` with an application published in a private Maven repository, with credentials defined in `COURSIER_CREDENTIALS`. 
Even if I am able to execute `cs fetch` on my dependency, the bootstrapped application has not been able to pull itself (401 from my Maven repo). 

```
$ cs bootstrap -r https://my-repo my-dep -o my-dep-bootstrap
Wrote {...} 

$ ./my-dep-bootstrap
Error while downloading {...}: Server returned HTTP response code: 401 for URL: {...}, ignoring it

```

By looking at `Download.java`, I have figured out that a misplaced filter was preventing `COURSIER_CREDENTIALS` content from being retrieved. This PR fixes it. 

Unfortunately, I don't know how to automatically test this change without a refactoring (`static` method using external files).
