### PR TITLE
Fix CI by pinning scalafmt version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
     - uses: coursier/setup-action@v1.3
       with:
         jvm: 17
-        apps: scalafmt
+        apps: scalafmt:3.8.3
     - run: scalafmt --check
 
   publish:


### PR DESCRIPTION
To work around https://github.com/scalameta/scalafmt/issues/4571