### PR TITLE
Run CI jobs against Java 8 and 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           - JDK: "8"
             SCALA_VERSION: "2.13.6"
             OS: "ubuntu-latest"
-          - JDK: "11"
+          - JDK: "17"
             SCALA_VERSION: "2.12.17"
             OS: "ubuntu-latest"
     steps:


### PR DESCRIPTION
Rather than Java 8 and 11