### PR TITLE
Fix ejb packaging handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
     - uses: coursier/cache-action@v6.4
     - uses: coursier/setup-action@v1.3.5
       with:
-        jvm: 8
+        jvm: 17
         apps: scalafmt
         version: "2.1.0"
     - run: scalafmt --check

--- a/modules/core/shared/src/main/scala/coursier/maven/MavenAttributes.scala
+++ b/modules/core/shared/src/main/scala/coursier/maven/MavenAttributes.scala
@@ -15,6 +15,7 @@ object MavenAttributes {
     Type("doc")            -> Extension.jar,
     Type("src")            -> Extension.jar,
     Type.testJar           -> Extension.jar,
+    Type("ejb")            -> Extension.jar,
     Type("ejb-client")     -> Extension.jar
   )
 

--- a/modules/tests/shared/src/test/scala/coursier/tests/CentralTests.scala
+++ b/modules/tests/shared/src/test/scala/coursier/tests/CentralTests.scala
@@ -332,6 +332,16 @@ abstract class CentralTests extends TestSuite {
           Attributes(Type("maven-plugin"), Classifier.empty)
         )
       }
+
+      test("ejb") {
+        // has packaging ejb - ensuring coursier gives its artifact the .jar extension
+        runner.ensureHasArtifactWithExtension(
+          mod"org.ferris:ferris-journal-ejb",
+          "0.0.2",
+          Extension.jar,
+          Attributes(Type("ejb"), Classifier.empty)
+        )
+      }
     }
 
     test("classifier") {


### PR DESCRIPTION
Fixes https://github.com/coursier/coursier/issues/3040

## Problem
`ejb` packaging is supposed to have the `jar` extension, but Coursier seems to be unaware about it.

```bash
[error] lmcoursier.internal.shaded.coursier.error.FetchError$DownloadingArtifacts: Error fetching artifacts:
[error] https://repo1.maven.org/maven2/org/jboss/da/reports-model/2.1.0/reports-model-2.1.0.ejb: not found: https://repo1.maven.org/maven2/org/jboss/da/reports-model/2.1.0/reports-model-2.1.0.ejb
```

Interestingly, this only started happening in sbt 1.9.4 (bumped Cousier from 2.1.2 to 2.1.6).

## Solution

This adds jar extension for ejb.

## Notes

Test is pending https://github.com/coursier/test-metadata/pull/10

```diff
$ git diff
diff --git a/modules/tests/metadata b/modules/tests/metadata
index 7e9ad43e6..66833f301 160000
--- a/modules/tests/metadata
+++ b/modules/tests/metadata
@@ -1 +1 @@
-Subproject commit 7e9ad43e665c9d1438db7399871d32d298614158
+Subproject commit 66833f3015c8e107246a2d5c61266449d0ca1756
diff --git a/modules/tests/shared/src/test/scala/coursier/tests/CentralTests.scala b/modules/tests/shared/src/test/scala/coursier/tests/CentralTests.scala
index d87aaada1..c53ddd2a9 100644
--- a/modules/tests/shared/src/test/scala/coursier/tests/CentralTests.scala
+++ b/modules/tests/shared/src/test/scala/coursier/tests/CentralTests.scala
@@ -332,6 +332,16 @@ abstract class CentralTests extends TestSuite {
           Attributes(Type("maven-plugin"), Classifier.empty)
         )
       }
+
+      test("ejb") {
+        // has packaging ejb - ensuring coursier gives its artifact the .jar extension
+        runner.ensureHasArtifactWithExtension(
+          mod"org.ferris:ferris-journal-ejb",
+          "0.0.2",
+          Extension.jar,
+          Attributes(Type("ejb"), Classifier.empty)
+        )
+      }
     }
```
