### PR TITLE
Fallback to JVM when not found native launcher for install

### DIFF
--- a/modules/install/src/test/scala/coursier/install/InstallDirTests.scala
+++ b/modules/install/src/test/scala/coursier/install/InstallDirTests.scala
@@ -12,27 +12,22 @@ import utest._
 object InstallDirTests extends TestSuite {
 
   val tests = Tests {
-    test("pass the GraalVM version to launcher params") {
+    test("fallback to JVM when pass the GraalVM params") { // https://github.com/coursier/coursier/pull/2652
 
-      val version = "X.Y.Z"
-
-      val installDir = InstallDir()
-        .withGraalvmParamsOpt(Some(GraalvmParams(Some(version), Nil)))
-
-      val params = installDir.params(
+      val mainClass = "main.class"
+      val params = InstallDir().params(
         AppDescriptor().withLauncherType(LauncherType.GraalvmNativeImage),
         AppArtifacts(),
         Nil,
-        "main.class",
-        Paths.get("/foo")
+        mainClass
       )
 
-      val nativeParams = params match {
-        case n: Parameters.NativeImage => n
-        case _                         => sys.error(s"Unrecognized parameters type: $params")
+      val bootstrapParams = params match {
+        case b: Parameters.Bootstrap => b
+        case _                       => sys.error(s"Unrecognized parameters type: $params")
       }
 
-      assert(nativeParams.graalvmVersion == Some(version))
+      assert(bootstrapParams.mainClass == mainClass)
     }
 
     test("assume SSL handshake exceptions are not found errors") {


### PR DESCRIPTION
It should fix issue described in https://github.com/coursier/coursier/pull/2649#issue-1517791024. That on `arm64`, this error appears: 
```
Exception in thread "main" coursier.jvm.JvmCache$JvmNotFoundInIndex: JVM graalvm:19.3 not found in index: No graalvm version matching '19.3' found
    at coursier.jvm.JvmCache.$anonfun$getIfInstalled$1(JvmCache.scala:35)
    at coursier.jvm.JvmCache.$anonfun$getIfInstalled$1$adapted(JvmCache.scala:34)
    at coursier.util.Task$.$anonfun$flatMap$extension$1(Task.scala:14)
    at coursier.util.Task$.$anonfun$flatMap$extension$1$adapted(Task.scala:14)
    at coursier.util.Task$.wrap(Task.scala:82)
    at coursier.util.Task$.$anonfun$flatMap$2(Task.scala:14)
    at scala.concurrent.Future.$anonfun$flatMap$1(Future.scala:307)
    at scala.concurrent.impl.Promise.$anonfun$transformWith$1(Promise.scala:41)
    at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
    at java.lang.Thread.run(Thread.java:833)
    at com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:704)
    at
```

This PR change, that when the `install` command doesn't find a native launcher for a specific architecture, it falls back to the JVM launcher