### PR TITLE
Resolve dependencies with a Scala 3 partial version

### DIFF
--- a/modules/cli-tests/src/main/scala/coursier/clitests/FetchTests.scala
+++ b/modules/cli-tests/src/main/scala/coursier/clitests/FetchTests.scala
@@ -98,8 +98,8 @@ abstract class FetchTests extends TestSuite {
         os.proc(launcher, "fetch", "org.scalacheck::scalacheck:1.16.0", "--scala-version", "3")
           .call()
       assert(res0.exitCode == 0)
-      val output = res0.out.text()
-      val scalacheckPath = Seq("org", "scalacheck", "scalacheck_3", "1.16.0").mkString(`/`)
+      val output           = res0.out.text()
+      val scalacheckPath   = Seq("org", "scalacheck", "scalacheck_3", "1.16.0").mkString(`/`)
       val scalaLibraryPath = Seq("org", "scala-lang", "scala3-library_3").mkString(`/`)
       assert(output.contains(scalacheckPath) && output.contains(scalaLibraryPath))
     }
@@ -109,8 +109,8 @@ abstract class FetchTests extends TestSuite {
         os.proc(launcher, "fetch", "org.scalacheck::scalacheck:1.16.0", "--scala-version", "3.2")
           .call()
       assert(res0.exitCode == 0)
-      val output = res0.out.text()
-      val scalacheckPath = Seq("org", "scalacheck", "scalacheck_3", "1.16.0").mkString(`/`)
+      val output           = res0.out.text()
+      val scalacheckPath   = Seq("org", "scalacheck", "scalacheck_3", "1.16.0").mkString(`/`)
       val scalaLibraryPath = Seq("org", "scala-lang", "scala3-library_3", "3.2").mkString(`/`)
       assert(output.contains(scalacheckPath) && output.contains(scalaLibraryPath))
     }
@@ -120,8 +120,8 @@ abstract class FetchTests extends TestSuite {
         os.proc(launcher, "fetch", "org.scalacheck::scalacheck:1.16.0", "--scala-version", "2")
           .call()
       assert(res0.exitCode == 0)
-      val output = res0.out.text()
-      val scalacheckPath = Seq("org", "scalacheck", "scalacheck_2.13", "1.16.0").mkString(`/`)
+      val output           = res0.out.text()
+      val scalacheckPath   = Seq("org", "scalacheck", "scalacheck_2.13", "1.16.0").mkString(`/`)
       val scalaLibraryPath = Seq("org", "scala-lang", "scala-library", "2.13.").mkString(`/`)
       assert(output.contains(scalacheckPath) && output.contains(scalaLibraryPath))
     }

