### PR TITLE
Update actions/download-artifact to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,7 +370,7 @@ jobs:
       with:
         jvm: 8
         version: "2.1.0"
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: launchers
         path: artifacts/


### PR DESCRIPTION
Superseded https://github.com/coursier/coursier/pull/3060. Not sure why it wasn't bumped to just `v4` there.