### PR TITLE
Leave pprint setup in shading config

### DIFF
--- a/project/modules/core0.sc
+++ b/project/modules/core0.sc
@@ -57,12 +57,14 @@ trait CoreJvmBase extends Core with CsMima with Shading {
     )
 
   def shadedDependencies = Agg(
-    Deps.fastParse
+    Deps.fastParse,
+    Deps.pprint
   )
   def validNamespaces = Seq("coursier")
   def shadeRenames = Seq(
     "fastparse.**"  -> "coursier.core.shaded.fastparse.@1",
     "geny.**"       -> "coursier.core.shaded.geny.@1",
-    "sourcecode.**" -> "coursier.core.shaded.sourcecode.@1"
+    "sourcecode.**" -> "coursier.core.shaded.sourcecode.@1",
+    "pprint.**"     -> "coursier.core.shaded.pprint.@1"
   )
 }

--- a/project/modules/coursier0.sc
+++ b/project/modules/coursier0.sc
@@ -40,12 +40,14 @@ trait CoursierJvmBase extends Coursier with CsMima with Shading {
     )
 
   def shadedDependencies = Agg(
-    Deps.fastParse
+    Deps.fastParse,
+    Deps.pprint
   )
   def validNamespaces = Seq("coursier")
   def shadeRenames = Seq(
     "fastparse.**"  -> "coursier.internal.shaded.fastparse.@1",
     "geny.**"       -> "coursier.internal.shaded.geny.@1",
-    "sourcecode.**" -> "coursier.internal.shaded.sourcecode.@1"
+    "sourcecode.**" -> "coursier.internal.shaded.sourcecode.@1",
+    "pprint.**"     -> "coursier.internal.shaded.pprint.@1"
   )
 }


### PR DESCRIPTION
So that pprint isn't added by default, but adding it doesn't break shading (which creates class not found exceptions at runtime, when using coursier artifacts published locally)