### PR TITLE
Fix #3085: Ignore info extra attributes in POM dependencies

### DIFF
--- a/modules/sbt-maven-repository/shared/src/main/scala/coursier/maven/SbtMavenRepository.scala
+++ b/modules/sbt-maven-repository/shared/src/main/scala/coursier/maven/SbtMavenRepository.scala
@@ -67,7 +67,8 @@ object SbtMavenRepository {
       attrs = parts
         .grouped(2)
         .collect {
-          case Seq(k, v) if v != "NULL" =>
+          // ignore NULL values and info attributes
+          case Seq(k, v) if v != "NULL" && !k.startsWith("info.") =>
             k.stripPrefix(Pom.extraAttributeDropPrefix) -> v
         }
         .toMap


### PR DESCRIPTION
Fix #3085

sbt writes more extra attributes in POM dependencies than it should do. Those attributes mess up the conflict resolution, because Coursier considers that 2 dependencies with different extra attributes are distinct.

See for instance [this POM file](https://repo1.maven.org/maven2/com/armanbilge/sbt-scala-native-config-brew-github-actions_2.12_1.0/0.3.0/sbt-scala-native-config-brew-github-actions_2.12_1.0-0.3.0.pom) which contain `e:info.apiURL`, `e:info.versionScheme` and `e:info.releaseNotesUrl` in its `extraDependencyAttributes`:

```
<extraDependencyAttributes xml:space="preserve">
+e:info.apiURL:#@#:+https://www.javadoc.io/doc/com.armanbilge/sbt-scala-native-config-brew_2.12/0.3.0/:#@#:
+e:sbtVersion:#@#:+1.0:#@#:
+e:info.releaseNotesUrl:#@#:
+https://github.com/armanbilge/scala-native-config-brew/releases/tag/v0.3.0:#@#:
+module:#@#:+sbt-scala-native-config-brew_2.12_1.0:#@#:
+e:scalaVersion:#@#:+2.12:#@#:$
+e:info.versionScheme:#@#:+early-semver:#@#:
+organisation:#@#:+com.armanbilge:#@#:
+branch:#@#:+@#:NULL:#@:#@#:
+revision:#@#:+0.3.0:#@#:
+e:sbtVersion:#@#:+1.0:#@#:
+module:#@#:+sbt-typelevel-github-actions_2.12_1.0:#@#:
+e:scalaVersion:#@#:+2.12:#@#:
+organisation:#@#:+org.typelevel:#@#:
+branch:#@#:+@#:NULL:#@:#@#:
+revision:#@#:+0.7.0:#@#:
</extraDependencyAttributes>
```

After https://github.com/sbt/librarymanagement/pull/451, sbt will stop writing those `info` attributes. As a hot fix for all the POMs that are already published, Coursier can ignore the attributes starting with `info.`.