### PR TITLE
Replace git submodule with `windows-ansi-ps` source dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "modules/tests/handmade-metadata"]
 	path = modules/tests/handmade-metadata
 	url = https://github.com/coursier/handmade-metadata.git
-[submodule "modules/windows-ansi"]
-	path = modules/windows-ansi
-	url = https://github.com/alexarchambault/windows-ansi.git

--- a/build.sc
+++ b/build.sc
@@ -90,7 +90,7 @@ object `custom-protocol-for-test` extends CsModule {
   def scalaVersion = ScalaVersions.scala213
 }
 
-object `bootstrap-launcher` extends BootstrapLauncher with CoursierModule { self =>
+object `bootstrap-launcher` extends BootstrapLauncher { self =>
   def proxySources = T.sources {
     val dest = T.dest / "sources"
     val orig = `proxy-setup`.sources()
@@ -109,7 +109,7 @@ object `bootstrap-launcher` extends BootstrapLauncher with CoursierModule { self
   def windowsAnsiPsSources = T {
     val jars = resolveDeps(
       T.task {
-        Agg(Deps.windowsAnsi.exclude("*" -> "*"))
+        Agg(Deps.windowsAnsiPs.exclude("*" -> "*"))
           .map(bindDependency())
       },
       sources = true

--- a/build.sc
+++ b/build.sc
@@ -119,7 +119,7 @@ object `bootstrap-launcher` extends BootstrapLauncher with CoursierModule { self
     }
     Seq(PathRef(T.dest))
   }
-  def sources = T.sources {
+  def sources = T {
     super.sources() ++
       directories.sources() ++
       paths.sources() ++

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -55,6 +55,7 @@ object Deps {
   def ujson                    = ivy"com.lihaoyi::ujson:3.3.1"
   def utest                    = ivy"com.lihaoyi::utest::0.8.3"
   def windowsAnsi              = ivy"io.github.alexarchambault.windows-ansi:windows-ansi:0.0.5"
+  def windowsAnsiPs            = ivy"io.github.alexarchambault.windows-ansi:windows-ansi-ps:${windowsAnsi.version}"
 }
 
 object Versions {

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -55,7 +55,8 @@ object Deps {
   def ujson                    = ivy"com.lihaoyi::ujson:3.3.1"
   def utest                    = ivy"com.lihaoyi::utest::0.8.3"
   def windowsAnsi              = ivy"io.github.alexarchambault.windows-ansi:windows-ansi:0.0.5"
-  def windowsAnsiPs            = ivy"io.github.alexarchambault.windows-ansi:windows-ansi-ps:${windowsAnsi.version}"
+  def windowsAnsiPs =
+    ivy"io.github.alexarchambault.windows-ansi:windows-ansi-ps:${windowsAnsi.version}"
 }
 
 object Versions {


### PR DESCRIPTION
Instead of using a git submodule, we just use a normal library dependency on the source artifact and use it in the build.

Related to https://github.com/coursier/coursier/issues/2985
