### PR TITLE
Use dependency library to parse dependencies and modules

### DIFF
--- a/modules/coursier/shared/src/main/scala/coursier/parse/DependencyParser.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/parse/DependencyParser.scala
@@ -15,7 +15,14 @@ import coursier.core.{
 import coursier.core.Validation._
 import coursier.util.ValidationNel
 import coursier.util.Traverse._
+import dependency.{NoAttributes, ScalaNameAttributes}
+import dependency.parser.{DependencyParser => DepParser}
 
+import scala.collection.mutable
+
+/** These are not meant to be used by coursier users. Better coursier/dependency based parsers to
+  * come.
+  */
 object DependencyParser {
 
   def dependency(
@@ -102,11 +109,11 @@ object DependencyParser {
    * @return A string if there is an error, otherwise None
    */
   private def validateAttributes(
-    attrs: Map[String, Seq[String]],
+    attrs: Set[String],
     dep: String,
     validAttrsKeys: Set[String]
   ): Option[String] = {
-    val extraAttributes = attrs.keys.toSet.diff(validAttrsKeys)
+    val extraAttributes = attrs.diff(validAttrsKeys)
 
     if (attrs.size > validAttrsKeys.size || extraAttributes.nonEmpty)
       Some(
@@ -140,206 +147,21 @@ object DependencyParser {
   def javaOrScalaDependencyParams(
     input: String,
     defaultConfiguration: Configuration
-  ): Either[String, (JavaOrScalaDependency, Map[String, String])] = {
-
-    // FIXME Fails to parse dependencies with version intervals, because of the comma in the interval
-    // e.g. "joda-time:joda-time:[2.2,2.8]"
-
-    // Assume org:name:version,attr1=val1,attr2=val2
-    // That is ',' has to go after ':'.
-    // E.g. "org:name,attr1=val1,attr2=val2:version:config" is illegal.
-    val attrSeparator = ","
-    val argSeparator  = ":"
-
-    def splitRest(rest: String): (String, Seq[String]) = {
-
-      def split(rest: String) =
-        // match is total
-        rest.split(attrSeparator) match {
-          case Array(coordsEnd, attrs @ _*) => (coordsEnd, attrs)
+  ): Either[String, (JavaOrScalaDependency, Map[String, String])] =
+    for {
+      anyDep <- DepParser.parse(input, acceptInlineConfiguration = true)
+      dep    <- JavaOrScalaDependency.from(anyDep)
+      map = JavaOrScalaDependency.leftOverUserParams(anyDep)
+        .map {
+          case (k, v) =>
+            (k, v.getOrElse(""))
         }
-
-      if (rest.startsWith("[") || rest.startsWith("(")) {
-        val idx = rest.indexWhere(c => c == ']' || c == ')')
-        if (idx < 0)
-          split(rest)
-        else {
-          val (ver, attrsPart)  = rest.splitAt(idx + 1)
-          val (coodsEnd, attrs) = split(attrsPart)
-          (ver + coodsEnd, attrs)
-        }
-      }
-      else
-        split(rest)
-    }
-
-    val (coords, rawAttrs) = input.split(":", 6) match {
-      case Array(org, "", "", name, "", rest) =>
-        val (coordsEnd, attrs) = splitRest(rest)
-        (s"$org:::$name::$coordsEnd", attrs)
-      case Array(org, "", name, "", rest) =>
-        val (coordsEnd, attrs) = splitRest(rest)
-        (s"$org::$name::$coordsEnd", attrs)
-      case Array(org, "", "", name, rest) =>
-        val (coordsEnd, attrs) = splitRest(rest)
-        (s"$org:::$name:$coordsEnd", attrs)
-      case Array(org, "", name, rest) =>
-        val (coordsEnd, attrs) = splitRest(rest)
-        (s"$org::$name:$coordsEnd", attrs)
-      case Array(org, name, rest @ _*) =>
-        val (coordsEnd, attrs) = splitRest(rest.mkString(":"))
-        (s"$org:$name:$coordsEnd", attrs)
-    }
-
-    val attrsOrErrors = rawAttrs
-      .map { x =>
-        if (x.contains(argSeparator))
-          Left(s"'$argSeparator' is not allowed in attribute '$x' in '$input'. Please follow the format " +
-            s"'org${argSeparator}name[${argSeparator}version][${argSeparator}config]${attrSeparator}attr1=val1${attrSeparator}attr2=val2'")
-        else
-          x.split("=") match {
-            case Array(k, v) =>
-              Right(k -> v)
-            case _ =>
-              Left(
-                s"Failed to parse attribute '$x' in '$input'. Keyword argument expected such as 'classifier=tests'"
-              )
-          }
-      }
-
-    attrsOrErrors
-      .collectFirst {
-        case Left(err) =>
-          // FIXME We're dropping other errors here (use validation in return type?)
-          Left(err)
-      }
-      .getOrElse {
-
-        val attrs = attrsOrErrors
-          .collect {
-            case Right(attr) => attr
-          }
-          .groupBy(_._1)
-          .map {
-            case (k, l) =>
-              k -> l.map(_._2)
-          }
-
-        val parts = coords.split(":", -1)
-
-        // Only attributes allowed
-        val validAttrsKeys = Set("classifier", "ext", "type", "url", "exclude")
-
-        validateAttributes(attrs, input, validAttrsKeys) match {
-          case Some(err) => Left(err)
-          case None =>
-            val type0 = attrs
-              .get("type")
-              .map(_.last)
-              .map(Type(_))
-              .getOrElse(Type.empty)
-            val ext = attrs
-              .get("ext")
-              .map(_.last)
-              .map(Extension(_))
-              .getOrElse(Extension.empty)
-            val classifier = attrs
-              .get("classifier")
-              .map(_.last)
-              .map(Classifier(_))
-              .getOrElse(Classifier.empty)
-            val publication = Publication("", type0, ext, classifier)
-            val excludeOpt = attrs
-              .get("exclude")
-              .map(_.eitherTraverse { s =>
-                // not using : to split, which would mess up with the parser
-                // Using a proper parsing library would help support ':'.
-                s.split("%", 2) match {
-                  case Array(o, n) =>
-                    for {
-                      org  <- validateCoordinate(o, "organization")
-                      name <- validateCoordinate(n, "module name")
-                    } yield (Organization(o), ModuleName(n))
-                  case _ => Left(s"Malformed exclusion: '$s' (expected 'org%name')")
-                }
-              })
-              .getOrElse(Right(Nil))
-              .map(_.toSet)
-
-            val extraDependencyParams: Map[String, String] = attrs.get("url").map(_.last) match {
-              case Some(url) => Map("url" -> url)
-              case None      => Map()
-            }
-
-            val dummyModule = Module(Organization(""), ModuleName(""), Map.empty)
-
-            val parts0 = parts match {
-              case Array(org, "", "", rawName, "", version, config) =>
-                Right((org, rawName, version, Configuration(config), ":::", true))
-
-              case Array(org, "", "", rawName, "", version) =>
-                Right((org, rawName, version, defaultConfiguration, ":::", true))
-
-              case Array(org, "", rawName, "", version, config) =>
-                Right((org, rawName, version, Configuration(config), "::", true))
-
-              case Array(org, "", rawName, "", version) =>
-                Right((org, rawName, version, defaultConfiguration, "::", true))
-
-              case Array(org, "", "", rawName, version, config) =>
-                Right((org, rawName, version, Configuration(config), ":::", false))
-
-              case Array(org, "", "", rawName, version) =>
-                Right((org, rawName, version, defaultConfiguration, ":::", false))
-
-              case Array(org, "", rawName, version, config) =>
-                Right((org, rawName, version, Configuration(config), "::", false))
-
-              case Array(org, "", rawName, version) =>
-                Right((org, rawName, version, defaultConfiguration, "::", false))
-
-              case Array(org, rawName, version, config) =>
-                Right((org, rawName, version, Configuration(config), ":", false))
-
-              case Array(org, rawName, version) =>
-                Right((org, rawName, version, defaultConfiguration, ":", false))
-
-              case _ =>
-                Left(s"Malformed dependency: $input")
-            }
-
-            parts0.flatMap {
-              case (org, rawName, version, config, orgNameSep, withPlatformSuffix) =>
-                for {
-                  exclude <- excludeOpt
-                  version <- validateCoordinate(version, "version")
-                  module  <- ModuleParser.javaOrScalaModule(s"$org$orgNameSep$rawName")
-                } yield {
-                  val dep = Dependency(
-                    dummyModule,
-                    version,
-                    config,
-                    exclude,
-                    publication,
-                    optional = false,
-                    transitive = true
-                  )
-                  val dep0 = JavaOrScalaDependency(module, dep)
-                  val dep1 =
-                    if (withPlatformSuffix)
-                      dep0 match {
-                        case j: JavaOrScalaDependency.JavaDependency => j
-                        case s: JavaOrScalaDependency.ScalaDependency =>
-                          s.withWithPlatformSuffix(true)
-                      }
-                    else
-                      dep0
-                  (dep1, extraDependencyParams)
-                }
-            }
-        }
-      }
-  }
+        .toMap
+      _ <- validateAttributes(map.keySet, input, Set("url", "bom")).toLeft(())
+    } yield (
+      dep,
+      JavaOrScalaDependency.leftOverUserParams(anyDep).map { case (k, v) => (k, v.getOrElse("")) }.toMap
+    )
 
   /** Parses coordinates like org:name:version with attributes, like
     * org:name:version,attr1=val1,attr2=val2 and a configuration, like org:name:version:config or

--- a/modules/coursier/shared/src/test/scala/coursier/tests/parse/DependencyParserTests.scala
+++ b/modules/coursier/shared/src/test/scala/coursier/tests/parse/DependencyParserTests.scala
@@ -208,7 +208,7 @@ object DependencyParserTests extends TestSuite {
           assert(dep.attributes == Attributes(Type.empty, Classifier.tests))
           assert(extraParams.isDefinedAt("url"))
           assert(extraParams.getOrElse("url", "") == url)
-          assert(dep.exclusions == Set((org"org", name"nme")))
+          assert(dep.minimizedExclusions.toSet() == Set((org"org", name"nme")))
       }
     }
 
@@ -254,7 +254,7 @@ object DependencyParserTests extends TestSuite {
           assert(dep.module.name.value.contains("sandbox_native0.3"))
           assert(dep.version == "[0.3.0,0.4.0)")
           assert(dep.attributes == Attributes(Type.empty, Classifier.tests))
-          assert(dep.exclusions == Set((org"foo", name"bar")))
+          assert(dep.minimizedExclusions.toSet() == Set((org"foo", name"bar")))
       }
     }
 
@@ -278,7 +278,7 @@ object DependencyParserTests extends TestSuite {
           assert(dep.module.organization == org"com.lihaoyi")
           assert(dep.module.name.value == "ammonite_2.12.8")
           assert(dep.version == "1.6.7")
-          assert(dep.exclusions == Set((org"aa", name"*")))
+          assert(dep.minimizedExclusions.toSet() == Set((org"aa", name"*")))
       }
     }
 

--- a/modules/coursier/shared/src/test/scala/coursier/tests/parse/DependencyParserTests.scala
+++ b/modules/coursier/shared/src/test/scala/coursier/tests/parse/DependencyParserTests.scala
@@ -194,7 +194,7 @@ object DependencyParserTests extends TestSuite {
       }
     }
 
-    test("multiple attrs with interval, url, and exclusions") {
+    test("multiple attrs with interval url and exclusions") {
       DependencyParser.dependencyParams(
         "org.apache.avro:avro:[1.7,1.8):runtime,classifier=tests,url=" + url + ",exclude=org%nme",
         "2.11.11"
@@ -221,7 +221,7 @@ object DependencyParserTests extends TestSuite {
         case Right((dep, _)) =>
           assert(dep.module.organization == org"io.get-coursier.scala-native")
           // use `contains` to be scala version agnostic
-          assert(dep.module.name.value.contains("sandbox_native0.3"))
+          assert(dep.module.name.value.contains("sandbox_native0.3_"))
           assert(dep.version == "0.3.0-coursier-1")
           assert(dep.attributes == Attributes(Type.empty, Classifier.tests))
       }
@@ -283,8 +283,8 @@ object DependencyParserTests extends TestSuite {
     }
 
     test("illegal 1") {
-      DependencyParser.dependencyParams("junit:junit:4.12,attr", "2.11.11") match {
-        case Left(err)  => assert(err.contains("Failed to parse attribute"))
+      DependencyParser.dependencyParams("junit:junit:4.12,classifier", "2.11.11") match {
+        case Left(err)  => assert(err.contains("Invalid empty classifier attribute"))
         case Right(dep) => assert(false)
       }
     }
@@ -296,9 +296,9 @@ object DependencyParserTests extends TestSuite {
       }
     }
 
-    test("illegal 3, malformed exclude") {
+    test("illegal 3 malformed exclude") {
       DependencyParser.dependencyParams("a:b:c,exclude=aaa", "2.11.11") match {
-        case Left(err)  => assert(err.contains("Malformed exclusion:"))
+        case Left(err)  => assert(err.contains("Unrecognized excluded module"))
         case Right(dep) => assert(false)
       }
     }

--- a/modules/coursier/shared/src/test/scala/coursier/tests/util/ModuleMatcherTests.scala
+++ b/modules/coursier/shared/src/test/scala/coursier/tests/util/ModuleMatcherTests.scala
@@ -1,5 +1,6 @@
 package coursier.tests.util
 
+import coursier.core.Module
 import coursier.util._
 import coursier.util.StringInterpolators._
 import utest._
@@ -75,9 +76,9 @@ object ModuleMatcherTests extends TestSuite {
         mod"io.foo:foo-core_2.11",
         mod"io.foo:foo-core",
         mod"io.fooo:foo-core_2.12",
-        mod":",
-        mod"io.fooo:",
-        mod":foo-core_2.12"
+        Module(org"", name"", Map.empty),
+        Module(org"io.fooo", name"", Map.empty),
+        Module(org"", name"foo-core_2.12", Map.empty)
       )
 
       for (m <- shouldMatch)

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -38,7 +38,7 @@ object Deps {
   // plexus-archiver needs its loggers
   def plexusContainerDefault = ivy"org.codehaus.plexus:plexus-container-default:2.1.1"
     .exclude("junit" -> "junit")
-  def pprint                   = ivy"com.lihaoyi::pprint:0.9.0"
+  def pprint                   = ivy"com.lihaoyi::pprint::0.9.0"
   def proguard                 = ivy"com.guardsquare:proguard-base:7.6.0"
   def pythonNativeLibs         = ivy"ai.kien::python-native-libs:0.2.4"
   def scalaAsync               = ivy"org.scala-lang.modules::scala-async::1.0.1"

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -11,6 +11,7 @@ object Deps {
   def concurrentReferenceHashMap =
     ivy"io.github.alexarchambault:concurrent-reference-hash-map:1.1.0"
   def dataClass         = ivy"io.github.alexarchambault::data-class:0.2.6"
+  def dependency        = ivy"io.get-coursier::dependency::0.3.1"
   def diffUtils         = ivy"io.github.java-diff-utils:java-diff-utils:4.12"
   def dockerClient      = ivy"com.spotify:docker-client:8.16.0"
   def fastParse         = ivy"com.lihaoyi::fastparse::${Versions.fastParse}"

--- a/project/modules/coursier0.sc
+++ b/project/modules/coursier0.sc
@@ -13,6 +13,7 @@ trait Coursier extends CsModule with CsCrossJvmJsModule with CoursierPublishModu
     Deps.scalaReflect(scalaVersion()) // ???
   )
   def ivyDeps = super.ivyDeps() ++ Agg(
+    Deps.dependency,
     Deps.fastParse,
     Deps.jsoniterCore
   )


### PR DESCRIPTION
This pulls [coursier/dependency](https://github.com/coursier/dependency), and uses it internally to parse dependencies. Some more thinking is needed to use it in the user facing API, at a later time.

My goal here is to later allow repeated parameters to be added in dependency strings, like `org:name:version,bom=org.apache.spark%spark-parent_2.13%3.5.3,bom=io.quarkus%quarkus-bom%3.16.2`