### PR TITLE
fix: fix fish config location when XDG_CONFIG_HOME is used

### DIFF
--- a/modules/env/src/main/scala/coursier/env/ProfileUpdater.scala
+++ b/modules/env/src/main/scala/coursier/env/ProfileUpdater.scala
@@ -20,9 +20,8 @@ import java.nio.file.FileSystemException
       case Some(Shell.Fish) =>
         val fishConfig = getEnv.flatMap(_("XDG_CONFIG_HOME"))
           .map(Paths.get(_))
-          .orElse(home)
-          .toSeq
-          .map(_.resolve(".config/fish/config.fish"))
+          .map(_.resolve("fish/config.fish"))
+          .fold(home.map(_.resolve(".config/fish/config.fish")).toSeq)(Seq(_))
 
         fishConfig
 


### PR DESCRIPTION
This was previoulsy looking in `.config/.config/fish/config.fish`