### PR TITLE
Add extra installation instruction for ARM64 Windows

### DIFF
--- a/doc/docs/cli-installation.md
+++ b/doc/docs/cli-installation.md
@@ -65,6 +65,8 @@ $ cs setup
 
 ### Windows
 
+> For ARM64 Windows users, please follow **JAR-based launcher** section. The Windows installer currently only installs x86_64 build of Coursier.
+
 On Windows, [download and execute the Windows installer](https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-win32.zip).
 
 If you prefer a command line-based install, or if you would like to customize the setup options, use:


### PR DESCRIPTION
Currently the Windows installer installs x86_64 build of Coursier, which then installs x86_64 version of Java by default causing every coursier installed JVM app to be slower as they use the installed x86_64 Java.

To mitigate this we should warn against using x86_64 Coursier installer to avoid emulation overhead.