### PR TITLE
chore(ci): bump setup-action to the latest to avoid node warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         fetch-depth: 0
         submodules: true
     - uses: coursier/cache-action@v6.4
-    - uses: coursier/setup-action@v1.3.0
+    - uses: coursier/setup-action@v1.3.5
       with:
         jvm: "temurin:17"
         version: "2.1.0"
@@ -42,7 +42,7 @@ jobs:
         fetch-depth: 0
         submodules: true
     - uses: coursier/cache-action@v6.4
-    - uses: coursier/setup-action@v1.3.0
+    - uses: coursier/setup-action@v1.3.5
       with:
         jvm: "temurin:17"
         version: "2.1.0"
@@ -81,7 +81,7 @@ jobs:
         fetch-depth: 0
         submodules: true
     - uses: coursier/cache-action@v6.4
-    - uses: coursier/setup-action@v1.3.0
+    - uses: coursier/setup-action@v1.3.5
       with:
         jvm: ${{ matrix.JDK }}
         version: "2.1.0"
@@ -116,7 +116,7 @@ jobs:
       with:
         node-version: '12'
     - uses: coursier/cache-action@v6.4
-    - uses: coursier/setup-action@v1.3.0
+    - uses: coursier/setup-action@v1.3.5
       with:
         jvm: 8
         version: "2.1.0"
@@ -134,7 +134,7 @@ jobs:
         fetch-depth: 0
         submodules: true
     - uses: coursier/cache-action@v6.4
-    - uses: coursier/setup-action@v1.3.0
+    - uses: coursier/setup-action@v1.3.5
       with:
         jvm: 8
         version: "2.1.0"
@@ -157,7 +157,7 @@ jobs:
       with:
         node-version: '12'
     - uses: coursier/cache-action@v6.4
-    - uses: coursier/setup-action@v1.3.0
+    - uses: coursier/setup-action@v1.3.5
       with:
         jvm: 17
         version: "2.1.0"
@@ -173,7 +173,7 @@ jobs:
         fetch-depth: 0
         submodules: true
     - uses: coursier/cache-action@v6.4
-    - uses: coursier/setup-action@v1.3.0
+    - uses: coursier/setup-action@v1.3.5
       with:
         jvm: 8
         apps: scalafmt
@@ -193,7 +193,7 @@ jobs:
       - run: .github/scripts/gpg-setup.sh
         env:
           PGP_SECRET: ${{ secrets.PUBLISH_SECRET_KEY }}
-      - uses: coursier/setup-action@v1.3.0
+      - uses: coursier/setup-action@v1.3.5
         with:
           jvm: 8
           version: "2.1.0"
@@ -433,7 +433,7 @@ jobs:
         with:
           node-version: '12'
       - uses: coursier/cache-action@v6.4
-      - uses: coursier/setup-action@v1.3.0
+      - uses: coursier/setup-action@v1.3.5
         with:
           jvm: 17
           version: "2.1.0"


### PR DESCRIPTION
supersedes #2754