### PR TITLE
Add `Deps.collectionCompat` to `coursier-core`

### DIFF
--- a/project/modules/core0.sc
+++ b/project/modules/core0.sc
@@ -11,7 +11,8 @@ trait Core extends CsModule with CsCrossJvmJsModule with CoursierPublishModule {
     Deps.dataClass
   )
   def ivyDeps = super.ivyDeps() ++ Agg(
-    Deps.fastParse
+    Deps.fastParse,
+    Deps.collectionCompat
   )
 
   def constantsFile = T {


### PR DESCRIPTION
### Issue

https://github.com/coursier/coursier/blob/880a2220015cd9aefd436977af76ca4c841c1e8e/modules/core/shared/src/main/scala/coursier/core/Resolution.scala#L8

`coursier-core` relies on `collectionCompat`, yet the dependency is not declared. As a result user of `coursier-core` has to manually add `collectionCompat` to their build config.

### Fix

Add `Deps.collectionCompat` to `coursier-core`