### PR TITLE
chore: bump default graalvm version

### DIFF
--- a/modules/cli/src/main/scala/coursier/cli/install/SharedInstallOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/install/SharedInstallOptions.scala
@@ -45,5 +45,5 @@ final case class SharedInstallOptions(
 
 object SharedInstallOptions {
   def defaultGraalvmVersion: Option[String] =
-    Some("19.3")
+    Some("22.1")
 }


### PR DESCRIPTION
It seems that there are situations where the default still pops up,
which seems to cause some issues. For example today I saw someone
mention seeing this issue:

```
Exception in thread "main" coursier.jvm.JvmCache$JvmNotFoundInIndex: JVM graalvm:19.3 not found in index: No graalvm version matching '19.3' found
    at coursier.jvm.JvmCache.$anonfun$getIfInstalled$1(JvmCache.scala:35)
    at coursier.jvm.JvmCache.$anonfun$getIfInstalled$1$adapted(JvmCache.scala:34)
    at coursier.util.Task$.$anonfun$flatMap$extension$1(Task.scala:14)
    at coursier.util.Task$.$anonfun$flatMap$extension$1$adapted(Task.scala:14)
    at coursier.util.Task$.wrap(Task.scala:82)
    at coursier.util.Task$.$anonfun$flatMap$2(Task.scala:14)
    at scala.concurrent.Future.$anonfun$flatMap$1(Future.scala:307)
    at scala.concurrent.impl.Promise.$anonfun$transformWith$1(Promise.scala:41)
    at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
    at java.lang.Thread.run(Thread.java:833)
    at com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:704)
    at
```

I think it might be a good idea to default to a newer version that
aligns with the version being used in coursier.
