### PR TITLE
Add resolution consistency check

### DIFF
--- a/project/deps.sc
+++ b/project/deps.sc
@@ -11,6 +11,7 @@ object Deps {
   def concurrentReferenceHashMap =
     ivy"io.github.alexarchambault:concurrent-reference-hash-map:1.1.0"
   def dataClass         = ivy"io.github.alexarchambault::data-class:0.2.6"
+  def diffUtils         = ivy"io.github.java-diff-utils:java-diff-utils:4.12"
   def dockerClient      = ivy"com.spotify:docker-client:8.16.0"
   def fastParse         = ivy"com.lihaoyi::fastparse::${Versions.fastParse}"
   def http4sBlazeServer = ivy"org.http4s::http4s-blaze-server:0.23.15"

--- a/project/modules/coursier0.sc
+++ b/project/modules/coursier0.sc
@@ -20,6 +20,7 @@ trait Coursier extends CsModule with CsCrossJvmJsModule with CoursierPublishModu
 trait CoursierTests extends TestModule {
   def ivyDeps = T {
     super.ivyDeps() ++ Agg(
+      Deps.diffUtils,
       Deps.pprint,
       Deps.scalaAsync
     )


### PR DESCRIPTION
There are two main ways to get dependency lists out of a `Resolution` instance:
- `orderedDependencies` (main one), which should be used to compute an ordered list of artifacts, and walks the dependency graph to compute its result
- `minDependencies`, used internally by `Resolution` itself, that contains a more compact list (removing some redundancies)

This adds checks in the tests that the two are consistent with each other (no extra dependencies on one side or the other).

This is being helpful in https://github.com/coursier/coursier/pull/3097 to debug new developments in `Resolution`.