### PR TITLE
Add --jdk-version option

### DIFF
--- a/modules/cli/src/main/scala/coursier/cli/options/ResolutionOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/ResolutionOptions.scala
@@ -98,7 +98,12 @@ final case class ResolutionOptions(
   @Group(OptionGroup.resolution)
   @Hidden
   @Help("Keep provided dependencies")
-    keepProvidedDependencies: Boolean = false
+    keepProvidedDependencies: Boolean = false,
+
+  @Group(OptionGroup.resolution)
+  @Hidden
+  @Help("Set JDK version used during resolution when picking profiles")
+    jdkVersion: Option[String] = None
 
 ) {
   // format: on
@@ -201,6 +206,7 @@ final case class ResolutionOptions(
           .withReconciliation(reconciliation)
           .withDefaultConfiguration(Configuration(defaultConfiguration))
           .withKeepProvidedDependencies(keepProvidedDependencies)
+          .withJdkVersionOpt(jdkVersion.map(_.trim).filter(_.nonEmpty).map(Version(_)))
     }
   }
 }


### PR DESCRIPTION
This adds a hidden / advanced option `--jdk-version` to most core CLI commands (`resolve`, `fetch`, …). That option allows to specify the JDK version that should be used when enabling / disabling Maven profiles (these can be enabled or disabled for specific JDK versions or version ranges).