### PR TITLE
Guard a `close()` in a finally clause

### DIFF
--- a/modules/cache/jvm/src/main/scala/coursier/cache/FileCache.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/FileCache.scala
@@ -458,7 +458,7 @@ object FileCache {
       is = new FileInputStream(localFile)
       FileUtil.withContent(is, new FileUtil.UpdateDigest(md))
     }
-    finally is.close()
+    finally if (is != null) is.close()
 
     md.digest()
   }


### PR DESCRIPTION
I observed this and would rather see the original exception:

```
java.lang.NullPointerException
 	at coursier.cache.FileCache$.computeDigest(FileCache.scala:461)
 	at coursier.cache.FileCache$.coursier$cache$FileCache$$persistedDigest(FileCache.scala:431)
 	at coursier.cache.FileCache.$anonfun$validateChecksum$4(FileCache.scala:132)
 	at scala.concurrent.Future$.$anonfun$apply$1(Future.scala:678)
 	at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:467)
 	at java.base@17.0.5/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
 	at java.base@17.0.5/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
 	at java.base@17.0.5/java.lang.Thread.run(Thread.java:833)
 	at com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:775)
 	at com.oracle.svm.core.posix.thread.PosixPlatformThreads.pthreadStartRoutine(PosixPlatformThreads.java:203)
```