### PR TITLE
refactor: nicer message when uninstalling something that doesn't exist

### DIFF
--- a/modules/cli/src/main/scala/coursier/cli/install/Uninstall.scala
+++ b/modules/cli/src/main/scala/coursier/cli/install/Uninstall.scala
@@ -1,5 +1,8 @@
 package coursier.cli.install
 
+import java.io.File
+import java.io.FileNotFoundException
+
 import caseapp.core.RemainingArgs
 import coursier.cli.{CoursierCommand, CommandGroup}
 import coursier.cli.Util.ValidatedExitOnError
@@ -10,8 +13,8 @@ import coursier.util.Task
 import coursier.util.EitherT
 import coursier.util.Artifact
 import coursier.cache.ArtifactError
-import java.io.File
 import scala.concurrent.ExecutionContext
+import java.nio.file.NoSuchFileException
 
 object Uninstall extends CoursierCommand[UninstallOptions] {
 
@@ -54,6 +57,9 @@ object Uninstall extends CoursierCommand[UninstallOptions] {
           catch {
             case e: InstallDirException if params.verbosity <= 1 =>
               System.err.println(e.getMessage)
+              sys.exit(1)
+            case _: FileNotFoundException | _: NoSuchFileException =>
+              System.err.println(s"$app is not installed by coursier")
               sys.exit(1)
           }
         resOpt match {


### PR DESCRIPTION
For some reason if you try to uninstall an app that doesn't exist or
isn't installed you currently see a big stack trace. For example:

```
❯ coursier uninstall example                                                                                 (base)
Exception in thread "main" java.nio.file.NoSuchFileException: /Users/ckipp/Library/Application Support/Coursier/bin/example
        at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
        at java.base/sun.nio.fs.UnixFileAttributeViews$Basic.readAttributes(UnixFileAttributeViews.java:55)
        at java.base/sun.nio.fs.UnixFileSystemProvider.readAttributes(UnixFileSystemProvider.java:149)
        at java.base/java.nio.file.Files.readAttributes(Files.java:1851)
        at java.base/java.util.zip.ZipFile$Source.get(ZipFile.java:1264)
        at java.base/java.util.zip.ZipFile$CleanableResource.<init>(ZipFile.java:709)
        at java.base/java.util.zip.ZipFile.<init>(ZipFile.java:243)
        at java.base/java.util.zip.ZipFile.<init>(ZipFile.java:172)
        at java.base/java.util.zip.ZipFile.<init>(ZipFile.java:186)
        at coursier.install.InfoFile$.isInfoFile(InfoFile.scala:28)
        at coursier.install.Updatable$.delete(Updatable.scala:115)
        at coursier.install.InstallDir.delete(InstallDir.scala:102)
        at coursier.cli.install.Uninstall$.$anonfun$run$1(Uninstall.scala:53)
        at coursier.cli.install.Uninstall$.$anonfun$run$1$adapted(Uninstall.scala:51)
        at scala.collection.immutable.List.foreach(List.scala:333)
        at coursier.cli.install.Uninstall$.run(Uninstall.scala:51)
        at coursier.cli.install.Uninstall$.run(Uninstall.scala:16)
        at caseapp.core.app.CaseApp.main(CaseApp.scala:157)
        at caseapp.core.app.CommandsEntryPoint.main(CommandsEntryPoint.scala:161)
        at coursier.cli.Coursier$.main(Coursier.scala:118)
        at coursier.cli.Coursier.main(Coursier.scala)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at coursier.bootstrap.launcher.a.a(Unknown Source)
        at coursier.bootstrap.launcher.Launcher.main(Unknown Source)
```

Now instead you'll see:

```
❯ ./mill cli[2.13.6].run uninstall example
[557/557] cli[2.13.6].run
example is not installed by coursier

```
