### PR TITLE
fix for #2885 - output correct JAVA env setters in Windows bash sessions

### DIFF
--- a/.github/scripts/generate-os-packages.sh
+++ b/.github/scripts/generate-os-packages.sh
@@ -17,7 +17,7 @@ launcher() {
   local launcherMillCommand="cliNativeImageLauncher"
   local launcherName
 
-  if [[ "$OS" == "Windows_NT" ]]; then
+  if [[ "${OS-}" == "Windows_NT" ]]; then
     launcherName="cs.exe"
   else
     launcherName="cs"

--- a/.github/scripts/generate-os-packages.sh
+++ b/.github/scripts/generate-os-packages.sh
@@ -6,7 +6,7 @@ ARCHITECTURE=$(uname -m)
 ARTIFACTS_DIR="artifacts/"
 mkdir -p "$ARTIFACTS_DIR"
 
-if [[ "$OSTYPE" == "msys" ]]; then
+if [[ -z "$OSTYPE" ]]; then
   mill="./mill.bat"
 else
   mill="./mill"
@@ -17,7 +17,7 @@ launcher() {
   local launcherMillCommand="cliNativeImageLauncher"
   local launcherName
 
-  if [[ "$OSTYPE" == "msys" ]]; then
+  if [[ "$OS" == "Windows_NT" ]]; then
     launcherName="cs.exe"
   else
     launcherName="cs"

--- a/modules/cli/src/main/scala/coursier/cli/jvm/Java.scala
+++ b/modules/cli/src/main/scala/coursier/cli/jvm/Java.scala
@@ -140,20 +140,22 @@ object Java extends CoursierCommand[JavaOptions] {
         sys.exit(1)
       }
 
+      def windowsShell = Option(System.getenv("OSTYPE")).getOrElse("")
+
       if (params.env.env) {
         val script =
-          if (params.env.windowsScript)
+          if (params.env.windowsScript && windowsShell.isEmpty)
             coursier.jvm.JavaHome.finalBatScript(envUpdate)
           else
             ShellUtil.shell() match {
               case Some(Shell.Fish) => coursier.jvm.JavaHome.finalFishScript(envUpdate)
-              case _                => coursier.jvm.JavaHome.finalBashScript(envUpdate)
+              case _                => coursier.jvm.JavaHome.finalBashScript(envUpdate).replace('\\', '/')
             }
         print(script)
       }
       else if (params.env.disableEnv) {
         val script =
-          if (params.env.windowsScript)
+          if (params.env.windowsScript && windowsShell.isEmpty)
             coursier.jvm.JavaHome.disableBatScript()
           else
             ShellUtil.shell() match {

--- a/modules/cli/src/main/scala/coursier/cli/jvm/Java.scala
+++ b/modules/cli/src/main/scala/coursier/cli/jvm/Java.scala
@@ -140,22 +140,22 @@ object Java extends CoursierCommand[JavaOptions] {
         sys.exit(1)
       }
 
-      def windowsShell = Option(System.getenv("OSTYPE")).getOrElse("")
-
       if (params.env.env) {
         val script =
-          if (params.env.windowsScript && windowsShell.isEmpty)
+          if (params.env.windowsScript)
             coursier.jvm.JavaHome.finalBatScript(envUpdate)
+          else if (params.env.windowsPosixScript)
+            coursier.jvm.JavaHome.finalBashScript(envUpdate).replace('\\', '/')
           else
             ShellUtil.shell() match {
               case Some(Shell.Fish) => coursier.jvm.JavaHome.finalFishScript(envUpdate)
-              case _                => coursier.jvm.JavaHome.finalBashScript(envUpdate).replace('\\', '/')
+              case _                => coursier.jvm.JavaHome.finalBashScript(envUpdate)
             }
         print(script)
       }
       else if (params.env.disableEnv) {
         val script =
-          if (params.env.windowsScript && windowsShell.isEmpty)
+          if (params.env.windowsScript)
             coursier.jvm.JavaHome.disableBatScript()
           else
             ShellUtil.shell() match {

--- a/modules/cli/src/main/scala/coursier/cli/jvm/JavaHome.scala
+++ b/modules/cli/src/main/scala/coursier/cli/jvm/JavaHome.scala
@@ -44,20 +44,19 @@ object JavaHome extends CoursierCommand[JavaHomeOptions] {
     }
 
     lazy val envUpdate = javaHome.environmentFor(isSystem, home)
-
-    def windowsShell = Option(System.getenv("OSTYPE")).getOrElse("")
-
     if (params.env.env) {
       val script =
-        if (params.env.windowsScript && windowsShell.isEmpty)
+        if (params.env.windowsScript)
           coursier.jvm.JavaHome.finalBatScript(envUpdate)
-        else
+        else if (params.env.windowsPosixScript)
           coursier.jvm.JavaHome.finalBashScript(envUpdate).replace('\\', '/')
+        else
+          coursier.jvm.JavaHome.finalBashScript(envUpdate)
       print(script)
     }
     else if (params.env.disableEnv) {
       val script =
-        if (params.env.windowsScript && windowsShell.isEmpty)
+        if (params.env.windowsScript)
           coursier.jvm.JavaHome.disableBatScript()
         else
           coursier.jvm.JavaHome.disableBashScript()

--- a/modules/cli/src/main/scala/coursier/cli/jvm/JavaHome.scala
+++ b/modules/cli/src/main/scala/coursier/cli/jvm/JavaHome.scala
@@ -44,17 +44,20 @@ object JavaHome extends CoursierCommand[JavaHomeOptions] {
     }
 
     lazy val envUpdate = javaHome.environmentFor(isSystem, home)
+
+    def windowsShell = Option(System.getenv("OSTYPE")).getOrElse("")
+
     if (params.env.env) {
       val script =
-        if (params.env.windowsScript)
+        if (params.env.windowsScript && windowsShell.isEmpty)
           coursier.jvm.JavaHome.finalBatScript(envUpdate)
         else
-          coursier.jvm.JavaHome.finalBashScript(envUpdate)
+          coursier.jvm.JavaHome.finalBashScript(envUpdate).replace('\\', '/')
       print(script)
     }
     else if (params.env.disableEnv) {
       val script =
-        if (params.env.windowsScript)
+        if (params.env.windowsScript && windowsShell.isEmpty)
           coursier.jvm.JavaHome.disableBatScript()
         else
           coursier.jvm.JavaHome.disableBashScript()

--- a/modules/cli/src/main/scala/coursier/cli/options/EnvOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/EnvOptions.scala
@@ -18,7 +18,11 @@ final case class EnvOptions(
 
   @Group(OptionGroup.scripting)
   @Hidden
-    windowsScript: Boolean = Properties.isWin,
+    windowsScript: Option[Boolean] = None,
+
+  @Group(OptionGroup.scripting)
+  @Hidden
+    windowsPosixScript: Option[Boolean] = None,
 
   @Group(OptionGroup.scripting)
   @HelpMessage("Sets the default JVM to be used")


### PR DESCRIPTION
This implements the changes required for using `cs.exe` to set java environment variables in bash scripts, as described in #2885.

When running `cs java --env` and similar commands from a `bash` session, this PR produces the output format for shell environments.   Currently, in `Windows`, the output is in `batch` file format, preventing shell scripts from using `cs.exe` to set `JAVA_HOME` and `PATH`.

In `Windows`, if env var `OSTYPE` is set, `posix` shell format is assumed, and `batch file` format otherwise.  So it will be possible to use the `.bat` file (e.g., `mill.bat`) if `OSTYPE` is unset and the batch file is made executable.   Running from a `CMD.EXE` session is not affected.

The following `Windows MINGW64 bash` sessions show the new and old format:
```bash
user@d5 MINGW64 ~/workspace/scala-cli
$ cs java --jvm 11 --env
export CS_FORMER_JAVA_HOME="$JAVA_HOME"
export JAVA_HOME="C:/Users/user/AppData/Local/Coursier/cache/arc/https/github.com/adoptium/temurin17-binaries/releases/download/jdk-17%252B35/OpenJDK17-jdk_x64_windows_hotspot_17_35.zip/jdk-17+35"
export PATH="C:/Users/user/AppData/Local/Coursier/cache/arc/https/github.com/adoptium/temurin17-binaries/releases/download/jdk-17%252B35/OpenJDK17-jdk_x64_windows_hotspot_17_35.zip/jdk-17+35/bin:$PATH"
```
The `Windows` batch file format results if OSTYPE is unset:
```bash
user@d5 MINGW64 ~/workspace/scala-cli
$ OSTYPE=  cs java --jvm 11 --env
set CS_FORMER_JAVA_HOME="%JAVA_HOME%"
set "JAVA_HOME=C:\Users\user\AppData\Local\Coursier\cache\arc\https\github.com\adoptium\temurin17-binaries\releases\download\jdk-17%252B35\OpenJDK17-jdk_x64_windows_hotspot_17_35.zip\jdk-17+35"
set "PATH=C:\Users\user\AppData\Local\Coursier\cache\arc\https\github.com\adoptium\temurin17-binaries\releases\download\jdk-17%252B35\OpenJDK17-jdk_x64_windows_hotspot_17_35.zip\jdk-17+35\bin;%PATH%"
```

The output of  a successful run of `.github/scripts/generate-os-packages.sh` script is shown below.

<details>
<pre>
user@d5 MINGW64 ~/workspace/coursier-fork
# .github/scripts/generate-os-packages.sh
Compiling C:\Users\user\workspace\coursier-fork\build.sc
C:\Users\user\workspace\coursier-fork\build.sc:563: value IMPLEMENTATION_VENDOR_ID in class Name is deprecated
      Name.IMPLEMENTATION_VENDOR_ID.toString -> "io.get-coursier",
           ^
[43/512] util.jvm[2.12.18].compile
[info] compiling 14 Scala sources to C:\Users\user\workspace\coursier-fork\out\util\jvm\2.12.18\compile.dest\classes ...
[warn] 8 feature warnings; re-run with -feature for details
[warn] one warning found
[info] done compiling
[50/512] core.jvm[2.12.18].publishVersion
[85/512] core.jvm[2.12.18].compile
[info] compiling 43 Scala sources to C:\Users\user\workspace\coursier-fork\out\core\jvm\2.12.18\compile.dest\classes ...
[warn] C:/Users/user/workspace/coursier-fork/modules/core/shared/src/main/scala/coursier/core/Dependency.scala:102:5: method withExclusions in class Dependency is deprecated (since 2.1.0-M6): This method will be dropped in favor of withMinimizedExclusions in a future version
[warn]     withExclusions(Exclusions.zero)
[warn]     ^
[warn] C:/Users/user/workspace/coursier-fork/modules/core/shared/src/main/scala/coursier/core/Dependency.scala:102:31: value zero in object Exclusions is deprecated (since 2.1.0-M6): This method will be replaced by MinimizedExclusions in a future version
[warn]     withExclusions(Exclusions.zero)
[warn]                               ^
[warn] C:/Users/user/workspace/coursier-fork/modules/core/shared/src/main/scala/coursier/core/Dependency.scala:110:7: method exclusions in class Dependency is deprecated (since 2.1.0-M6): This method will be dropped in favor of minimizedExclusions() in a future version
[warn]       exclusions.toString,
[warn]       ^
[warn] C:/Users/user/workspace/coursier-fork/modules/core/shared/src/main/scala/coursier/core/Orders.scala:61:6: trait PartialOrdering in object Orders is deprecated (since 2.0.0-RC3): Will likely be removed at some point in future versions
[warn]   ): PartialOrdering[Configuration] =
[warn]      ^
[warn] C:/Users/user/workspace/coursier-fork/modules/core/shared/src/main/scala/coursier/core/Orders.scala:62:9: trait PartialOrdering in object Orders is deprecated (since 2.0.0-RC3): Will likely be removed at some point in future versions
[warn]     new PartialOrdering[Configuration] {
[warn]         ^
[warn] C:/Users/user/workspace/coursier-fork/modules/core/shared/src/main/scala/coursier/core/Resolution.scala:340:19: method exclusions in class Dependency is deprecated (since 2.1.0-M6): This method will be dropped in favor of minimizedExclusions() in a future version
[warn]           if (dep.exclusions.isEmpty)
[warn]                   ^
[warn] C:/Users/user/workspace/coursier-fork/modules/core/shared/src/main/scala/coursier/core/Resolution.scala:341:23: method withExclusions in class Dependency is deprecated (since 2.1.0-M6): This method will be dropped in favor of withMinimizedExclusions in a future version
[warn]             dep = dep.withExclusions(mgmtDep.exclusions)
[warn]                       ^
[warn] C:/Users/user/workspace/coursier-fork/modules/core/shared/src/main/scala/coursier/core/Resolution.scala:341:46: method exclusions in class Dependency is deprecated (since 2.1.0-M6): This method will be dropped in favor of minimizedExclusions() in a future version
[warn]             dep = dep.withExclusions(mgmtDep.exclusions)
[warn]                                              ^
[warn] C:/Users/user/workspace/coursier-fork/modules/core/shared/src/main/scala/coursier/core/Resolution.scala:540:12: method exclusions in class Dependency is deprecated (since 2.1.0-M6): This method will be dropped in favor of minimizedExclusions() in a future version
[warn]       from.exclusions
[warn]            ^
[warn] C:/Users/user/workspace/coursier-fork/modules/core/shared/src/main/scala/coursier/graph/DependencyTree.scala:84:18: method withExclusions in class Dependency is deprecated (since 2.1.0-M6): This method will be dropped in favor of withMinimizedExclusions in a future version
[warn]             dep0.withExclusions(Set.empty),
[warn]                  ^
[warn] C:/Users/user/workspace/coursier-fork/modules/core/shared/src/main/scala/coursier/ivy/IvyXml.scala:200:66: method apply in object Exclusions is deprecated (since 2.1.0-M6): This method is slow and will be replaced by MinimizedExclusions in a future version
[warn]         val filters       = globalExcludes.view.mapValues(set => Exclusions(set)).toMap
[warn]                                                                  ^
[warn] C:/Users/user/workspace/coursier-fork/modules/core/shared/src/main/scala/coursier/util/Print.scala:24:8: method exclusions in class Dependency is deprecated (since 2.1.0-M6): This method will be dropped in favor of minimizedExclusions() in a future version
[warn]       .exclusions
[warn]        ^
[warn] 33 feature warnings; re-run with -feature for details
[warn] 13 warnings found
[info] done compiling
[129/512] cache.jvm[2.12.18].compile
[info] compiling 39 Scala sources and 13 Java sources to C:\Users\user\workspace\coursier-fork\out\cache\jvm\2.12.18\compile.dest\classes ...
[warn] 15 feature warnings; re-run with -feature for details
[warn] one warning found
[info] done compiling
[186/512] coursier.jvm[2.12.18].compile
[info] compiling 46 Scala sources to C:\Users\user\workspace\coursier-fork\out\coursier\jvm\2.12.18\compile.dest\classes ...
[warn] C:/Users/user/workspace/coursier-fork/modules/coursier/shared/src/main/scala/coursier/util/StringInterpolators.scala:142:29: method exclusions in class Dependency is deprecated (since 2.1.0-M6): This method will be dropped in favor of minimizedExclusions() in a future version
[warn]             val excls = dep.exclusions.toSeq.map {
[warn]                             ^
[warn] 10 feature warnings; re-run with -feature for details
[warn] two warnings found
[info] done compiling
[222/512] sbt-maven-repository.jvm[2.12.18].compile
[info] compiling 1 Scala source to C:\Users\user\workspace\coursier-fork\out\sbt-maven-repository\jvm\2.12.18\compile.dest\classes ...
[warn] four feature warnings; re-run with -feature for details
[warn] one warning found
[info] done compiling
[259/512] env[2.12.18].compile
[info] compiling 6 Scala sources to C:\Users\user\workspace\coursier-fork\out\env\2.12.18\compile.dest\classes ...
[info] done compiling
[297/512] jvm[2.12.18].compile
[info] compiling 7 Scala sources and 5 Java sources to C:\Users\user\workspace\coursier-fork\out\jvm\2.12.18\compile.dest\classes ...
[info] done compiling
[384/512] bootstrap-launcher.proguardedAssembly
[390/512] bootstrap-launcher.proguardedResourceAssembly
[418/512] launcher[2.12.18].compile
[info] compiling 20 Scala sources to C:\Users\user\workspace\coursier-fork\out\launcher\2.12.18\compile.dest\classes ...
[info] done compiling
[455/512] install[2.12.18].compile
[info] compiling 30 Scala sources to C:\Users\user\workspace\coursier-fork\out\install\2.12.18\compile.dest\classes ...
[warn] C:/Users/user/workspace/coursier-fork/modules/install/src/main/scala/coursier/install/InstallDir.scala:39:2: value os in class InstallDir is deprecated (since 2.1.0-M4): ignored, use platform instead
[warn] @data class InstallDir(
[warn]  ^
[warn] one warning found
[info] done compiling
[492/512] cli[2.12.18].compile
[info] compiling 103 Scala sources and 2 Java sources to C:\Users\user\workspace\coursier-fork\out\cli\2.12.18\compile.dest\classes ...
[warn] C:/Users/user/workspace/coursier-fork/modules/cli/src/main/scala/coursier/cli/util/DeprecatedModuleRequirements.scala:11:9: method withExclusions in class Dependency is deprecated (since 2.1.0-M6): This method will be dropped in favor of withMinimizedExclusions in a future version
[warn]     dep.withExclusions(
[warn]         ^
[warn] C:/Users/user/workspace/coursier-fork/modules/cli/src/main/scala/coursier/cli/util/DeprecatedModuleRequirements.scala:12:55: method exclusions in class Dependency is deprecated (since 2.1.0-M6): This method will be dropped in favor of minimizedExclusions() in a future version
[warn]       localExcludes.getOrElse(dep.module.orgName, dep.exclusions) | globalExcludes
[warn]                                                       ^
[warn] C:/Users/user/workspace/coursier-fork/modules/cli/src/main/scala/coursier/cli/util/JsonReport.scala:203:42: method exclusions in class Dependency is deprecated (since 2.1.0-M6): This method will be dropped in favor of minimizedExclusions() in a future version
[warn]   lazy val exclusions: Set[String] = dep.exclusions.map {
[warn]                                          ^
[warn] C:/Users/user/workspace/coursier-fork/modules/cli/src/main/scala/coursier/cli/util/JsonReport.scala:225:15: method withExclusions in class Dependency is deprecated (since 2.1.0-M6): This method will be dropped in favor of withMinimizedExclusions in a future version
[warn]           dep.withExclusions(Set.empty),
[warn]               ^
[warn] C:/Users/user/workspace/coursier-fork/modules/cli/src/main/scala/coursier/cli/util/JsonReport.scala:238:18: method withExclusions in class Dependency is deprecated (since 2.1.0-M6): This method will be dropped in favor of withMinimizedExclusions in a future version
[warn]                 .withExclusions(Set.empty[(Organization, ModuleName)])
[warn]                  ^
[warn] one feature warning; re-run with -feature for details
[warn] 6 warnings found
[info] done compiling
[510/512] cli[2.12.18].base-image.nativeImage
Checking https://github.com/coursier/jvm-index/raw/master/index.json
Checked https://github.com/coursier/jvm-index/raw/master/index.json
Downloading https://github.com/coursier/jvm-index/raw/master/index.json
Downloaded https://github.com/coursier/jvm-index/raw/master/index.json

C:\Users\user\workspace\coursier-fork>chcp 437
Active code page: 437
**********************************************************************
** Visual Studio 2022 Developer Command Prompt v17.7.5
** Copyright (c) 2022 Microsoft Corporation
**********************************************************************
[vcvarsall.bat] Environment initialized for: 'x64'
========================================================================================================================
GraalVM Native Image: Generating 'cs' (executable)...
========================================================================================================================
Warning: Feature class coursier.cli.internal.CsJniUtilsFeature is annotated with the deprecated annotation @AutomaticFeature. Support for this annotation will be removed in a future version of GraalVM. Applications should register a feature using the option --features=coursier.cli.internal.CsJniUtilsFeature
[1/7] Initializing...                                                                                   (13.2s @ 0.32GB)
 Version info: 'GraalVM 22.3.0 Java 17 CE'
 Java version info: '17.0.5+8-jvmci-22.3-b08'
 C compiler: cl.exe (microsoft, x64, 19.37.32825)
 Garbage collector: Serial GC
 2 user-specific feature(s)
 - com.oracle.svm.polyglot.scala.ScalaFeature
 - coursier.cli.internal.CsJniUtilsFeature
[2/7] Performing analysis...  [**********]                                                              (49.6s @ 2.61GB)
  16,254 (91.62%) of 17,740 classes reachable
  20,683 (65.68%) of 31,492 fields reachable
  73,786 (45.76%) of 161,242 methods reachable
     396 classes,   121 fields, and 2,148 methods registered for reflection
      81 classes,    74 fields, and    67 methods registered for JNI access
       8 native libraries: advapi32, crypt32, ncrypt, ole32, psapi, shell32, version, winhttp
[3/7] Building universe...                                                                               (5.5s @ 1.38GB)
[4/7] Parsing methods...      [**]                                                                       (2.9s @ 2.12GB)
[5/7] Inlining methods...     [***]                                                                      (1.4s @ 4.10GB)
[6/7] Compiling methods...    [****]                                                                    (19.9s @ 3.30GB)
[7/7] Creating image...                                                                                  (4.1s @ 5.02GB)
  28.15MB (47.42%) for code area:    44,926 compilation units
  30.70MB (51.73%) for image heap:  302,862 objects and 16 resources
 515.92KB ( 0.85%) for other data
  59.36MB in total
------------------------------------------------------------------------------------------------------------------------
Top 10 packages in code area:                               Top 10 object types in image heap:
   1.48MB sun.security.ssl                                     5.90MB java.lang.Class
 930.33KB java.util                                            5.59MB byte[] for code metadata
 850.31KB coursier.install                                     5.15MB byte[] for java.lang.String
 756.27KB java.lang.invoke                                     2.71MB java.lang.String
 740.36KB coursier.core                                        2.40MB byte[] for general heap data
 720.15KB coursier.cli.options                                 1.24MB com.oracle.svm.core.hub.DynamicHubCompanion
 701.31KB com.sun.crypto.provider                            880.14KB byte[] for embedded resources
 691.15KB coursier.cli.install                               754.61KB byte[] for reflection metadata
 614.45KB scala.collection.immutable                         598.32KB c.o.svm.core.hub.DynamicHub$ReflectionMetadata
 471.36KB sun.security.x509                                  575.80KB java.lang.String[]
  20.00MB for 386 more packages                                4.63MB for 5011 more object types
------------------------------------------------------------------------------------------------------------------------
                        3.5s (3.4% of total time) in 36 GCs | Peak RSS: 6.51GB | CPU load: 6.06
------------------------------------------------------------------------------------------------------------------------
Produced artifacts:
 C:\Users\user\workspace\coursier-fork\out\cli\2.12.18\base-image\nativeImage.dest\cs.build_artifacts.txt (txt)
 C:\Users\user\workspace\coursier-fork\out\cli\2.12.18\base-image\nativeImage.dest\cs.exe (executable)
========================================================================================================================
Finished generating 'cs' in 1m 41s.
[512/512] copyTo

7-Zip [64] 17.05 : Copyright (c) 1999-2021 Igor Pavlov : 2017-08-28
p7zip Version 17.05 (locale=en_US.UTF-8,Utf16=on,HugeFiles=on,64 bits,12 CPUs Intel(R) Core(TM) i5-10400 CPU @ 2.90GHz (A0653),ASM,AES-NI)

Scanning the drive:
2 folders, 1 file, 62238720 bytes (60 MiB)

Creating archive: cs-x86_64-pc-win32-sdk.zip

Items to compress: 3

Files read from disk: 1
Archive size: 19730190 bytes (19 MiB)
Everything is Ok

</pre>
</details>