### PR TITLE
Add option to pass file with dependencies to fetch

### DIFF
--- a/doc/docs/cli-fetch.md
+++ b/doc/docs/cli-fetch.md
@@ -61,8 +61,8 @@ $ cs fetch --javadoc com.lihaoyi:ammonite_2.12.8:1.6.0
 
 ## File arguments
 
-Pass `--dependency-file <filename>` to read dependecies from file. 
-File content should a list of dependencies separated by a newline character.
+Pass `--dependency-file <filename>` to read dependencies from a file. 
+The file content should be a list of dependencies separated by a newline character.
 Example usage:
 ```bash
 $ cs fetch --dependency-file file_1 --dependency-file file_2
@@ -74,6 +74,10 @@ With `file_1` content:
 ```
 io.circe::circe-generic:0.12.3
 com.lihaoyi:ammonite_2.12.8:1.6.0
+```
+And `file_2`:
+```
+com.chuusai:shapeless_2.13:2.3.3
 ```
 
 ## Multiple classifiers

--- a/doc/docs/cli-fetch.md
+++ b/doc/docs/cli-fetch.md
@@ -59,6 +59,23 @@ $ cs fetch --javadoc com.lihaoyi:ammonite_2.12.8:1.6.0
 …
 ```
 
+## File arguments
+
+Pass `--dependency-file <filename>` to read dependecies from file. 
+File content should a list of dependencies separated by a newline character.
+Example usage:
+```bash
+$ cs fetch --dependency-file file_1 --dependency-file file_2
+/path/to/coursier/cache/v1/https/repo1.maven.org/maven2/io/circe/circe-generic_2.13/0.12.3/circe-generic_2.13-0.12.3.jar
+/path/to/coursier/cache/v1/https/repo1.maven.org/maven2/com/lihaoyi/ammonite_2.12.8/1.6.0/ammonite_2.12.8-1.6.0.jar
+…
+```
+With `file_1` content:
+```
+io.circe::circe-generic:0.12.3
+com.lihaoyi:ammonite_2.12.8:1.6.0
+```
+
 ## Multiple classifiers
 
 With both `--sources` and `--javadoc`, if you want to retain standard JARs along

--- a/doc/docs/cli-fetch.md
+++ b/doc/docs/cli-fetch.md
@@ -61,7 +61,7 @@ $ cs fetch --javadoc com.lihaoyi:ammonite_2.12.8:1.6.0
 
 ## File arguments
 
