### PR TITLE
Add retries around some accesses of freshly created files on Windows

### DIFF
--- a/modules/cache/jvm/src/main/scala/coursier/cache/FileCache.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/FileCache.scala
@@ -3,14 +3,20 @@ package coursier.cache
 import java.io.{Serializable => _, _}
 import java.math.BigInteger
 import java.nio.charset.StandardCharsets.UTF_8
-import java.nio.file.{FileAlreadyExistsException, Files, NoSuchFileException, StandardCopyOption}
+import java.nio.file.{
+  AccessDeniedException,
+  FileAlreadyExistsException,
+  Files,
+  NoSuchFileException,
+  StandardCopyOption
+}
 import java.security.MessageDigest
 import java.time.Clock
 import java.util.Locale
 import java.util.concurrent.ExecutorService
 import javax.net.ssl.{HostnameVerifier, SSLSocketFactory}
 
-import coursier.cache.internal.{Downloader, DownloadResult, FileUtil}
+import coursier.cache.internal.{Downloader, DownloadResult, FileUtil, Retry}
 import coursier.credentials.{Credentials, DirectCredentials, FileCredentials}
 import coursier.paths.CachePath
 import coursier.util.{Artifact, EitherT, Sync, Task, WebPage}
@@ -19,6 +25,7 @@ import dataclass.data
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.{Duration, FiniteDuration}
+import scala.util.Properties
 import scala.util.control.NonFatal
 
 // format: off

--- a/modules/cache/jvm/src/main/scala/coursier/cache/internal/Downloader.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/internal/Downloader.scala
@@ -173,8 +173,17 @@ import scala.util.control.NonFatal
         val succeeded =
           try {
             val content =
-              WebPage.listElements(url, new String(Files.readAllBytes(file.toPath), UTF_8))
-                .mkString("\n")
+              WebPage.listElements(
+                url,
+                new String(
+                  retry.retry {
+                    Files.readAllBytes(file.toPath)
+                  } {
+                    case _: AccessDeniedException if Properties.isWin =>
+                  },
+                  UTF_8
+                )
+              ).mkString("\n")
 
             var fos: FileOutputStream = null
             try {

--- a/modules/cache/jvm/src/main/scala/coursier/cache/internal/Retry.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/internal/Retry.scala
@@ -1,0 +1,39 @@
+package coursier.cache.internal
+
+import scala.concurrent.duration.FiniteDuration
+import scala.annotation.tailrec
+
+final case class Retry(
+  count: Int,
+  initialDelay: FiniteDuration,
+  delayMultiplier: Double
+) {
+
+  // This may try more than retry times, if f returns None too many times
+  def retryOpt[T](f: => Option[T])(catchEx: PartialFunction[Throwable, Unit]): T = {
+
+    @tailrec
+    def loop(attempt: Int, delay: FiniteDuration): T = {
+      val resOpt =
+        if (attempt >= count || Downloader.throwExceptions) f
+        else
+          try f
+          catch catchEx.andThen(_ => None)
+      resOpt match {
+        case Some(res) => res
+        case None =>
+          Thread.sleep(delay.toMillis)
+          loop(
+            attempt + 1,
+            delayMultiplier * delay match {
+              case f: FiniteDuration => f
+              case _                 => delay // should not happen
+            }
+          )
+      }
+    }
+
+    loop(1, initialDelay)
+  }
+
+}

--- a/modules/cache/jvm/src/main/scala/coursier/cache/internal/Retry.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/internal/Retry.scala
@@ -9,6 +9,9 @@ final case class Retry(
   delayMultiplier: Double
 ) {
 
+  def retry[T](f: => T)(catchEx: PartialFunction[Throwable, Unit]): T =
+    retryOpt(Some(f))(catchEx)
+
   // This may try more than retry times, if f returns None too many times
   def retryOpt[T](f: => Option[T])(catchEx: PartialFunction[Throwable, Unit]): T = {
 


### PR DESCRIPTION
Seems security or antivirus software might be accessing those files with exclusive access, making our attempts to read or move them fail