### PR TITLE
Fix Metals import instructions

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -45,6 +45,7 @@ $ ./mill -w __.compile
 Using the default import functionality of Metals is _not_ recommended. Instead,
 generate bloop configuration files with
 ```text
+$ ./mill clean
 $ ./mill mill.contrib.bloop.Bloop/install
 ```
 


### PR DESCRIPTION
For some reason, if I don't run `clean` before `mill.contrib.bloop.Bloop/install`, Mill only generates five Bloop configuration files, instead of 77. @julienrf was also able to reproduce this.

For now I think it is safer to ask people to always run `./mill clean` before `./mill mill.contrib.bloop.Bloop/install`