-Pass `--dependency-file <filename>` to read dependencies from a file. 
+Pass `--dependency-file <filename>` to read dependencies from a file.
 The file content should be a list of dependencies separated by a newline character.
 Example usage:
 ```bash

--- a/modules/cli/src/main/scala/coursier/cli/options/DependencyOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/DependencyOptions.scala
@@ -50,7 +50,8 @@ final case class DependencyOptions(
   @Group(OptionGroup.dependency)
   @Help("Path to file with dependencies. " +
     "Dependencies should be separated with newline character")
-    dependencyFiles: List[String] = Nil
+  @Short("f")
+    dependencyFile: List[String] = Nil
 
 )
 // format: on

--- a/modules/cli/src/main/scala/coursier/cli/options/DependencyOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/DependencyOptions.scala
@@ -45,7 +45,12 @@ final case class DependencyOptions(
   @Group(OptionGroup.dependency)
   @Help("Enable scala-native")
   @Short("S")
-    native: Boolean = false
+    native: Boolean = false,
+
+  @Group(OptionGroup.dependency)
+  @Help("Path to file with dependencies. " +
+    "Dependencies should be separated with newline character")
+    dependencyFiles: List[String] = Nil
 
 )
 // format: on

--- a/modules/cli/src/main/scala/coursier/cli/options/DependencyOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/DependencyOptions.scala
@@ -50,7 +50,6 @@ final case class DependencyOptions(
   @Group(OptionGroup.dependency)
   @Help("Path to file with dependencies. " +
     "Dependencies should be separated with newline character")
-  @Short("f")
     dependencyFile: List[String] = Nil
 
 )

--- a/modules/cli/src/main/scala/coursier/cli/params/DependencyParams.scala
+++ b/modules/cli/src/main/scala/coursier/cli/params/DependencyParams.scala
@@ -59,10 +59,10 @@ object DependencyParams {
       }
 
     val fromFilesDependenciesV: ValidatedNel[String, Seq[String]] =
-      if (options.dependencyFiles.isEmpty)
+      if (options.dependencyFile.isEmpty)
         Validated.validNel(Seq.empty)
       else {
-        val files = options.dependencyFiles
+        val files = options.dependencyFile
         val fromFileDependencies = files.flatMap { file =>
           val source = Source.fromFile(file)
           val lines =

--- a/modules/cli/src/main/scala/coursier/cli/resolve/Resolve.scala
+++ b/modules/cli/src/main/scala/coursier/cli/resolve/Resolve.scala
@@ -60,9 +60,10 @@ object Resolve extends CoursierCommand[ResolveOptions] {
 
     lift {
 
+      val fromFilesDependencies = params.dependency.fromFilesDependencies
       val (javaOrScalaDeps, urlDeps) = unlift {
         Dependencies.withExtraRepo(
-          args,
+          args ++ fromFilesDependencies,
           params.dependency.intransitiveDependencies
         )
       }

--- a/modules/cli/src/test/scala/coursier/cli/FetchTests.scala
+++ b/modules/cli/src/test/scala/coursier/cli/FetchTests.scala
@@ -84,6 +84,20 @@ object FetchTests extends TestSuite {
       assert(files.map(_._2.getName).toSet.equals(Set("junit-4.12.jar", "hamcrest-core-1.3.jar")))
     }
 
+    test("fetch dependencies from file") - withFile(
+      "junit:junit:4.12"
+    ) { (file, writer) =>
+      val dependencyOpt = DependencyOptions(dependencyFiles = List(file.getAbsolutePath))
+      val resolveOpt    = SharedResolveOptions(dependencyOptions = dependencyOpt)
+      val options       = FetchOptions(resolveOptions = resolveOpt)
+      val params        = paramsOrThrow(options)
+
+      val (_, _, _, files) = Fetch.task(params, pool, Seq.empty)
+        .unsafeRun()(ec)
+
+      assert(files.map(_._2.getName).toSet.equals(Set("junit-4.12.jar", "hamcrest-core-1.3.jar")))
+    }
+
     test("Underscore and source classifier should fetch default and source files") {
       val artifactOpt = ArtifactOptions(
         classifier = List("_"),

--- a/modules/cli/src/test/scala/coursier/cli/FetchTests.scala
+++ b/modules/cli/src/test/scala/coursier/cli/FetchTests.scala
@@ -87,7 +87,7 @@ object FetchTests extends TestSuite {
     test("fetch dependencies from file") - withFile(
       "junit:junit:4.12"
     ) { (file, writer) =>
-      val dependencyOpt = DependencyOptions(dependencyFiles = List(file.getAbsolutePath))
+      val dependencyOpt = DependencyOptions(dependencyFile = List(file.getAbsolutePath))
       val resolveOpt    = SharedResolveOptions(dependencyOptions = dependencyOpt)
       val options       = FetchOptions(resolveOptions = resolveOpt)
       val params        = paramsOrThrow(options)

--- a/modules/cli/src/test/scala/coursier/cli/FetchTests.scala
+++ b/modules/cli/src/test/scala/coursier/cli/FetchTests.scala
@@ -106,36 +106,23 @@ object FetchTests extends TestSuite {
       val options       = FetchOptions(resolveOptions = resolveOpt)
       val params        = paramsOrThrow(options)
 
-      val thrownException =
-        try {
-          Fetch.task(params, pool, Seq.empty).unsafeRun()(ec)
-          false
-        }
-        catch {
-          case _: ResolveException =>
-            true
-        }
-      assert(thrownException)
+      intercept[ResolveException] {
+        Fetch.task(params, pool, Seq.empty).unsafeRun()(ec)
+      }
     }
 
     test("fail fetching dependencies from non-existing file") {
-      val path          = "path/to/non-existing-file"
+      val path          = "non-existing-file-path"
       val dependencyOpt = DependencyOptions(dependencyFile = List(path))
       val resolveOpt    = SharedResolveOptions(dependencyOptions = dependencyOpt)
       val options       = FetchOptions(resolveOptions = resolveOpt)
 
       val errorMessage =
-        "Got errors:" + System.lineSeparator() + "  " + "Cannot read dependencies from files:" + System.lineSeparator() + "  " + path + " (No such file or directory)"
-      val thrownException =
-        try {
-          paramsOrThrow(options)
-          false
-        }
-        catch {
-          case e: Throwable =>
-            e.getMessage().trim() == errorMessage
-        }
-      assert(thrownException)
+        "Got errors:" + System.lineSeparator() + "  " + "Cannot read dependencies from files:" + System.lineSeparator() + "  " + path
+      val thrownException = intercept[RuntimeException] {
+        paramsOrThrow(options)
+      }
+      assert(thrownException.getMessage().startsWith(errorMessage))
     }
 
     test("Underscore and source classifier should fetch default and source files") {

--- a/modules/cli/src/test/scala/coursier/cli/FetchTests.scala
+++ b/modules/cli/src/test/scala/coursier/cli/FetchTests.scala
@@ -117,12 +117,11 @@ object FetchTests extends TestSuite {
       val resolveOpt    = SharedResolveOptions(dependencyOptions = dependencyOpt)
       val options       = FetchOptions(resolveOptions = resolveOpt)
 
-      val errorMessage =
-        "Got errors:" + System.lineSeparator() + "  " + "Cannot read dependencies from files:" + System.lineSeparator() + "  " + path
-      val thrownException = intercept[RuntimeException] {
+      val expectedErrorMessage = s"Error reading dependencies from $path"
+      val thrownException = intercept[Exception] {
         paramsOrThrow(options)
       }
-      assert(thrownException.getMessage().startsWith(errorMessage))
+      assert(thrownException.getMessage == expectedErrorMessage)
     }
 
     test("Underscore and source classifier should fetch default and source files") {


### PR DESCRIPTION
Connected to https://github.com/coursier/coursier/issues/2443

Allows to pass file based parameters to `resolve` and `fetch`.
Usage: 
`cs resolve --dependency-file <file>` or  with multiple files `cs resolve --dependency-file <file1>  --dependency-file <file2> `