### PR TITLE
Tweak Maven scopes handling

### DIFF
--- a/modules/core/shared/src/main/scala/coursier/core/Orders.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Orders.scala
@@ -41,7 +41,7 @@ object Orders {
     configurations
       .keys
       .toList
-      .map(config => config -> (allParents(config) - config))
+      .map(config => config -> allParents(config))
       .toMap
   }
 

--- a/modules/core/shared/src/main/scala/coursier/core/Resolution.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Resolution.scala
@@ -511,25 +511,6 @@ object Resolution {
     (config0, parentConfigurations(config0, configurations))
   }
 
-  private val mavenScopes = {
-
-    val base = Map[Configuration, Set[Configuration]](
-      Configuration.compile -> Set(Configuration.compile),
-      Configuration.optional -> Set(
-        Configuration.compile,
-        Configuration.optional,
-        Configuration.runtime
-      ),
-      Configuration.provided -> Set(),
-      Configuration.runtime  -> Set(Configuration.compile, Configuration.runtime),
-      Configuration.test -> Set(Configuration.compile, Configuration.runtime, Configuration.test)
-    )
-
-    base ++ Seq(
-      Configuration.default -> base(Configuration.runtime)
-    )
-  }
-
   private def staticProjectProperties(project: Project): Seq[(String, String)] =
     // FIXME The extra properties should only be added for Maven projects, not Ivy ones
     Seq(
@@ -636,7 +617,7 @@ object Resolution {
     val withProvidedOpt =
       if (keepProvidedDependencies) Some(Configuration.provided)
       else None
-    val keepOpt = mavenScopes.get(actualConfig).map(_ ++ withProvidedOpt)
+    val keepOpt = project0.allConfigurations.get(actualConfig).map(_ ++ withProvidedOpt)
 
     withExclusions(
       // 2.1 & 2.2
@@ -997,7 +978,7 @@ object Resolution {
         bomProject.configurations
       )
       // adding the initial config too in case it's the "provided" config
-      keepConfigs = mavenScopes.getOrElse(bomConfig0, Set()) + bomConfig0
+      keepConfigs = bomProject.allConfigurations.getOrElse(bomConfig0, Set()) + bomConfig0
       entry <- withProperties(
         bomProject.dependencyManagement.filter {
           case (config, _) =>

--- a/modules/core/shared/src/main/scala/coursier/maven/Pom.scala
+++ b/modules/core/shared/src/main/scala/coursier/maven/Pom.scala
@@ -301,7 +301,7 @@ object Pom {
         finalProjModule,
         version,
         relocationDependencyOpt.toSeq ++ deps,
-        Map.empty,
+        Map.empty, // this is customized later on in MavenRepositoryInternal
         parentModuleOpt.map((_, parentVersionOpt.getOrElse(""))),
         depMgmts,
         properties,


### PR DESCRIPTION
Seems these were hard-coded in Resolution, making it impossible for users to customize some aspects of configuration handling