### PR TITLE
Improve output of update command for non-installed applications

### DIFF
--- a/modules/install/src/test/scala/coursier/install/InstallTests.scala
+++ b/modules/install/src/test/scala/coursier/install/InstallTests.scala
@@ -432,6 +432,27 @@ object InstallTests extends TestSuite {
       test("windows") - run("windows", "x86_64")
     }
 
+    test("try updating a non-installed app") {
+      def run(os: String, arch: String) = withTempDir { tmpDir =>
+        val installDir0 = installDir(tmpDir, os, arch)
+          .withVerbosity(1)
+
+        val result =
+          installDir0.maybeUpdate(
+            "dummy-app-id",
+            src => sys.error("illegal: that code should not be reached")
+          ).attempt.unsafeRun()(cache.ec)
+
+        assert(
+          result.contains(Some(false))
+        ) // TODO Check the output contains "Cannot find installed application 'dummy-app-id'..."
+      }
+
+      test("linux") - run("linux", "x86_64")
+      test("mac") - run("mac", "x86_64")
+      test("windows") - run("windows", "x86_64")
+    }
+
     test("install a prebuilt launcher") {
       def run(os: String, arch: String) = withTempDir { tmpDir =>
 


### PR DESCRIPTION
Tested locally:

~~~ text
$ ./mill cli.run update dummy-app-id
[504/504] cli.run
Cannot find installed application 'dummy-app-id' (installation directory is /home/julien/.local/share/coursier/bin).
Try running 'cs install dummy-app-id'.
~~~

Fixes #2661