### PR TITLE
Fix instructions to install the native launcher on Linux

### DIFF
--- a/doc/docs/cli-installation.md
+++ b/doc/docs/cli-installation.md
@@ -39,6 +39,9 @@ Currently, we support the following architectures: x86-64 and ARM64.
 On macOS, download and run the coursier installer with
 
 ```bash
+# On Apple M1:
+$ curl -fL https://github.com/VirtusLab/coursier-m1/releases/latest/download/cs-aarch64-apple-darwin.gz | gzip -d > cs
+# Otherwise:
 $ curl -fL https://github.com/coursier/launchers/raw/master/cs-x86_64-apple-darwin.gz | gzip -d > cs
 $ chmod +x cs
 $ ./cs setup

--- a/doc/docs/cli-installation.md
+++ b/doc/docs/cli-installation.md
@@ -27,10 +27,12 @@ After the setup, you can [start using Scala](https://docs.scala-lang.org/scala3/
 On Linux, download and run the coursier installer with
 
 ```bash
-$ curl -fL https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz | gzip -d > cs
+$ curl -fL "https://github.com/coursier/launchers/raw/master/cs-$(uname -m)-pc-linux.gz" | gzip -d > cs
 $ chmod +x cs
 $ ./cs setup
 ```
+
+Currently, we support the following architectures: x86-64 and ARM64.
 
 ### macOS
 


### PR DESCRIPTION
The current instructions don’t work on other architectures than x86.

We resolve the host architecture with `uname -m`.