### PR TITLE
chore: Revert ujson to avoid updating coursier to 3.0.0

### DIFF
--- a/project/deps.sc
+++ b/project/deps.sc
@@ -52,7 +52,7 @@ object Deps {
   def scalazConcurrent         = ivy"org.scalaz::scalaz-concurrent:${Versions.scalaz}"
   def slf4JNop                 = ivy"org.slf4j:slf4j-nop:2.0.13"
   def svm                      = ivy"org.graalvm.nativeimage:svm:22.0.0.2"
-  def ujson                    = ivy"com.lihaoyi::ujson:4.0.0"
+  def ujson                    = ivy"com.lihaoyi::ujson:3.3.1"
   def utest                    = ivy"com.lihaoyi::utest::0.8.3"
   def windowsAnsi              = ivy"io.github.alexarchambault.windows-ansi:windows-ansi:0.0.5"
   def windowsAnsiPs =


### PR DESCRIPTION
We should probably do a bulk update for dependencies when needed.