### PR TITLE
Use Java 21 on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     - uses: coursier/cache-action@v6.4
     - uses: coursier/setup-action@v1.3
       with:
-        jvm: 17
+        jvm: 21
     - run: ./mill -i __.compile
 
   compile-all-no-package-object:
@@ -47,7 +47,7 @@ jobs:
     - uses: coursier/cache-action@v6.4
     - uses: coursier/setup-action@v1.3
       with:
-        jvm: 17
+        jvm: 21
     - run: |
         test -e modules/coursier/shared/src/main/scala/coursier/package.scala
         rm -f modules/coursier/shared/src/main/scala/coursier/package.scala
@@ -79,7 +79,7 @@ jobs:
     - uses: coursier/cache-action@v6.4
     - uses: coursier/setup-action@v1.3
       with:
-        jvm: 17
+        jvm: 21
     - run: sudo apt-get install -y nailgun
       if: runner.os == 'Linux'
     # - run: .github/scripts/scala-native-setup.sh
@@ -113,7 +113,7 @@ jobs:
     - uses: coursier/cache-action@v6.4
     - uses: coursier/setup-action@v1.3
       with:
-        jvm: 17
+        jvm: 21
     - run: npm install && ./mill -i jsTests --scalaVersion "$SCALA_VERSION"
       shell: bash
       env:
@@ -130,7 +130,7 @@ jobs:
     - uses: coursier/cache-action@v6.4
     - uses: coursier/setup-action@v1.3
       with:
-        jvm: 17
+        jvm: 21
     - run: ./mill -i -k __.mimaReportBinaryIssues
 
   website-check:
@@ -152,7 +152,7 @@ jobs:
     - uses: coursier/cache-action@v6.4
     - uses: coursier/setup-action@v1.3
       with:
-        jvm: 17
+        jvm: 21
     - run: ./mill -i doc.generate --npm-install --yarn-run-build
       env:
         COURSIER_JNI: force
@@ -167,7 +167,7 @@ jobs:
     - uses: coursier/cache-action@v6.4
     - uses: coursier/setup-action@v1.3
       with:
-        jvm: 17
+        jvm: 21
         apps: scalafmt:3.8.3
     - run: scalafmt --check
 
@@ -186,7 +186,7 @@ jobs:
           PGP_SECRET: ${{ secrets.PUBLISH_SECRET_KEY }}
       - uses: coursier/setup-action@v1.3
         with:
-          jvm: 17
+          jvm: 21
       - run: |
           mv .mill-jvm-opts .mill-jvm-opts.bak
           cat .mill-jvm-opts.bak | grep -v -- '-Xmx' > .mill-jvm-opts
@@ -222,7 +222,7 @@ jobs:
       - uses: coursier/cache-action@v6.4
       - uses: coursier/setup-action@v1.3
         with:
-          jvm: 17
+          jvm: 21
       - run: sudo apt-get install -y nailgun
         if: runner.os == 'Linux'
       - run: .github/scripts/maybe-with-graalvm-home.sh nativeTests
@@ -255,7 +255,7 @@ jobs:
       - uses: coursier/cache-action@v6.4
       - uses: coursier/setup-action@v1.3
         with:
-          jvm: 17
+          jvm: 21
       - run: sudo apt-get install -y nailgun
         if: runner.os == 'Linux'
       - run: .github/scripts/maybe-with-graalvm-home.sh nativeStaticTests
@@ -285,7 +285,7 @@ jobs:
       - uses: coursier/cache-action@v6.4
       - uses: coursier/setup-action@v1.3
         with:
-          jvm: 17
+          jvm: 21
       - run: sudo apt-get install -y nailgun
         if: runner.os == 'Linux'
       - run: .github/scripts/maybe-with-graalvm-home.sh nativeMostlyStaticTests
@@ -315,7 +315,7 @@ jobs:
       - uses: coursier/cache-action@v6.4
       - uses: coursier/setup-action@v1.3
         with:
-          jvm: 17
+          jvm: 21
       - run: sudo apt-get install -y nailgun
         if: runner.os == 'Linux'
       - run: .github/scripts/maybe-with-graalvm-home.sh nativeContainerTests
@@ -347,7 +347,7 @@ jobs:
     - uses: coursier/cache-action@v6.4
     - uses: coursier/setup-action@v1.3
       with:
-        jvm: 17
+        jvm: 21
     - name: Wait for sync to Central
       run: ./mill -i waitForSync
     - name: Copy artifacts
@@ -376,7 +376,7 @@ jobs:
     - uses: coursier/cache-action@v6.4
     - uses: coursier/setup-action@v1.3
       with:
-        jvm: 17
+        jvm: 21
     - uses: actions/download-artifact@v4
       with:
         name: launchers-linux
@@ -426,7 +426,7 @@ jobs:
       - uses: coursier/cache-action@v6.4
       - uses: coursier/setup-action@v1.3
         with:
-          jvm: 17
+          jvm: 21
       - run: .github/scripts/scala-cli.sh .github/scripts/UpdateBrewFormula.scala
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -447,7 +447,7 @@ jobs:
       - uses: coursier/cache-action@v6.4
       - uses: coursier/setup-action@v1.3
         with:
-          jvm: 17
+          jvm: 21
       - run: npm install && export PATH="$PATH:$(pwd)/node_modules/bower/bin" && ./mill -i updateWebsite
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -468,7 +468,7 @@ jobs:
       - uses: coursier/cache-action@v6.4
       - uses: coursier/setup-action@v1.3
         with:
-          jvm: 17
+          jvm: 21
       - run: npm install && export PATH="$PATH:$(pwd)/node_modules/bower/bin" && ./mill -i updateWebsite
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/modules/cli-tests/src/main/scala/coursier/clitests/BootstrapTests.scala
+++ b/modules/cli-tests/src/main/scala/coursier/clitests/BootstrapTests.scala
@@ -1126,6 +1126,7 @@ abstract class BootstrapTests extends TestSuite with LauncherOptions {
         os.write(
           appSource,
           """//> using scala "2.13.10"
+            |//> using jvm "17"
             |//> using lib "io.get-coursier.jniutils:windows-jni-utils:0.3.3"
             |//> using publish.organization "io.get-coursier.tests"
             |//> using publish.name "test-app"

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -75,7 +75,7 @@ def sbtCoursierVersion = "2.1.4"
 def graalVmVersion = "22.3.0"
 def graalVmJvmId   = s"graalvm-java17:$graalVmVersion"
 
-def scalaCliVersion = "1.0.0-RC1"
+def scalaCliVersion = "1.5.1"
 
 // should be the default index in the upcoming coursier release (> 2.0.16)
 def jvmIndex = "https://github.com/coursier/jvm-index/raw/master/index.json"


### PR DESCRIPTION
Don't know if there's a reason _not_ to do that… 🤔

https://github.com/coursier/coursier/pull/3137 should ensure the published artifacts are still compatible with Java 8