### PR TITLE
Update the sbt-coursier version on site to actual

### DIFF
--- a/doc/docs/sbt-coursier.md
+++ b/doc/docs/sbt-coursier.md
@@ -41,6 +41,8 @@ not handle publishing for now.
 
 ## Setup
 
+Since `sbt-coursier` is a distinct project, check the latest version at [Github](https://github.com/coursier/sbt-coursier). The below might not be an up-to-date version.
+
 ### Per project
 
 #### No other plugin
@@ -84,6 +86,4 @@ Add the following to `~/.sbt/1.0/global.sbt`,
 // Work around for https://github.com/coursier/coursier/issues/450
 classpathTypes += "maven-plugin"
 ```
-
-#### sbt 1.3.x
 

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -66,7 +66,7 @@ object Versions {
   def scalaz        = "7.2.36"
 }
 
-def sbtCoursierVersion = "2.0.8"
+def sbtCoursierVersion = "2.1.4"
 
 def graalVmVersion = "22.3.0"
 def graalVmJvmId   = s"graalvm-java17:$graalVmVersion"


### PR DESCRIPTION
Hey there. I observed a minor issue: the version of `sbt-coursier` on site is outdated and generally not automatically updated by Scala Steward / dependabot when new versions arrive. In this PR, we update the version and add a caution on where to pick the latest version on site. 