### PR TITLE
OOM while collecting transitive dependencies

### DIFF
--- a/modules/cli/src/main/scala/coursier/cli/util/JsonReport.scala
+++ b/modules/cli/src/main/scala/coursier/cli/util/JsonReport.scala
@@ -78,23 +78,34 @@ object JsonReport {
     private def collapseNode[A: Show](node: DependencyTree[A]): Eval[Chain[String]] =
       node.foldMapM(child => Eval.now(Chain.one(child.show)))
 
-    // Builds a map of flattened dependencies starting at this element
-    // The implementation makes use of Cofree[List, T] which is a foldable co-monad
-    // and because of that, we can collapse it at each of its nodes and aggregate the results
     private def transitiveOf[A: Eq: Show](
       elem: A,
       fetchChildren: A => Seq[A]
-    ): Eval[Map[A, Chain[String]]] = {
-      // Create the DepTree structure by unfolding it starting at the element given
-      val zipper                     = TreeZipper.of(elem, fetchChildren)
-      val depTree: DependencyTree[A] = Cofree.ana(zipper)(_.children, _.focus)
-
-      // Fold the tail of the root into a chain of dependencies
-      // and them map the root element to the dependencies
-      // Using `Eval` here to do the fold so we convert the recursive operation into a stack-safe loop
-      depTree.tail
-        .flatMap(_.foldMapM(collapseNode[A]))
-        .map(deps => Map(depTree.head -> deps))
+    ): Eval[Map[A, Set[String]]] = {
+      println()
+      val knownElems = mutable.HashMap[String, mutable.Set[String]]() 
+      def collectDeps[A: Eq: Show](
+        elem: A,
+        fetchChildren: A => Seq[A]
+      ): mutable.Set[String] = {
+        val key = elem.show
+        if(knownElems.contains(key)) {
+          return knownElems.get(key).orNull
+        } else {
+          val deps = mutable.HashSet[String]()
+          knownElems.put(key, deps)
+          for(child <- fetchChildren(elem)) {
+            deps.add(child.show)
+            val childDeps = collectDeps(child, fetchChildren)
+            for(dep <- childDeps) {
+              deps.add(dep)
+            }
+          }
+          return deps
+        }
+      }
+      val result = collectDeps(elem, fetchChildren).toSet[String]
+      return Eval.now(Map(elem -> result))
     }
 
     def flatten[A](


### PR DESCRIPTION
Hi,

I have faced an issue with coursier in my project. I tried to fetch our company's internal artifacts with the '--json-output-file` flag, but the coursier failed with OOM. Actually, the problem arose quite a long ago but giving it ~ 50Gb heap solved the issue (actually building JSON report took about 10 minutes with such settings, but it was acceptable), so I preferred to do nothing. Now the artifact tree has become ever more complex and this does not work anymore. 

Unfortunately, I can't provide a reproducible example because mentioned artifacts are part of our closed-source project and are available only in an internal repo.

I have made some investigation and have found that the issue is caused by building a JSON report, more specifically it is in calculating all transitive dependencies of each particular artifact. Imagine that you have artifact A which depends on artifacts B and C. And artifact B depends on artifact C too. In order to calculate all transitive dependencies of A the current algorithm first goes to B and tries to calculate all transitive dependencies of B, then it goes to C (because B depends on C) and does the same procedure. Then it goes to C (because A depends on C) and does the same procedure for C again instead of using the already calculated value. In the usual artifacts tree, it is not a problem because usually, you do not have a lot of complex dependencies with a lot of dependents. But in our project, we have, for example, some util artifact which has about ~100 non-unique dependencies, and almost any artifact in the project depends on util. Because of that, the current algorithm visited all ~100 utils' dependencies hundreds of thousands of times...

I'm not a scala developer and not good at functional programming (really, I have no idea what Cofree is and how it is supposed to work :) ), so I was not able to fix the issue without rewriting functional code to imperative style. Thus, I just replaced the current algorithm with plain old DFS and it fixed the issue (the JSON report now is built with the default memory setting for about 4 seconds). I do not expect my code to be merged into the master (I created PR just for highlighting the problematic code) because I believe there should be a much more elegant solution in a scala-way functional style. But I would appreciate it if you find time to fix the issue.

Thanks in advance!