--- a/modules/cli-tests/src/main/scala/coursier/clitests/FetchTests.scala
+++ b/modules/cli-tests/src/main/scala/coursier/clitests/FetchTests.scala
@@ -7,6 +7,8 @@ abstract class FetchTests extends TestSuite {
   def launcher: String
 
   val tests = Tests {
+    val `/` = java.io.File.separator
+
     test("mirror") {
       TestUtil.withTempDir { tmpDir0 =>
         val tmpDir = os.Path(tmpDir0, os.pwd)
@@ -89,6 +91,39 @@ abstract class FetchTests extends TestSuite {
           os.rel / "https" / "maven-central.storage-download.googleapis.com" / "maven2"
         assert(jars1.forall(_.startsWith(gcsPrefix)))
       }
+    }
+
+    test("Scala 3 partial version") {
+      val res0 =
+        os.proc(launcher, "fetch", "org.scalacheck::scalacheck:1.16.0", "--scala-version", "3")
+          .call()
+      assert(res0.exitCode == 0)
+      val output = res0.out.text()
+      val scalacheckPath = Seq("org", "scalacheck", "scalacheck_3", "1.16.0").mkString(`/`)
+      val scalaLibraryPath = Seq("org", "scala-lang", "scala3-library_3").mkString(`/`)
+      assert(output.contains(scalacheckPath) && output.contains(scalaLibraryPath))
+    }
+
+    test("Scala 3 partial version with two numbers") {
+      val res0 =
+        os.proc(launcher, "fetch", "org.scalacheck::scalacheck:1.16.0", "--scala-version", "3.2")
+          .call()
+      assert(res0.exitCode == 0)
+      val output = res0.out.text()
+      val scalacheckPath = Seq("org", "scalacheck", "scalacheck_3", "1.16.0").mkString(`/`)
+      val scalaLibraryPath = Seq("org", "scala-lang", "scala3-library_3", "3.2").mkString(`/`)
+      assert(output.contains(scalacheckPath) && output.contains(scalaLibraryPath))
+    }
+
+    test("Scala 2 partial version with one number") {
+      val res0 =
+        os.proc(launcher, "fetch", "org.scalacheck::scalacheck:1.16.0", "--scala-version", "2")
+          .call()
+      assert(res0.exitCode == 0)
+      val output = res0.out.text()
+      val scalacheckPath = Seq("org", "scalacheck", "scalacheck_2.13", "1.16.0").mkString(`/`)
+      val scalaLibraryPath = Seq("org", "scala-lang", "scala-library", "2.13.").mkString(`/`)
+      assert(output.contains(scalacheckPath) && output.contains(scalaLibraryPath))
     }
   }
 }

--- a/modules/cli/src/main/scala/coursier/cli/resolve/Resolve.scala
+++ b/modules/cli/src/main/scala/coursier/cli/resolve/Resolve.scala
@@ -80,7 +80,8 @@ object Resolve extends CoursierCommand[ResolveOptions] {
           .withRepositories(params.repositories.repositories)
           .withScalaVersionOpt(
             params.resolution.scalaVersionOpt.map { s =>
-              if (s.count(_ == '.') == 1 && s.forall(c => c.isDigit || c == '.')) s + "+"
+              // add a "+" to partial Scala version numbers such as "2.13", "2.12", "3"
+              if (s.count(_ == '.') < 2 && s.forall(c => c.isDigit || c == '.')) s + "+"
               else s
             }
           )

--- a/modules/coursier/shared/src/main/scala/coursier/Resolve.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/Resolve.scala
@@ -247,8 +247,8 @@ object Resolve extends PlatformResolve {
       if (params.doForceScalaVersion)
         if (params.selectedScalaVersion.startsWith("3"))
           Seq(
-            Module(scalaOrg, ModuleName("scala3-library"))  -> params.selectedScalaVersion,
-            Module(scalaOrg, ModuleName("scala3-compiler")) -> params.selectedScalaVersion
+            Module(scalaOrg, ModuleName("scala3-library_3"))  -> params.selectedScalaVersion,
+            Module(scalaOrg, ModuleName("scala3-compiler_3")) -> params.selectedScalaVersion
           )
         else
           Seq(

--- a/modules/coursier/shared/src/main/scala/coursier/parse/JavaOrScalaModule.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/parse/JavaOrScalaModule.scala
@@ -27,7 +27,18 @@ object JavaOrScalaModule {
 
   def scalaBinaryVersion(scalaVersion: String): String =
     // Directly inspired from https://github.com/sbt/librarymanagement/blob/5ef0af2486d19cc237684000ef34c99191b88dfd/core/src/main/scala/sbt/internal/librarymanagement/cross/CrossVersionUtil.scala#L87
-    if (scalaVersion.startsWith("3"))
+    if (scalaVersion.startsWith("2."))
+      scalaVersion match {
+        case ReleaseV(maj, min, _) =>
+          s"$maj.$min"
+        case BinCompatV(maj, min, _, _, _) =>
+          s"$maj.$min"
+        case NonReleaseV_1(maj, min, patch, _) if patch.toLong > 0 =>
+          s"$maj.$min"
+        case _ =>
+          scalaVersion
+      }
+    else
       scalaVersion match {
         case ReleaseV(maj, _, _) =>
           maj
@@ -36,17 +47,6 @@ object JavaOrScalaModule {
         case BinCompatV(maj, min, patch, stageOrNull, _) =>
           val stage = if (stageOrNull != null) stageOrNull else ""
           scalaBinaryVersion(s"$maj.$min.$patch$stage")
-        case _ =>
-          scalaVersion
-      }
-    else
-      scalaVersion match {
-        case ReleaseV(maj, min, _) =>
-          s"$maj.$min"
-        case BinCompatV(maj, min, _, _, _) =>
-          s"$maj.$min"
-        case NonReleaseV_1(maj, min, patch, _) if patch.toLong > 0 =>
-          s"$maj.$min"
         case _ =>
           scalaVersion
       }

--- a/modules/coursier/shared/src/main/scala/coursier/parse/JavaOrScalaModule.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/parse/JavaOrScalaModule.scala
@@ -27,7 +27,7 @@ object JavaOrScalaModule {
 
   def scalaBinaryVersion(scalaVersion: String): String =
     // Directly inspired from https://github.com/sbt/librarymanagement/blob/5ef0af2486d19cc237684000ef34c99191b88dfd/core/src/main/scala/sbt/internal/librarymanagement/cross/CrossVersionUtil.scala#L87
-    if (scalaVersion.startsWith("3."))
+    if (scalaVersion.startsWith("3"))
       scalaVersion match {
         case ReleaseV(maj, _, _) =>
           maj

--- a/modules/install/src/main/scala/coursier/install/AppDescriptor.scala
+++ b/modules/install/src/main/scala/coursier/install/AppDescriptor.scala
@@ -458,7 +458,9 @@ object AppDescriptor {
     }
 
     val availableScalaVersions =
-      listVersions(cache, repositories, mod"org.scala-lang:scala-library")
+      listVersions(cache, repositories, mod"org.scala-lang:scala-library") ++
+        listVersions(cache, repositories, mod"org.scala-lang:scala3-library_3")
+          .filterNot(_.endsWith("NIGHTLY")) // Nightlies cannot be used as a "binary" version
 
     if (verbosity >= 2) {
       System.err.println(s"Found ${availableScalaVersions.size} scala versions:")


### PR DESCRIPTION
Fixes #2407

- Support partial versions such as "3" (previously, you had to write at least two numbers, as in "2.13")
- Fix module name of forced Scala modules (scala3-library and scala3-compiler). This also fixes a bug in "cs fetch --scala-version 3.2.1 '...'" not forcing the Scala 3 version in scala3-library)
- Look up Scala 3 versions (previously, only Scala 2 versions were looked up), and default to Scala 3 if the module has been published for Scala 3.