### PR TITLE
Allow users to add BOMs to resolutions

### DIFF
--- a/modules/cli-tests/src/main/scala/coursier/clitests/ResolveTests.scala
+++ b/modules/cli-tests/src/main/scala/coursier/clitests/ResolveTests.scala
@@ -29,6 +29,33 @@ abstract class ResolveTests extends TestSuite {
       )
       assert(jacksonOutput == expectedJacksonOutput)
     }
+
+    test("BOM") {
+      val dependency = "ch.epfl.scala:bsp4j:2.2.0-M2"
+      val bom        = "io.quarkus:quarkus-bom:3.16.2"
+      val gsonModule = "com.google.code.gson:gson"
+
+      val noBomRes =
+        os.proc(launcher, "resolve", dependency).call().out.lines()
+      val bomRes =
+        os.proc(launcher, "resolve", dependency, "--bom", bom).call().out.lines()
+
+      def gsonVersion(results: Seq[String]) =
+        results
+          .find(_.startsWith(gsonModule + ":"))
+          .map(_.stripPrefix(gsonModule + ":"))
+          .map(_.split(":").apply(0))
+          .getOrElse(sys.error(s"$gsonModule not found in $results"))
+
+      val noBomGsonVersion = gsonVersion(noBomRes)
+      val bomGsonVersion   = gsonVersion(bomRes)
+
+      val expectedNoBomGsonVersion = "2.10.1"
+      val expectedBomGsonVersion   = "2.11.0"
+
+      assert(noBomGsonVersion == expectedNoBomGsonVersion)
+      assert(bomGsonVersion == expectedBomGsonVersion)
+    }
   }
 
 }

--- a/modules/cli/src/main/scala/coursier/cli/options/DependencyOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/DependencyOptions.scala
@@ -50,7 +50,12 @@ final case class DependencyOptions(
   @Group(OptionGroup.dependency)
   @HelpMessage("Path to file with dependencies. " +
     "Dependencies should be separated with newline character")
-    dependencyFile: List[String] = Nil
+    dependencyFile: List[String] = Nil,
+
+  @Group(OptionGroup.dependency)
+  @HelpMessage("BOM dependency coordinates")
+  @ExtraName("bom")
+    bomDependencies: List[String] = Nil
 
 )
 // format: on

