### PR TITLE
Warn about use of  `~/.m2/repository`

### DIFF
--- a/doc/docs/other-repositories.md
+++ b/doc/docs/other-repositories.md
@@ -29,6 +29,8 @@ $ cs fetch --no-default \
   org.scalameta:scalafmt-cli_2.12:2.0.0-RC4+29-f2154330-SNAPSHOT
 ```
 
+⚠️ _Avoid using `~/.m2/repository` as a repository as it is maven's internal file-system cache._ 
+
 ## Ivy Repositories
 
 It is possible to use a custom Ivy repository and pattern by concatenating them:

--- a/doc/docs/other-repositories.md
+++ b/doc/docs/other-repositories.md
@@ -29,7 +29,9 @@ $ cs fetch --no-default \
   org.scalameta:scalafmt-cli_2.12:2.0.0-RC4+29-f2154330-SNAPSHOT
 ```
 
-⚠️ _Avoid using `~/.m2/repository` as a repository as it is maven's internal file-system cache._ 
+⚠️ _Avoid using `~/.m2/repository` as a repository if you can. This is maven's internal file-system cache and it's not meant to be read by external tools.
+By using it you are risking running into some issues like e.g. directories with POMs inside but without corresponding jar files.
+You can read more about it [here](https://github.com/ghostbuster91/demos/tree/coursier-not-found) and [here](https://github.com/coursier/coursier/issues/1832#issuecomment-1357764540)._ 
 
 ## Ivy Repositories
 


### PR DESCRIPTION
We have just run ourselves into a weird issue with coursier where it would fail with artifact not found error. After closer inspection it turned out that it was because of use of ~/.m2/repository as a coursier repository.

I think that it would be great to add a warning to the documentation about this.

This was also mentioned here https://github.com/coursier/coursier/issues/1832#issuecomment-1357764540

This directory is maven internal files-system cache and afaik its layout can change without prior notice. It also can contain POMs without corresponding jars (e.g. when a transitive dependency was evicted due to a version conflict) which confuses coursier.

See problem reproduction and more details in https://github.com/ghostbuster91/demos/tree/coursier-not-found