### PR TITLE
Undeprecate JvmIndex#load overload

### DIFF
--- a/modules/jvm/src/main/scala/coursier/jvm/JvmIndex.scala
+++ b/modules/jvm/src/main/scala/coursier/jvm/JvmIndex.scala
@@ -179,7 +179,6 @@ object JvmIndex {
         }
     }
 
-  @deprecated("Use the override accepting os and arch", "2.1.15")
   def load(
     cache: Cache[Task],
     repositories: Seq[Repository],


### PR DESCRIPTION
That overload is fine to use, users shouldn't need to provide values for `os` and `arch` when they don't need to