### PR TITLE
drop jabba from pre-installed JVM indexes

### DIFF
--- a/doc/docs/cli-java.md
+++ b/doc/docs/cli-java.md
@@ -68,9 +68,8 @@ openjdk:1.14.0
 
 ## JVM index
 
-Currently, the `java` and `java-home` commands rely on
-[the index](https://github.com/shyiko/jabba/blob/master/index.json)
-from the command-line tool [jabba](https://github.com/shyiko/jabba).
+By default `java` and `java-home` commands rely on
+[coursier index](https://github.com/coursier/jvm-index).
 This index is regularly updated, and lists a large variety of JVMs
 for Linux / macOS / Windows.
 
@@ -85,8 +84,23 @@ To list the JVM that can be installed from it, run
 $ cs java --available
 ```
 
-If needed, that index could be complemented or replaced by
-[an index of our own](https://github.com/coursier/jvm-index) at some point.
+JVM index source could be changed providing `--jvm-index` option. Possible values are
+
+- `cs` (default)
+
+  Uses [coursier index](https://github.com/coursier/jvm-index)
+
+- `cs-maven`
+
+  Fetches index from [io.get-coursier:jvm-index](https://repo1.maven.org/maven2/io/get-coursier/jvm-index/) maven repository
+
+- arbitrary URL
+
+  It's also possible to specify arbitrary URL containing JVM index. For example,
+
+  ```bash
+  cs java --available --jvm-index https://url/of/your/index.json
+  ```
 
 ## Short JVM names
 

--- a/doc/docs/cli-java.md
+++ b/doc/docs/cli-java.md
@@ -68,8 +68,8 @@ openjdk:1.14.0
 
 ## JVM index
 
-By default `java` and `java-home` commands rely on
-[coursier index](https://github.com/coursier/jvm-index).
+By default, the `java` and `java-home` commands rely on
+the [coursier index](https://github.com/coursier/jvm-index).
 This index is regularly updated, and lists a large variety of JVMs
 for Linux / macOS / Windows.
 
@@ -84,7 +84,7 @@ To list the JVM that can be installed from it, run
 $ cs java --available
 ```
 
-JVM index source could be changed providing `--jvm-index` option. Possible values are
+The JVM index source can be changed by using the `--jvm-index` option. Possible values are
 
 - `cs` (default)
 
@@ -92,9 +92,9 @@ JVM index source could be changed providing `--jvm-index` option. Possible value
 
 - `cs-maven`
 
-  Fetches index from [io.get-coursier:jvm-index](https://repo1.maven.org/maven2/io/get-coursier/jvm-index/) maven repository
+  Fetches index from [io.get-coursier:jvm-index](https://repo1.maven.org/maven2/io/get-coursier/jvm-index/) Maven repository
 
-- arbitrary URL
+- an arbitrary URL
 
   It's also possible to specify arbitrary URL containing JVM index. For example,
 

--- a/doc/docs/cli-overview.md
+++ b/doc/docs/cli-overview.md
@@ -150,7 +150,7 @@ OpenJDK 64-Bit Server VM AdoptOpenJDK (build 11.0.6+10, mixed mode)
 ```
 will automatically download the latest AdoptOpenJDK 11 (in the coursier cache), unpack it (in the [managed JVM directory](https://get-coursier.io/docs/cli-java.html#managed-jvm-directory)), and run it with `-version`.
 
-It uses the [index](https://github.com/coursier/jvm-index) by default to know from where to download JVM archives, and assumes AdoptOpenJDK if only a version is passed.
+It uses the [index](https://github.com/coursier/jvm-index) by default to know where to download JVM archives from, and assumes AdoptOpenJDK if only a version is passed.
 
 The `java-home` command prints the Java home of a JVM, like
 ```bash

--- a/doc/docs/cli-overview.md
+++ b/doc/docs/cli-overview.md
@@ -150,7 +150,7 @@ OpenJDK 64-Bit Server VM AdoptOpenJDK (build 11.0.6+10, mixed mode)
 ```
 will automatically download the latest AdoptOpenJDK 11 (in the coursier cache), unpack it (in the [managed JVM directory](https://get-coursier.io/docs/cli-java.html#managed-jvm-directory)), and run it with `-version`.
 
-It uses the [index](https://github.com/shyiko/jabba/blob/8c8e6be29610a3d5ea505087a791e9a57f6e48a6/index.json) of jabba to know where to download JVM archives, and assumes AdoptOpenJDK if only a version is passed.
+It uses the [index](https://github.com/coursier/jvm-index) by default to know from where to download JVM archives, and assumes AdoptOpenJDK if only a version is passed.
 
 The `java-home` command prints the Java home of a JVM, like
 ```bash

--- a/modules/jvm/src/main/scala/coursier/jvm/JvmIndex.scala
+++ b/modules/jvm/src/main/scala/coursier/jvm/JvmIndex.scala
@@ -25,15 +25,12 @@ object JvmIndex {
     indexName match {
       case "cs"       => coursierIndexUrl
       case "cs-maven" => coursierIndexCoordinates
-      case "jabba"    => jabbaIndexUrl
       case other      => other
     }
 
   def defaultIndexUrl: String =
     coursierIndexUrl
 
-  def jabbaIndexUrl: String =
-    "https://github.com/shyiko/jabba/raw/master/index.json"
   def coursierIndexUrl: String =
     "https://github.com/coursier/jvm-index/raw/master/index.json"
   def coursierIndexCoordinates: String =
@@ -147,39 +144,13 @@ object JvmIndex {
         Task.fromEither(fromString(content))
     }
 
-  def jabbaIndexGraalvmJava8Hack(index: JvmIndex): JvmIndex =
-    index.withContent(
-      index.content.map {
-        case (os, m1) =>
-          os -> m1.map {
-            case (arch, m2) =>
-              arch -> m2.flatMap {
-                case (jdkName @ "jdk@graalvm", m3) =>
-                  val jdk8 = jdkName -> m3.map {
-                    case (version, url) =>
-                      version -> url.replace("-java11-", "-java8-")
-                  }
-                  val jdk11 = s"$jdkName-java11" -> m3.collect {
-                    case (version, url) if url.contains("-java8-") || url.contains("-java11-") =>
-                      version -> url.replace("-java8-", "-java11-")
-                  }
-                  Seq(jdk8, jdk11).filter(_._2.nonEmpty)
-                case (jdkName, m3) =>
-                  Seq(jdkName -> m3)
-              }
-          }
-      }
-    )
-
   def load(
     cache: Cache[Task]
   ): Task[JvmIndex] =
     load(cache, defaultIndexUrl)
-      .map(jabbaIndexGraalvmJava8Hack)
 
   def load(): Task[JvmIndex] =
     load(FileCache(), defaultIndexUrl)
-      .map(jabbaIndexGraalvmJava8Hack)
 
   lazy val currentOs: Either[String, String] =
     Option(System.getProperty("os.name")).map(_.toLowerCase(Locale.ROOT)) match {


### PR DESCRIPTION
jabba index has not been updated for a while therefore there is no need to keep extra code to support it. Moreover, dropping it fixes https://github.com/coursier/coursier/issues/2487 because downloaded index was modified by `JvmIndex.jabbaIndexGraalvmJava8Hack` function with no respect to index source - so not only `jabba` index was modified by it. For example, for coursier index
https://github.com/coursier/jvm-index it messed up graalvm versions badly and caused the lost of latest graalvm versions.