### PR TITLE
Fix unquoted variable for java path in boostrap script

### DIFF
--- a/modules/launcher/src/main/scala/coursier/launcher/Preamble.scala
+++ b/modules/launcher/src/main/scala/coursier/launcher/Preamble.scala
@@ -47,7 +47,7 @@ import scala.io.{Codec, Source}
         val setJavaCmd =
           """[ -x "$JAVA_HOME/bin/java" ] && JAVA_CMD="$JAVA_HOME/bin/java" || JAVA_CMD=java"""
 
-        val javaCmd = Seq("$JAVA_CMD") ++
+        val javaCmd = Seq("\"$JAVA_CMD\"") ++
           // escaping possibly a bit loose :-|
           javaOpts.map(s => "'" + s.replace("'", "\\'") + "'") ++
           jvmOptionFile.toSeq.map(_ => "${extra_jvm_opts[@]}") ++


### PR DESCRIPTION
The unquoted `$JAVA_CMD` breaks when `$JAVA_HOME` contains a space (e.g. in `C:\Program Files` on Windows).
