### PR TITLE
bugfix: Generate native launcher for linux on the previous ubuntu image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        OS: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        OS: ["ubuntu-20.04", "windows-latest", "macos-latest"]
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Previously, we would generate native image on ubuntu 22, which would cause issues for users of older linux distros. Now, we generate them the same way we did previously on ubuntu 20.

Fixes https://github.com/coursier/coursier/issues/2624