### PR TITLE
Add coursier.core.Type.Exotic.aar

### DIFF
--- a/modules/core/shared/src/main/scala/coursier/core/Definitions.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Definitions.scala
@@ -125,6 +125,9 @@ object Type {
 
     // Kotlin stuff
     val klib = Type("klib")
+
+    // Android thing
+    val aar = Type("aar")
   }
 }
 


### PR DESCRIPTION
For Android's `aar` packaging

Not added in artifact types pulled by default