### PR TITLE
Remove argonaut-shapeless dependency from jvm module

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -525,7 +525,6 @@ trait Jvm extends CrossSbtModule with CsModule
     Deps.svm
   )
   def ivyDeps = super.ivyDeps() ++ Agg(
-    Deps.argonautShapeless,
     Deps.jsoniterCore
   )
   object test extends CrossSbtModuleTests with CsTests {

--- a/modules/cache/jvm/src/test/scala/coursier/cache/FileCacheRedirectionTests.scala
+++ b/modules/cache/jvm/src/test/scala/coursier/cache/FileCacheRedirectionTests.scala
@@ -24,13 +24,11 @@ import scala.util.Try
 
 object FileCacheRedirectionTests extends TestSuite {
 
-  private val pool        = Sync.fixedThreadPool(4)
-  private implicit val ec = ExecutionContext.fromExecutorService(pool)
+  private val pool                          = Sync.fixedThreadPool(4)
+  private implicit val ec: ExecutionContext = ExecutionContext.fromExecutorService(pool)
 
-  override def utestAfterAll() = {
-    ec.shutdown()
+  override def utestAfterAll() =
     pool.shutdown()
-  }
 
   private def fileCache0() = FileCache()
     .noCredentials

--- a/modules/jvm/src/test/scala/coursier/jvm/JavaHomeTests.scala
+++ b/modules/jvm/src/test/scala/coursier/jvm/JavaHomeTests.scala
@@ -32,7 +32,7 @@ object JavaHomeTests extends TestSuite {
     poolInitialized.set(true)
     p
   }
-  private implicit val ec = ExecutionContext.fromExecutorService(pool)
+  private implicit val ec: ExecutionContext = ExecutionContext.fromExecutorService(pool)
 
   override def utestAfterAll(): Unit =
     if (poolInitialized.getAndSet(false))


### PR DESCRIPTION
Seems it was unused.

I think dropping dependencies is supposed to break binary compatibility though 🤔 (if a library compiled with coursier `2.1.14` relies on shapeless via it, and users bump coursier to `2.1.15` at runtime, shapeless is likely to be missing)