--- a/modules/cli/src/main/scala/coursier/cli/resolve/Resolve.scala
+++ b/modules/cli/src/main/scala/coursier/cli/resolve/Resolve.scala
@@ -275,6 +275,7 @@ object Resolve extends CoursierCommand[ResolveOptions] {
           .withDependencies(deps)
           .withRepositories(repositories)
           .withResolutionParams(params0.resolution)
+          .withBomDependencies(params0.dependency.bomDependencies)
           .withCache(cache)
           .transformResolution { t =>
             if (benchmark == 0) t

--- a/modules/core/shared/src/main/scala/coursier/core/Resolution.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Resolution.scala
@@ -822,7 +822,8 @@ object Resolution {
   keepProvidedDependencies: Boolean = false,
   @since("2.1.15")
   forceDepMgmtVersions: Boolean = false,
-  enableDependencyOverrides: Boolean = Resolution.enableDependencyOverridesDefault
+  enableDependencyOverrides: Boolean = Resolution.enableDependencyOverridesDefault,
+  bomDependencies: Seq[Dependency] = Nil
 ) {
 
   lazy val dependencies: Set[Dependency] =
@@ -969,6 +970,41 @@ object Resolution {
       .toVector
       .flatMap(finalDependencies0)
 
+  private lazy val hasAllBoms =
+    bomDependencies.forall { bomDep =>
+      projectCache.contains(bomDep.moduleVersion)
+    }
+  private lazy val processedRootDependencies =
+    if (hasAllBoms) {
+      val bomProjects = bomDependencies
+        .map(_.moduleVersion)
+        .map(projectCache(_)._2)
+      val allDepMgmt = DepMgmt.addSeq(
+        Map.empty,
+        bomProjects.flatMap { bomProject =>
+          withProperties(bomProject.dependencyManagement, projectProperties(bomProject).toMap)
+        },
+        composeValues = true
+      )
+      val rootDependencies0 = rootDependencies.map(withDefaultConfig(_, defaultConfiguration))
+      if (allDepMgmt.isEmpty) rootDependencies0
+      else
+        rootDependencies0.map { rootDep =>
+          val rootDep0 = rootDep.withOverrides(
+            DepMgmt.add(allDepMgmt, rootDep.overrides.toSeq, composeValues = true)
+          )
+          if (rootDep0.version == "_")
+            allDepMgmt.get(DepMgmt.key(rootDep0)) match {
+              case Some(values) => rootDep0.withVersion(values.version)
+              case None         => rootDep0
+            }
+          else
+            rootDep0
+        }
+    }
+    else
+      Nil
+
   /** The "next" dependency set, made of the current dependencies and their transitive dependencies,
     * trying to solve version conflicts. Transitive dependencies are calculated with the current
     * cache.
@@ -982,18 +1018,10 @@ object Resolution {
   lazy val nextDependenciesAndConflicts: (Seq[Dependency], Seq[Dependency], Map[Module, String]) =
     // TODO Provide the modules whose version was forced by dependency overrides too
     merge(
-      rootDependencies.map(withDefaultConfig(_, defaultConfiguration)) ++ transitiveDependencies,
+      processedRootDependencies ++ transitiveDependencies,
       forceVersions,
       reconciliation
     )
-
-  private def updatedRootDependencies =
-    merge(
-      rootDependencies.map(withDefaultConfig(_, defaultConfiguration)),
-      forceVersions,
-      reconciliation,
-      preserveOrder = true
-    )._2
 
   lazy val reconciledVersions: Map[Module, String] =
     nextDependenciesAndConflicts._3.map {
@@ -1007,12 +1035,15 @@ object Resolution {
   /** The modules we miss some info about.
     */
   lazy val missingFromCache: Set[ModuleVersion] = {
+    val boms = bomDependencies
+      .map(_.moduleVersion)
+      .toSet
     val modules = dependencies
       .map(_.moduleVersion)
     val nextModules = nextDependenciesAndConflicts._2
       .map(_.moduleVersion)
 
-    (modules ++ nextModules)
+    (boms ++ modules ++ nextModules)
       .filterNot(mod => projectCache.contains(mod) || errorCache.contains(mod))
   }
 
@@ -1064,10 +1095,7 @@ object Resolution {
     * The versions of all the dependencies returned are erased (emptied).
     */
   lazy val remainingDependencies: Set[Dependency] = {
-    val rootDependencies0 = rootDependencies
-      .map(withDefaultConfig(_, defaultConfiguration))
-      .map(eraseVersion)
-      .toSet
+    val rootDependencies0 = processedRootDependencies.map(eraseVersion).toSet
 
     @tailrec
     def helper(
@@ -1416,6 +1444,12 @@ object Resolution {
           }
       }
 
+    val (_, updatedRootDependencies, _) = merge(
+      processedRootDependencies,
+      forceVersions,
+      reconciliation,
+      preserveOrder = true
+    )
     val rootDeps = updatedRootDependencies
       .map(withDefaultConfig(_, defaultConfiguration))
       .map(dep => updated(dep, withRetainedVersions = true, withFallbackConfig = true))

--- a/modules/core/shared/src/main/scala/coursier/core/Resolution.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Resolution.scala
@@ -426,8 +426,6 @@ object Resolution {
           dep = dep.withOverrides {
             if (dep.overrides.isEmpty)
               dictForOverrides
-            else if (dictForOverrides.isEmpty)
-              dep.overrides
             else
               DepMgmt.add(dictForOverrides, dep.overrides.toSeq, composeValues = true)
           }
@@ -1356,8 +1354,6 @@ object Resolution {
       .foldLeft(Map.empty[DependencyManagement.Key, DependencyManagement.Values]) { (acc, elem) =>
         DepMgmt.addSeq(acc, elem, composeValues = enableDependencyOverrides)
       }
-
-    val retainedParentDepsSet = retainedParentDeps.toSet
 
     project0
       .withPackagingOpt(project0.packagingOpt.map(_.map(substituteProps(_, propertiesMap0))))

--- a/modules/coursier/shared/src/main/scala/coursier/Resolve.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/Resolve.scala
@@ -97,6 +97,8 @@ import scala.language.higherKinds
 
   def addDependencies(dependencies: Dependency*): Resolve[F] =
     withDependencies(this.dependencies ++ dependencies)
+  def addBomDependencies(bomDependencies: Dependency*): Resolve[F] =
+    withBomDependencies(this.bomDependencies ++ bomDependencies)
 
   def addRepositories(repositories: Repository*): Resolve[F] =
     withRepositories(this.repositories ++ repositories)
@@ -150,7 +152,8 @@ import scala.language.higherKinds
       finalDependencies,
       resolutionParams,
       initialResolution,
-      mapDependenciesOpt
+      mapDependenciesOpt,
+      bomDependencies
     )
 
     def run(res: Resolution): F[Resolution] = {
@@ -261,7 +264,8 @@ object Resolve extends PlatformResolve {
     dependencies: Seq[Dependency],
     params: ResolutionParams = ResolutionParams(),
     initialResolutionOpt: Option[Resolution] = None,
-    mapDependenciesOpt: Option[Dependency => Dependency] = None
+    mapDependenciesOpt: Option[Dependency => Dependency] = None,
+    bomDependencies: Seq[Dependency] = Nil
   ): Resolution = {
     import coursier.core.{Resolution => CoreResolution}
 
@@ -377,6 +381,7 @@ object Resolve extends PlatformResolve {
       .withEnableDependencyOverrides(
         params.enableDependencyOverrides.getOrElse(Resolution.enableDependencyOverridesDefault)
       )
+      .withBomDependencies(bomDependencies)
   }
 
   private[coursier] def runProcess[F[_]](

--- a/modules/coursier/shared/src/test/scala/coursier/tests/ResolveTests.scala
+++ b/modules/coursier/shared/src/test/scala/coursier/tests/ResolveTests.scala
@@ -1427,5 +1427,48 @@ object ResolveTests extends TestSuite {
         androiCheck(dep"androidx.compose.material3:material3:1.0.1")
       }
     }
+
+    test("bom") {
+
+      def bomCheck(bomDependencies: Dependency*)(dependencies: Dependency*): Future[Unit] =
+        async {
+          val res = await {
+            resolve
+              .addDependencies(dependencies: _*)
+              .addBomDependencies(bomDependencies: _*)
+              .future()
+          }
+          await(validateDependencies(res))
+        }
+
+      test("spark-parent") {
+        test {
+          bomCheck(dep"org.apache.spark:spark-parent_2.13:3.5.3")(
+            dep"org.apache.commons:commons-lang3:_"
+          )
+        }
+        test {
+          bomCheck(dep"org.apache.spark:spark-parent_2.13:3.5.3")(
+            dep"org.glassfish.jaxb:jaxb-runtime:_"
+          )
+        }
+        test {
+          bomCheck(dep"org.apache.spark:spark-parent_2.13:3.5.3")(
+            dep"org.apache.logging.log4j:log4j-core:_"
+          )
+        }
+      }
+
+      test("quarkus-bom") {
+        test("disabled") {
+          check(dep"ch.epfl.scala:bsp4j:2.2.0-M2")
+        }
+        test("enabled") {
+          bomCheck(dep"io.quarkus:quarkus-bom:3.16.2")(
+            dep"ch.epfl.scala:bsp4j:2.2.0-M2"
+          )
+        }
+      }
+    }
   }
 }

--- a/modules/coursier/shared/src/test/scala/coursier/tests/TestHelpers.scala
+++ b/modules/coursier/shared/src/test/scala/coursier/tests/TestHelpers.scala
@@ -72,13 +72,13 @@ object TestHelpers extends PlatformTestHelpers {
             }
             .mkString("_")
 
-    val hashPart =
+    val dependenciesHashPart =
       if (isSimple) ""
       else {
         val repr =
           if (res.rootDependencies.lengthCompare(1) == 0) res.rootDependencies.head.toString
           else res.rootDependencies.toString
-        s"_dep" + sha1(repr)
+        "_dep" + sha1(repr)
       }
 
     val paramsPart =
@@ -121,7 +121,7 @@ object TestHelpers extends PlatformTestHelpers {
           ""
         else
           "_" + rootDep.configuration.value.replace('(', '_').replace(')', '_')
-      ) + hashPart + paramsPart + extraKeyPart
+      ) + dependenciesHashPart + paramsPart + extraKeyPart
     ).filter(_.nonEmpty).mkString("/")
 
     def tryRead = textResource(path)

--- a/modules/coursier/shared/src/test/scala/coursier/tests/TestHelpers.scala
+++ b/modules/coursier/shared/src/test/scala/coursier/tests/TestHelpers.scala
@@ -81,6 +81,10 @@ object TestHelpers extends PlatformTestHelpers {
         "_dep" + sha1(repr)
       }
 
+    val bomDependenciesHashPart =
+      if (res.bomDependencies.isEmpty) ""
+      else "_bomDep" + sha1(res.bomDependencies.toString)
+
     val paramsPart =
       if (params == ResolutionParams())
         ""
@@ -121,7 +125,7 @@ object TestHelpers extends PlatformTestHelpers {
           ""
         else
           "_" + rootDep.configuration.value.replace('(', '_').replace(')', '_')
-      ) + dependenciesHashPart + paramsPart + extraKeyPart
+      ) + dependenciesHashPart + bomDependenciesHashPart + paramsPart + extraKeyPart
     ).filter(_.nonEmpty).mkString("/")
 
     def tryRead = textResource(path)

--- a/modules/tests/shared/src/test/resources/resolutions/ch.epfl.scala/bsp4j/2.2.0-M2
+++ b/modules/tests/shared/src/test/resources/resolutions/ch.epfl.scala/bsp4j/2.2.0-M2
@@ -1,0 +1,14 @@
+ch.epfl.scala:bsp4j:2.2.0-M2:default
+org.eclipse.lsp4j:org.eclipse.lsp4j.generator:0.20.1:default
+org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc:0.20.1:default
+org.eclipse.xtend:org.eclipse.xtend.lib:2.28.0:default
+com.google.code.gson:gson:2.10.1:default
+org.eclipse.xtext:org.eclipse.xtext.xbase.lib:2.28.0:default
+org.eclipse.xtend:org.eclipse.xtend.lib.macro:2.28.0:default
+com.google.guava:guava:30.1-jre:default
+com.google.guava:failureaccess:1.0.1:default
+com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava:default
+com.google.code.findbugs:jsr305:3.0.2:default
+org.checkerframework:checker-qual:3.5.0:default
+com.google.errorprone:error_prone_annotations:2.3.4:default
+com.google.j2objc:j2objc-annotations:1.3:default

--- a/modules/tests/shared/src/test/resources/resolutions/ch.epfl.scala/bsp4j/2.2.0-M2_bomDepac989e697e6504a4cfc90a4f007b5ce4dbe9a7b7
+++ b/modules/tests/shared/src/test/resources/resolutions/ch.epfl.scala/bsp4j/2.2.0-M2_bomDepac989e697e6504a4cfc90a4f007b5ce4dbe9a7b7
@@ -1,0 +1,12 @@
+ch.epfl.scala:bsp4j:2.2.0-M2:default
+org.eclipse.lsp4j:org.eclipse.lsp4j.generator:0.20.1:default
+org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc:0.20.1:default
+org.eclipse.xtend:org.eclipse.xtend.lib:2.28.0:default
+com.google.code.gson:gson:2.11.0:default
+org.eclipse.xtext:org.eclipse.xtext.xbase.lib:2.28.0:default
+org.eclipse.xtend:org.eclipse.xtend.lib.macro:2.28.0:default
+com.google.errorprone:error_prone_annotations:2.33.0:default
+com.google.guava:guava:33.3.1-jre:default
+com.google.guava:failureaccess:1.0.1:default
+org.checkerframework:checker-qual:3.48.1:default
+com.google.j2objc:j2objc-annotations:2.8:default

--- a/modules/tests/shared/src/test/resources/resolutions/org.apache.commons/commons-lang3/__bomDep5cb30d942de2ced5ee12ef2c311a1727772f57db
+++ b/modules/tests/shared/src/test/resources/resolutions/org.apache.commons/commons-lang3/__bomDep5cb30d942de2ced5ee12ef2c311a1727772f57db
@@ -1,0 +1,1 @@
+org.apache.commons:commons-lang3:3.12.0:default

--- a/modules/tests/shared/src/test/resources/resolutions/org.apache.logging.log4j/log4j-core/__bomDep5cb30d942de2ced5ee12ef2c311a1727772f57db
+++ b/modules/tests/shared/src/test/resources/resolutions/org.apache.logging.log4j/log4j-core/__bomDep5cb30d942de2ced5ee12ef2c311a1727772f57db
@@ -1,0 +1,2 @@
+org.apache.logging.log4j:log4j-core:2.20.0:default
+org.apache.logging.log4j:log4j-api:2.20.0:default

--- a/modules/tests/shared/src/test/resources/resolutions/org.glassfish.jaxb/jaxb-runtime/__bomDep5cb30d942de2ced5ee12ef2c311a1727772f57db
+++ b/modules/tests/shared/src/test/resources/resolutions/org.glassfish.jaxb/jaxb-runtime/__bomDep5cb30d942de2ced5ee12ef2c311a1727772f57db
@@ -1,0 +1,7 @@
+org.glassfish.jaxb:jaxb-runtime:2.3.2:default
+jakarta.xml.bind:jakarta.xml.bind-api:2.3.2:default
+org.glassfish.jaxb:txw2:2.3.2:default
+com.sun.istack:istack-commons-runtime:3.0.8:default
+org.jvnet.staxex:stax-ex:1.8.1:default
+com.sun.xml.fastinfoset:FastInfoset:1.2.16:default
+jakarta.activation:jakarta.activation-api:1.2.1:default


### PR DESCRIPTION
This allows coursier users to pass coordinates of a "BOM" to be used during resolution. The BOM is basically a POM file containing versions (and exclusions too) of dependencies, meant to override versions (and for exclusions, be added) pulled during resolutions.

From the API, users can add BOM coordinates like
```scala
Resolve()
  .addBomDependencies(dep"io.quarkus:quarkus-bom:3.16.2")
// or
Fetch()
  .addBomDependencies(dep"io.quarkus:quarkus-bom:3.16.2")
```

From the CLI, users can use the `--bom` option, like
```text
$ cs resolve --bom io.quarkus:quarkus-bom:3.16.2 org:name:version
```

Both from the API and the CLI, root dependencies can have `_` as a version. In that case, the version is read from the BOM:
```text
$ cs resolve com.google.code.gson:gson:_ --bom io.quarkus:quarkus-bom:3.16.2
```