### PR TITLE
fix: use project.git in .scalafmt.conf

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,6 @@
 version = "3.7.17"
 
+project.git = true
 align.preset = more
 maxColumn = 100
 assumeStandardLibraryStripMargin = true
@@ -31,8 +32,6 @@ rewrite.sortModifiers.order = [
   "implicit", "sealed", "abstract", "lazy"
 ]
 project.excludeFilters = [
-  ".metals"
-  "out"
   "modules/directories"
   "modules/windows-ansi"
 ]


### PR DESCRIPTION
This allows you to not have to exclude certain directories like .metals
if they are already excluded in your .gitignore.