### PR TITLE
Update Scala to 2.13.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
             SCALA_VERSION: "2.12.18"
             OS: "windows-latest"
           - JDK: "8"
-            SCALA_VERSION: "2.13.6"
+            SCALA_VERSION: "2.13.12"
             OS: "ubuntu-latest"
           - JDK: "17"
             SCALA_VERSION: "2.12.18"
@@ -101,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        SCALA_VERSION: ["2.12.18", "2.13.6"]
+        SCALA_VERSION: ["2.12.18", "2.13.12"]
     steps:
     - name: Don't convert LF to CRLF during checkout
       if: runner.os == 'Windows'

--- a/modules/util/shared/src/main/scala/coursier/util/Gather.scala
+++ b/modules/util/shared/src/main/scala/coursier/util/Gather.scala
@@ -1,7 +1,36 @@
 package coursier.util
 
-import simulacrum._
-
-@typeclass trait Gather[F[_]] extends Monad[F] {
+trait Gather[F[_]] extends Monad[F] {
   def gather[A](elems: Seq[F[A]]): F[Seq[A]]
+}
+
+object Gather {
+  def apply[F[_]](implicit instance: Gather[F]): Gather[F] = instance
+
+  trait Ops[F[_], A] {
+    def typeClassInstance: Gather[F]
+    def self: F[A]
+  }
+
+  trait ToGatherOps {
+    implicit def toGatherOps[F[_], A](target: F[A])(implicit tc: Gather[F]): Ops[F, A] =
+      new Ops[F, A] {
+        val self              = target
+        val typeClassInstance = tc
+      }
+  }
+
+  object nonInheritedOps extends ToGatherOps
+
+  trait AllOps[F[_], A] extends Monad.AllOps[F, A] with Ops[F, A] {
+    def typeClassInstance: Gather[F]
+  }
+
+  object ops {
+    implicit def toAllGatherOps[F[_], A](target: F[A])(implicit tc: Gather[F]): AllOps[F, A] =
+      new AllOps[F, A] {
+        val self              = target
+        val typeClassInstance = tc
+      }
+  }
 }

--- a/modules/util/shared/src/main/scala/coursier/util/Monad.scala
+++ b/modules/util/shared/src/main/scala/coursier/util/Monad.scala
@@ -1,11 +1,42 @@
 package coursier.util
 
-import simulacrum._
-
-@typeclass trait Monad[F[_]] {
+trait Monad[F[_]] extends Serializable {
   def point[A](a: A): F[A]
-  @op("flatMap") def bind[A, B](elem: F[A])(f: A => F[B]): F[B]
+  def bind[A, B](elem: F[A])(f: A => F[B]): F[B]
 
   def map[A, B](elem: F[A])(f: A => B): F[B] =
     bind(elem)(a => point(f(a)))
+}
+
+object Monad {
+  def apply[F[_]](implicit instance: Monad[F]): Monad[F] = instance
+
+  trait Ops[F[_], A] {
+    def typeClassInstance: Monad[F]
+    def self: F[A]
+    def map[B](f: A => B): F[B]        = typeClassInstance.map(self)(f)
+    def flatMap[B](f: A => F[B]): F[B] = typeClassInstance.bind(self)(f)
+  }
+
+  trait ToMonadOps {
+    implicit def toMonadOps[F[_], A](target: F[A])(implicit tc: Monad[F]): Ops[F, A] =
+      new Ops[F, A] {
+        val self              = target
+        val typeClassInstance = tc
+      }
+  }
+
+  object nonInheritedOps extends ToMonadOps
+
+  trait AllOps[F[_], A] extends Ops[F, A] {
+    def typeClassInstance: Monad[F]
+  }
+
+  object ops {
+    implicit def toAllMonadOps[F[_], A](target: F[A])(implicit tc: Monad[F]): AllOps[F, A] =
+      new AllOps[F, A] {
+        val self              = target
+        val typeClassInstance = tc
+      }
+  }
 }

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -79,7 +79,7 @@ def jvmIndex = "https://github.com/coursier/jvm-index/raw/master/index.json"
 def csDockerVersion = "2.1.0-RC1"
 
 object ScalaVersions {
-  def scala213 = "2.13.6"
+  def scala213 = "2.13.12"
   def scala212 = "2.12.18"
   val all      = Seq(scala213, scala212)
 

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -50,7 +50,6 @@ object Deps {
   def scalaXml                 = ivy"org.scala-lang.modules::scala-xml:2.2.0"
   def scalazCore               = ivy"org.scalaz::scalaz-core::${Versions.scalaz}"
   def scalazConcurrent         = ivy"org.scalaz::scalaz-concurrent:${Versions.scalaz}"
-  def simulacrum               = ivy"org.typelevel::simulacrum:1.0.1"
   def slf4JNop                 = ivy"org.slf4j:slf4j-nop:2.0.9"
   def svm                      = ivy"org.graalvm.nativeimage:svm:22.0.0.2"
   def ujson                    = ivy"com.lihaoyi::ujson:3.1.3"

--- a/project/modules/tests0.sc
+++ b/project/modules/tests0.sc
@@ -8,7 +8,6 @@ trait TestsModule extends CsCrossJvmJsModule {
     Deps.scalaAsync
   )
   def compileIvyDeps = Agg(
-    Deps.dataClass,
-    Deps.simulacrum
+    Deps.dataClass
   )
 }

--- a/project/modules/util0.sc
+++ b/project/modules/util0.sc
@@ -10,8 +10,7 @@ trait Util extends CsModule with CsCrossJvmJsModule with CoursierPublishModule {
     Deps.collectionCompat
   )
   def compileIvyDeps = Agg(
-    Deps.dataClass,
-    Deps.simulacrum
+    Deps.dataClass
   )
 }
 


### PR DESCRIPTION
This gets rid of simulacrum in particular, that doesn't support Scala 2.13 versions higher than 2.13.6. Simulacrum wasn't used much anyway (2 `@typeclass` annotations, but only one of them actually necessary in practice).