### PR TITLE
Always build Linux binaries from the controlled Docker image if we are in the CI

### DIFF
--- a/project/launchers.sc
+++ b/project/launchers.sc
@@ -99,7 +99,7 @@ trait Launchers extends CsModule {
   private val arch = sys.props.getOrElse("os.arch", "").toLowerCase(java.util.Locale.ROOT)
   private def isCI = System.getenv("CI") != null
   def nativeImage =
-    if (Properties.isLinux && arch == "x86_64" && isCI)
+    if (Properties.isLinux && isCI)
       `linux-docker-image`.nativeImage
     else
       `base-image`.nativeImage


### PR DESCRIPTION
We used to switch to the Docker environment in case the host environment’s architecture was `x86_64`, but `ubuntu:latest` is currently `amd64`. Now we always use the Docker environment to build the Linux launchers’ binaries when we are in the CI to make sure we don’t depend on the current state of the `ubuntu` image provided by GitHub.