### PR TITLE
Pin the macos-12 for generate-native-launchers job in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        OS: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        OS: ["ubuntu-latest", "windows-latest", "macos-12"]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
It's an attempt to make CI green. 