### PR TITLE
Better handling of same JVM concurrent downloads

### DIFF
--- a/modules/cache/jvm/src/main/scala/coursier/cache/ArtifactError.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/ArtifactError.scala
@@ -146,6 +146,7 @@ object ArtifactError {
     "locked",
     file.toString
   )
+  @deprecated("Not thrown by coursier anymore", "2.1.0-RC2")
   final class ConcurrentDownload(val url: String) extends Recoverable(
     "concurrent download",
     url

--- a/modules/cache/jvm/src/main/scala/coursier/cache/CacheLocks.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/CacheLocks.scala
@@ -57,6 +57,8 @@ object CacheLocks {
           lock =
             try channel.tryLock()
             catch {
+              case _: OverlappingFileLockException =>
+                null
               case ex: IOException if ex.getMessage == "Resource deadlock avoided" =>
                 deadlockAvoided = true
                 Thread.sleep(200L)
@@ -76,10 +78,6 @@ object CacheLocks {
               channel = null
               Files.deleteIfExists(lockFile)
             }
-        }
-        catch {
-          case _: OverlappingFileLockException =>
-            ifLocked
         }
         finally if (lock != null)
             lock.release()

--- a/project/modules/shared.sc
+++ b/project/modules/shared.sc
@@ -37,7 +37,44 @@ lazy val buildVersion = {
   }
 }
 
-trait CoursierPublishModule extends PublishModule with JavaModule {
+trait PublishLocalNoFluff extends PublishModule {
+  def emptyZip = T {
+    import java.io._
+    import java.util.zip._
+    val dest = T.dest / "empty.zip"
+    val baos = new ByteArrayOutputStream
+    val zos  = new ZipOutputStream(baos)
+    zos.finish()
+    zos.close()
+    os.write(dest, baos.toByteArray)
+    PathRef(dest)
+  }
+  // adapted from https://github.com/com-lihaoyi/mill/blob/fea79f0515dda1def83500f0f49993e93338c3de/scalalib/src/PublishModule.scala#L70-L85
+  // writes empty zips as source and doc JARs
+  def publishLocalNoFluff(localIvyRepo: String = null): define.Command[PathRef] = T.command {
+
+    import mill.scalalib.publish.LocalIvyPublisher
+    val publisher = localIvyRepo match {
+      case null => LocalIvyPublisher
+      case repo =>
+        new LocalIvyPublisher(os.Path(repo.replace("{VERSION}", publishVersion()), os.pwd))
+    }
+
+    publisher.publish(
+      jar = jar().path,
+      sourcesJar = emptyZip().path,
+      docJar = emptyZip().path,
+      pom = pom().path,
+      ivy = ivy().path,
+      artifact = artifactMetadata(),
+      extras = extraPublish()
+    )
+
+    jar()
+  }
+}
+
+trait CoursierPublishModule extends PublishModule with PublishLocalNoFluff with JavaModule {
   import mill.scalalib.publish._
   def pomSettings = PomSettings(
     description = artifactName(),


### PR DESCRIPTION
This fixes the issues I'm getting while running locally the repro of https://github.com/com-lihaoyi/mill/pull/2112#issuecomment-1314435915.

Likely fixes https://github.com/coursier/coursier/issues/1753 (`concurrent download` errors are no more thrown)
Likely fixes https://github.com/coursier/coursier/issues/2022 too (`concurrent download` errors are no more thrown)

Should fix https://github.com/coursier/coursier/issues/1815 (this addresses a race condition, that was making some parallel downloads wipe files freshly written by others).