### PR TITLE
Add Variant and VariantSelector ADTs

### DIFF
--- a/modules/cli/src/main/scala/coursier/cli/fetch/JsonReport.scala
+++ b/modules/cli/src/main/scala/coursier/cli/fetch/JsonReport.scala
@@ -82,7 +82,7 @@ object JsonReport {
           )
         )
         if (proj.relocated)
-          Iterator(dep.module -> proj.dependencies.head._2)
+          Iterator(dep.module -> proj.dependencies0.head._2)
         else
           Iterator.empty
       }

--- a/modules/cli/src/main/scala/coursier/cli/util/LegacyJsonReport.scala
+++ b/modules/cli/src/main/scala/coursier/cli/util/LegacyJsonReport.scala
@@ -281,7 +281,7 @@ final case class JsonElem(
           case (mod, ver) =>
             JsonElem(
               Dependency(mod, ver)
-                .withConfiguration(Configuration.empty)
+                .withVariantSelector(VariantSelector.emptyConfiguration)
                 .clearExclusions
                 .withAttributes(Attributes.empty)
                 .withOptional(false)

--- a/modules/core/jvm/src/main/scala/coursier/maven/WritePom.scala
+++ b/modules/core/jvm/src/main/scala/coursier/maven/WritePom.scala
@@ -1,6 +1,6 @@
 package coursier.maven
 
-import coursier.core.{Configuration, Dependency, Project}
+import coursier.core.{Configuration, Dependency, Project, Variant}
 
 object WritePom {
 
@@ -47,13 +47,16 @@ object WritePom {
       // SCM
       // developers
         {
-          if (proj.dependencies.isEmpty)
+          if (proj.dependencies0.isEmpty)
             Nil
           else
             <dependencies>
               {
-                proj.dependencies.map {
-                  case (config, dep) =>
+                proj.dependencies0.map {
+                  case (variant, dep) =>
+                    val config = variant match {
+                      case c: Variant.Configuration => c.configuration
+                    }
                     dependencyNode(config, dep)
                 }
               }

--- a/modules/core/shared/src/main/scala/coursier/core/Definitions.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Definitions.scala
@@ -251,8 +251,7 @@ object Attributes {
 @data class Project(
   module: Module,
   version0: Version0,
-  // First String is configuration (scope for Maven)
-  dependencies: Seq[(Configuration, Dependency)],
+  dependencies0: Seq[(Variant, Dependency)],
   // For Maven, this is the standard scopes as an Ivy configuration
   configurations: Map[Configuration, Seq[Configuration]],
 
@@ -269,13 +268,43 @@ object Attributes {
     * having a wrong version in their metadata.
     */
   actualVersionOpt0: Option[Version0],
-  publications: Seq[(Configuration, Publication)],
+  publications0: Seq[(Variant, Publication)],
 
   // Extra infos, not used during resolution
   info: Info,
   @since("2.1.23")
   overrides: Overrides = Overrides.empty
 ) {
+
+  @deprecated("Use dependencies0 instead", "2.1.25")
+  def dependencies: Seq[(Configuration, Dependency)] =
+    dependencies0.map {
+      case (c: Variant.Configuration, dep) =>
+        (c.configuration, dep)
+    }
+  @deprecated("Use withDependencies0 instead", "2.1.25")
+  def withDependencies(newDependencies: Seq[(Configuration, Dependency)]): Project =
+    withDependencies0(
+      newDependencies.map {
+        case (config, dep) =>
+          (Variant.Configuration(config), dep)
+      }
+    )
+
+  @deprecated("Use publications0 instead", "2.1.25")
+  def publications: Seq[(Configuration, Publication)] =
+    publications0.map {
+      case (c: Variant.Configuration, pub) =>
+        (c.configuration, pub)
+    }
+  @deprecated("Use withPublications0 instead", "2.1.25")
+  def withPublications(newPublications: Seq[(Configuration, Publication)]): Project =
+    withPublications0(
+      newPublications.map {
+        case (config, pub) =>
+          (Variant.Configuration(config), pub)
+      }
+    )
 
   @deprecated("Use the override accepting Version-s instead", "2.1.25")
   def this(
@@ -299,7 +328,10 @@ object Attributes {
     this(
       module,
       Version0(version),
-      dependencies,
+      dependencies.map {
+        case (config, dep) =>
+          (Variant.Configuration(config), dep)
+      },
       configurations,
       parent.map { case (mod, ver) => (mod, Version0(ver)) },
       dependencyManagement,
@@ -310,7 +342,10 @@ object Attributes {
       packagingOpt,
       relocated,
       actualVersionOpt.map(Version0(_)),
-      publications,
+      publications.map {
+        case (config, dep) =>
+          (Variant.Configuration(config), dep)
+      },
       info,
       overrides
     )
@@ -336,7 +371,10 @@ object Attributes {
     this(
       module,
       Version0(version),
-      dependencies,
+      dependencies.map {
+        case (config, dep) =>
+          (Variant.Configuration(config), dep)
+      },
       configurations,
       parent.map { case (mod, ver) => (mod, Version0(ver)) },
       dependencyManagement,
@@ -347,7 +385,10 @@ object Attributes {
       packagingOpt,
       relocated,
       actualVersionOpt.map(Version0(_)),
-      publications,
+      publications.map {
+        case (config, dep) =>
+          (Variant.Configuration(config), dep)
+      },
       info
     )
 
@@ -425,7 +466,10 @@ object Project {
     apply(
       module,
       Version0(version),
-      dependencies,
+      dependencies.map {
+        case (config, dep) =>
+          (Variant.Configuration(config), dep)
+      },
       configurations,
       parent.map { case (mod, ver) => (mod, Version0(ver)) },
       dependencyManagement,
@@ -436,7 +480,10 @@ object Project {
       packagingOpt,
       relocated,
       actualVersionOpt.map(Version0(_)),
-      publications,
+      publications.map {
+        case (config, dep) =>
+          (Variant.Configuration(config), dep)
+      },
       info
     )
   @deprecated("Use the override accepting Version-s instead", "2.1.25")
@@ -461,7 +508,10 @@ object Project {
     apply(
       module,
       Version0(version),
-      dependencies,
+      dependencies.map {
+        case (config, dep) =>
+          (Variant.Configuration(config), dep)
+      },
       configurations,
       parent.map { case (mod, ver) => (mod, Version0(ver)) },
       dependencyManagement,
@@ -472,7 +522,10 @@ object Project {
       packagingOpt,
       relocated,
       actualVersionOpt.map(Version0(_)),
-      publications,
+      publications.map {
+        case (config, dep) =>
+          (Variant.Configuration(config), dep)
+      },
       info,
       overrides
     )

--- a/modules/core/shared/src/main/scala/coursier/core/DependencyManagement.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/DependencyManagement.scala
@@ -79,7 +79,7 @@ object DependencyManagement {
       Dependency(
         Module(key.organization, key.name, Map.empty),
         versionConstraint,
-        config,
+        VariantSelector.ConfigurationBased(config),
         minimizedExclusions,
         Publication("", key.`type`, Extension.empty, key.classifier),
         optional = optional,

--- a/modules/core/shared/src/main/scala/coursier/core/Variant.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Variant.scala
@@ -1,0 +1,21 @@
+package coursier.core
+
+import coursier.core.{Configuration => Configuration0}
+import dataclass.data
+
+sealed abstract class Variant extends Product with Serializable {
+  def asConfiguration: Option[Configuration0]
+  def isEmpty: Boolean
+}
+
+object Variant {
+  @data class Configuration(configuration: Configuration0) extends Variant {
+    def asConfiguration: Option[Configuration0] =
+      Some(configuration)
+    def isEmpty: Boolean =
+      configuration.isEmpty
+  }
+
+  lazy val emptyConfiguration: Variant =
+    Configuration(Configuration0.empty)
+}

--- a/modules/core/shared/src/main/scala/coursier/core/VariantSelector.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/VariantSelector.scala
@@ -1,0 +1,22 @@
+package coursier.core
+
+import dataclass.data
+
+sealed abstract class VariantSelector extends Product with Serializable {
+  def asConfiguration: Option[Configuration]
+  def isEmpty: Boolean
+  final def nonEmpty: Boolean = !isEmpty
+
+  def repr: String
+}
+
+object VariantSelector {
+  @data class ConfigurationBased(configuration: Configuration) extends VariantSelector {
+    def asConfiguration: Option[Configuration] = Some(configuration)
+    def isEmpty: Boolean                       = configuration.isEmpty
+    def repr: String                           = configuration.value
+  }
+
+  lazy val emptyConfiguration: VariantSelector =
+    VariantSelector.ConfigurationBased(Configuration.empty)
+}

--- a/modules/core/shared/src/main/scala/coursier/maven/MavenRepositoryInternal.scala
+++ b/modules/core/shared/src/main/scala/coursier/maven/MavenRepositoryInternal.scala
@@ -402,7 +402,7 @@ private[coursier] class MavenRepositoryInternal(
       val types =
         // this ignores publication.ext if publication.`type` is empty… should we?
         if (dependency.publication.`type`.isEmpty)
-          if (dependency.configuration == Configuration.test)
+          if (dependency.variantSelector.asConfiguration.exists(_ == Configuration.test))
             Seq((Type.jar, Extension.empty), (Type.testJar, Extension.empty))
           else
             Seq((Type.jar, Extension.empty))

--- a/modules/core/shared/src/main/scala/coursier/maven/PomParser.scala
+++ b/modules/core/shared/src/main/scala/coursier/maven/PomParser.scala
@@ -111,7 +111,7 @@ object PomParser {
 
     var packagingOpt = Option.empty[Type]
 
-    val dependencies         = new ListBuffer[(Configuration, Dependency)]
+    val dependencies         = new ListBuffer[(Variant, Dependency)]
     val dependencyManagement = new ListBuffer[(Configuration, Dependency)]
 
     val properties = new ListBuffer[(String, String)]
@@ -212,14 +212,14 @@ object PomParser {
             relocationVersionOpt.nonEmpty
           if (isRelocated)
             Some {
-              Configuration.empty -> Dependency(
+              Variant.emptyConfiguration -> Dependency(
                 Module(
                   organization = relocationGroupIdOpt.getOrElse(projModule.organization),
                   name = relocationArtifactIdOpt.getOrElse(projModule.name),
                   attributes = projModule.attributes
                 ),
                 relocationVersionOpt.getOrElse(VersionConstraint.fromVersion(finalVersion)),
-                Configuration.empty,
+                VariantSelector.emptyConfiguration,
                 Set.empty[(Organization, ModuleName)],
                 Attributes.empty,
                 optional = false,
@@ -332,7 +332,7 @@ object PomParser {
   ) ++ dependencyHandlers(
     "dependency" :: "dependencies" :: "project" :: Nil,
     (s, c, d) =>
-      s.dependencies += c -> d
+      s.dependencies += Variant.Configuration(c) -> d
   ) ++ dependencyHandlers(
     "dependency" :: "dependencies" :: "dependencyManagement" :: "project" :: Nil,
     (s, c, d) =>
@@ -480,7 +480,7 @@ object PomParser {
           val d = Dependency(
             Module(state.dependencyGroupIdOpt.get, state.dependencyArtifactIdOpt.get, Map.empty),
             VersionConstraint(state.dependencyVersion),
-            Configuration.empty,
+            VariantSelector.emptyConfiguration,
             state.dependencyExclusions,
             Attributes(state.dependencyType, state.dependencyClassifier),
             state.dependencyOptional,

--- a/modules/coursier/jvm/src/test/scala/coursier/tests/FetchTests.scala
+++ b/modules/coursier/jvm/src/test/scala/coursier/tests/FetchTests.scala
@@ -3,17 +3,16 @@ package coursier.tests
 import java.io.File
 
 import coursier.{Artifacts, Fetch, Repositories}
-import coursier.core.{Activation, Classifier, Configuration, Extension, Type}
+import coursier.core.{Activation, Classifier, Configuration, Extension, Type, VariantSelector}
 import coursier.maven.MavenRepository
 import coursier.params.ResolutionParams
 import coursier.ivy.IvyRepository
 import coursier.util.StringInterpolators._
 import coursier.util.Task
-import coursier.version.Version
+import coursier.version.{Version, VersionConstraint}
 import utest._
 
 import scala.async.Async.{async, await}
-import coursier.version.VersionConstraint
 
 object FetchTests extends TestSuite {
 
@@ -219,7 +218,7 @@ object FetchTests extends TestSuite {
               .addRepositories(m2Repo)
               .addDependencies(
                 dep"com.thoughtworks:top_2.12:0.1.0-SNAPSHOT"
-                  .withConfiguration(Configuration.test)
+                  .withVariantSelector(VariantSelector.ConfigurationBased(Configuration.test))
               )
               .futureResult()
           }
@@ -253,7 +252,7 @@ object FetchTests extends TestSuite {
               .addRepositories(ivy2Repo)
               .addDependencies(
                 dep"com.thoughtworks:top_2.12:0.1.0-SNAPSHOT"
-                  .withConfiguration(Configuration.test)
+                  .withVariantSelector(VariantSelector.ConfigurationBased(Configuration.test))
               )
               .futureResult()
           }

--- a/modules/coursier/shared/src/main/scala/coursier/error/ResolutionError.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/error/ResolutionError.scala
@@ -97,7 +97,7 @@ object ResolutionError {
 
                 s"${node.module}:${node.retainedVersion0.asString} " +
                   (if (assumeCompatibleVersions) colors0.yellow else colors0.red) +
-                  s"wants ${node.dependsOnModule}:${node.dependsOnVersionConstraint}" +
+                  s"wants ${node.dependsOnModule}:${node.dependsOnVersionConstraint.asString}" +
                   colors0.reset
               }
               else

--- a/modules/coursier/shared/src/main/scala/coursier/parse/DependencyParser.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/parse/DependencyParser.scala
@@ -134,9 +134,10 @@ object DependencyParser {
     dep: String,
     validAttrsKeys: Set[String]
   ): Option[String] = {
-    val extraAttributes = attrs.diff(validAttrsKeys)
+    val attrs0          = attrs.filter(!_.startsWith("variant."))
+    val extraAttributes = attrs0.diff(validAttrsKeys)
 
-    if (attrs.size > validAttrsKeys.size || extraAttributes.nonEmpty)
+    if (attrs0.size > validAttrsKeys.size || extraAttributes.nonEmpty)
       Some {
         val invalidMsg =
           if (extraAttributes.nonEmpty)
@@ -144,7 +145,7 @@ object DependencyParser {
               s"${extraAttributes.map(_ + s" in " + dep).mkString(", ")}"
           else
             ""
-        s"The only attributes allowed are: ${validAttrsKeys.mkString(", ")}.$invalidMsg"
+        s"The only attributes allowed are: ${validAttrsKeys.mkString(", ")} and variant.* .$invalidMsg"
       }
     else None
   }

--- a/modules/coursier/shared/src/main/scala/coursier/parse/JavaOrScalaDependency.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/parse/JavaOrScalaDependency.scala
@@ -10,7 +10,8 @@ import coursier.core.{
   Module,
   ModuleName,
   Organization,
-  Type
+  Type,
+  VariantSelector
 }
 import coursier.version.VersionConstraint
 import dataclass.data
@@ -177,7 +178,7 @@ object JavaOrScalaDependency {
           (dep.userParamsMap, None)
       }
     for (config <- configOpt)
-      csDep = csDep.withConfiguration(Configuration(config))
+      csDep = csDep.withVariantSelector(VariantSelector.ConfigurationBased(Configuration(config)))
 
     val excludes = dep.exclude.map { mod =>
       mod.nameAttributes match {

--- a/modules/coursier/shared/src/main/scala/coursier/util/StringInterpolators.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/util/StringInterpolators.scala
@@ -183,6 +183,12 @@ object StringInterpolators {
                 ${bomDep.forceOverrideVersions}
               )"""
             }
+            val variantSelector = dep.variantSelector match {
+              case c: VariantSelector.ConfigurationBased =>
+                q"""_root_.coursier.core.VariantSelector.ConfigurationBased(
+                  _root_.coursier.core.Configuration(${c.configuration.value})
+                )"""
+            }
             c.Expr(q"""
               _root_.coursier.core.Dependency(
                 _root_.coursier.core.Module(
@@ -193,7 +199,7 @@ object StringInterpolators {
                 _root_.coursier.version.VersionConstraint(
                   ${dep.versionConstraint.asString}
                 ),
-                _root_.coursier.core.Configuration(${dep.configuration.value}),
+                $variantSelector,
                 _root_.coursier.core.MinimizedExclusions(_root_.scala.collection.immutable.Set[(_root_.coursier.core.Organization, _root_.coursier.core.ModuleName)](..$excls)),
                 _root_.coursier.core.Publication(
                   ${dep.publication.name},

--- a/modules/coursier/shared/src/test/scala/coursier/tests/ResolveTests.scala
+++ b/modules/coursier/shared/src/test/scala/coursier/tests/ResolveTests.scala
@@ -12,7 +12,8 @@ import coursier.core.{
   ModuleName,
   Repository,
   Resolution,
-  Type
+  Type,
+  VariantSelector
 }
 import coursier.error.ResolutionError
 import coursier.ivy.IvyRepository
@@ -531,7 +532,9 @@ object ResolveTests extends TestSuite {
             resolve
               .addDependencies(
                 dep"com.netflix.karyon:karyon-eureka:1.0.28"
-                  .withConfiguration(Configuration.defaultRuntime)
+                  .withVariantSelector(
+                    VariantSelector.ConfigurationBased(Configuration.defaultRuntime)
+                  )
               )
               .future()
           }
@@ -1604,7 +1607,7 @@ object ResolveTests extends TestSuite {
           // as we pull the test entries too
           bomCheck(
             dep"org.apache.spark:spark-parent_2.13:3.5.3"
-              .withConfiguration(Configuration.test)
+              .withVariantSelector(VariantSelector.ConfigurationBased(Configuration.test))
               .asBomDependency
           )(
             dep"org.scalatestplus.play:scalatestplus-play_2.13:7.0.1"
@@ -1617,7 +1620,7 @@ object ResolveTests extends TestSuite {
             check(
               dep"org.scalatestplus.play:scalatestplus-play_2.13:7.0.1".addBom(
                 dep"org.apache.spark:spark-parent_2.13:3.5.3"
-                  .withConfiguration(Configuration.test)
+                  .withVariantSelector(VariantSelector.ConfigurationBased(Configuration.test))
                   .asBomDependency
               )
             )
@@ -1629,7 +1632,9 @@ object ResolveTests extends TestSuite {
             check(
               dep"org.scalatestplus.play:scalatestplus-play_2.13:7.0.1".addBom(
                 dep"org.apache.spark:spark-parent_2.13:3.5.3"
-                  .withConfiguration(Configuration.defaultRuntime)
+                  .withVariantSelector(
+                    VariantSelector.ConfigurationBased(Configuration.defaultRuntime)
+                  )
                   .asBomDependency
               )
             )
@@ -1640,7 +1645,7 @@ object ResolveTests extends TestSuite {
       test("runtime") {
         bomCheck(
           dep"io.quarkus:quarkus-bom:3.15.1"
-            .withConfiguration(Configuration.runtime)
+            .withVariantSelector(VariantSelector.ConfigurationBased(Configuration.runtime))
             .asBomDependency
         )(
           dep"org.mvnpm.at.hpcc-js:wasm"
@@ -1653,7 +1658,7 @@ object ResolveTests extends TestSuite {
           // protobuf-java is marked as provided there
           bomCheck(
             dep"org.apache.spark:spark-parent_2.13:3.5.3"
-              .withConfiguration(Configuration.provided)
+              .withVariantSelector(VariantSelector.ConfigurationBased(Configuration.provided))
               .asBomDependency
           )(
             dep"com.google.protobuf:protobuf-java"
@@ -1664,7 +1669,7 @@ object ResolveTests extends TestSuite {
           // protobuf-java is marked as provided there
           bomCheck(
             dep"org.apache.spark:spark-parent_2.13:3.5.3"
-              .withConfiguration(Configuration.provided)
+              .withVariantSelector(VariantSelector.ConfigurationBased(Configuration.provided))
               .asBomDependency
           )(
             dep"com.google.protobuf:protobuf-java-util"
@@ -1678,7 +1683,7 @@ object ResolveTests extends TestSuite {
                 .addDependencies(dep"com.google.protobuf:protobuf-java")
                 .addBom(
                   dep"org.apache.spark:spark-parent_2.13:3.5.3"
-                    .withConfiguration(Configuration.compile)
+                    .withVariantSelector(VariantSelector.ConfigurationBased(Configuration.compile))
                     .asBomDependency
                 )
                 .io
@@ -1707,7 +1712,7 @@ object ResolveTests extends TestSuite {
             check(
               dep"com.google.protobuf:protobuf-java:3.7.1".addBom(
                 dep"org.apache.spark:spark-parent_2.13:3.5.3"
-                  .withConfiguration(Configuration.provided)
+                  .withVariantSelector(VariantSelector.ConfigurationBased(Configuration.provided))
                   .asBomDependency
               )
             )
@@ -1719,7 +1724,7 @@ object ResolveTests extends TestSuite {
             check(
               dep"com.google.protobuf:protobuf-java-util:3.7.1".addBom(
                 dep"org.apache.spark:spark-parent_2.13:3.5.3"
-                  .withConfiguration(Configuration.provided)
+                  .withVariantSelector(VariantSelector.ConfigurationBased(Configuration.provided))
                   .asBomDependency
               )
             )
@@ -1730,7 +1735,9 @@ object ResolveTests extends TestSuite {
             check(
               dep"com.google.protobuf:protobuf-java-util:3.7.1".addBom(
                 dep"org.apache.spark:spark-parent_2.13:3.5.3"
-                  .withConfiguration(Configuration.defaultRuntime)
+                  .withVariantSelector(
+                    VariantSelector.ConfigurationBased(Configuration.defaultRuntime)
+                  )
                   .asBomDependency
               )
             )
@@ -1744,7 +1751,7 @@ object ResolveTests extends TestSuite {
             check(
               dep"com.google.protobuf:protobuf-java:3.7.1".addBom(
                 dep"org.apache.spark:spark-parent_2.13:3.5.3"
-                  .withConfiguration(Configuration.provided)
+                  .withVariantSelector(VariantSelector.ConfigurationBased(Configuration.provided))
                   .asBomDependency
                   .withForceOverrideVersions(true)
               )
@@ -1756,7 +1763,7 @@ object ResolveTests extends TestSuite {
             check(
               dep"com.google.protobuf:protobuf-java-util:3.7.1".addBom(
                 dep"org.apache.spark:spark-parent_2.13:3.5.3"
-                  .withConfiguration(Configuration.provided)
+                  .withVariantSelector(VariantSelector.ConfigurationBased(Configuration.provided))
                   .asBomDependency
                   .withForceOverrideVersions(true)
               )

--- a/modules/coursier/shared/src/test/scala/coursier/tests/parse/DependencyParserTests.scala
+++ b/modules/coursier/shared/src/test/scala/coursier/tests/parse/DependencyParserTests.scala
@@ -13,7 +13,8 @@ import coursier.core.{
   ModuleName,
   Organization,
   Publication,
-  Type
+  Type,
+  VariantSelector
 }
 import coursier.util.StringInterpolators._
 import coursier.version.VersionConstraint
@@ -32,7 +33,7 @@ object DependencyParserTests extends TestSuite {
           assert(dep.module.organization == org"org.apache.avro")
           assert(dep.module.name == name"avro")
           assert(dep.versionConstraint.asString == "1.7.4")
-          assert(dep.configuration == Configuration.empty)
+          assert(dep.variantSelector == VariantSelector.ConfigurationBased(Configuration.empty))
           assert(dep.attributes == Attributes.empty)
       }
     }
@@ -44,7 +45,7 @@ object DependencyParserTests extends TestSuite {
           assert(dep.module.organization == org"org.apache.avro")
           assert(dep.module.name == name"avro")
           assert(dep.versionConstraint.asString.isEmpty)
-          assert(dep.configuration == Configuration.empty)
+          assert(dep.variantSelector == VariantSelector.ConfigurationBased(Configuration.empty))
           assert(dep.attributes == Attributes.empty)
       }
     }
@@ -56,7 +57,7 @@ object DependencyParserTests extends TestSuite {
           assert(dep.module.organization == org"org.apache.avro")
           assert(dep.module.name == name"avro")
           assert(dep.versionConstraint.asString == "1.7.4")
-          assert(dep.configuration == Configuration.runtime)
+          assert(dep.variantSelector == VariantSelector.ConfigurationBased(Configuration.runtime))
           assert(dep.attributes == Attributes.empty)
       }
     }
@@ -68,7 +69,7 @@ object DependencyParserTests extends TestSuite {
           assert(dep.module.organization == org"org.apache.avro")
           assert(dep.module.name == name"avro")
           assert(dep.versionConstraint.asString.isEmpty)
-          assert(dep.configuration == Configuration.runtime)
+          assert(dep.variantSelector == VariantSelector.ConfigurationBased(Configuration.runtime))
           assert(dep.attributes == Attributes.empty)
       }
     }
@@ -80,7 +81,7 @@ object DependencyParserTests extends TestSuite {
           assert(dep.module.organization == org"org.apache.avro")
           assert(dep.module.name == name"avro")
           assert(dep.versionConstraint.asString == "[1.7,1.8)")
-          assert(dep.configuration == Configuration.runtime)
+          assert(dep.variantSelector == VariantSelector.ConfigurationBased(Configuration.runtime))
           assert(dep.attributes == Attributes.empty)
       }
     }
@@ -95,7 +96,7 @@ object DependencyParserTests extends TestSuite {
           assert(dep.module.organization == org"org.apache.avro")
           assert(dep.module.name == name"avro")
           assert(dep.versionConstraint.asString == "1.7.4")
-          assert(dep.configuration == Configuration.runtime)
+          assert(dep.variantSelector == VariantSelector.ConfigurationBased(Configuration.runtime))
           assert(dep.attributes == Attributes(Type.empty, Classifier.tests))
       }
     }
@@ -110,7 +111,7 @@ object DependencyParserTests extends TestSuite {
           assert(dep.module.organization == org"org.apache.avro")
           assert(dep.module.name == name"avro")
           assert(dep.versionConstraint.asString.isEmpty)
-          assert(dep.configuration == Configuration.runtime)
+          assert(dep.variantSelector == VariantSelector.ConfigurationBased(Configuration.runtime))
           assert(dep.attributes == Attributes(Type.empty, Classifier.tests))
       }
     }
@@ -125,7 +126,7 @@ object DependencyParserTests extends TestSuite {
           assert(dep.module.organization == org"org.apache.avro")
           assert(dep.module.name == name"avro")
           assert(dep.versionConstraint.asString == "1.7.4")
-          assert(dep.configuration == Configuration.runtime)
+          assert(dep.variantSelector == VariantSelector.ConfigurationBased(Configuration.runtime))
           assert(dep.publication == Publication("", Type.empty, Extension("exe"), Classifier.empty))
       }
     }
@@ -140,7 +141,7 @@ object DependencyParserTests extends TestSuite {
           assert(dep.module.organization == org"org.apache.avro")
           assert(dep.module.name == name"avro")
           assert(dep.versionConstraint.asString == "1.7.4")
-          assert(dep.configuration == Configuration.runtime)
+          assert(dep.variantSelector == VariantSelector.ConfigurationBased(Configuration.runtime))
           val expectedPublication = Publication(
             "",
             Type("typetype"),
@@ -161,7 +162,7 @@ object DependencyParserTests extends TestSuite {
           assert(dep.module.organization == org"org.apache.avro")
           assert(dep.module.name == name"avro")
           assert(dep.versionConstraint.asString == "1.7.4")
-          assert(dep.configuration == Configuration.runtime)
+          assert(dep.variantSelector == VariantSelector.ConfigurationBased(Configuration.runtime))
           val expectedPublication = Publication(
             "",
             Type("typetype"),
@@ -182,7 +183,7 @@ object DependencyParserTests extends TestSuite {
           assert(dep.module.organization == org"org.apache.avro")
           assert(dep.module.name == name"avro")
           assert(dep.versionConstraint.asString == "[1.7,1.8)")
-          assert(dep.configuration == Configuration.runtime)
+          assert(dep.variantSelector == VariantSelector.ConfigurationBased(Configuration.runtime))
           assert(dep.attributes == Attributes(Type.empty, Classifier.tests))
       }
     }
@@ -197,7 +198,7 @@ object DependencyParserTests extends TestSuite {
           assert(dep.module.organization == org"org.apache.avro")
           assert(dep.module.name == name"avro")
           assert(dep.versionConstraint.asString == "1.7.4")
-          assert(dep.configuration == Configuration.runtime)
+          assert(dep.variantSelector == VariantSelector.ConfigurationBased(Configuration.runtime))
           assert(dep.attributes == Attributes.empty)
           assert(extraParams.isDefinedAt("url"))
           assert(extraParams.getOrElse("url", "") == url)
@@ -214,7 +215,7 @@ object DependencyParserTests extends TestSuite {
           assert(dep.module.organization == org"org.apache.avro")
           assert(dep.module.name == name"avro")
           assert(dep.versionConstraint.asString == "1.7.4")
-          assert(dep.configuration == Configuration.runtime)
+          assert(dep.variantSelector == VariantSelector.ConfigurationBased(Configuration.runtime))
           assert(dep.attributes == Attributes(Type.empty, Classifier.tests))
           assert(extraParams.isDefinedAt("url"))
           assert(extraParams.getOrElse("url", "") == url)
@@ -231,7 +232,7 @@ object DependencyParserTests extends TestSuite {
           assert(dep.module.organization == org"org.apache.avro")
           assert(dep.module.name == name"avro")
           assert(dep.versionConstraint.asString == "[1.7,1.8)")
-          assert(dep.configuration == Configuration.runtime)
+          assert(dep.variantSelector == VariantSelector.ConfigurationBased(Configuration.runtime))
           assert(dep.attributes == Attributes(Type.empty, Classifier.tests))
           assert(extraParams.isDefinedAt("url"))
           assert(extraParams.getOrElse("url", "") == url)
@@ -248,7 +249,7 @@ object DependencyParserTests extends TestSuite {
           assert(dep.module.organization == org"org.apache.avro")
           assert(dep.module.name == name"avro")
           assert(dep.versionConstraint.asString == "[1.7,1.8)")
-          assert(dep.configuration == Configuration.runtime)
+          assert(dep.variantSelector == VariantSelector.ConfigurationBased(Configuration.runtime))
           assert(dep.attributes == Attributes(Type.empty, Classifier.tests))
           assert(extraParams.isDefinedAt("url"))
           assert(extraParams.getOrElse("url", "") == url)
@@ -475,7 +476,7 @@ object DependencyParserTests extends TestSuite {
           assert(params.isEmpty)
           val expected = JavaOrScalaDependency.ScalaDependency(
             Dependency(mod"org:name", VersionConstraint("ver"))
-              .withConfiguration(Configuration.empty),
+              .withVariantSelector(VariantSelector.emptyConfiguration),
             fullCrossVersion = false,
             withPlatformSuffix = false,
             exclude = Set.empty
@@ -490,7 +491,8 @@ object DependencyParserTests extends TestSuite {
         case Right((dep, params)) =>
           assert(params.isEmpty)
           val expected = JavaOrScalaDependency.ScalaDependency(
-            Dependency(mod"org:name", VersionConstraint("")).withConfiguration(Configuration.empty),
+            Dependency(mod"org:name", VersionConstraint(""))
+              .withVariantSelector(VariantSelector.emptyConfiguration),
             fullCrossVersion = false,
             withPlatformSuffix = false,
             exclude = Set.empty
@@ -506,7 +508,7 @@ object DependencyParserTests extends TestSuite {
           assert(params.isEmpty)
           val expected = JavaOrScalaDependency.ScalaDependency(
             Dependency(mod"org:name", VersionConstraint("ver"))
-              .withConfiguration(Configuration.empty),
+              .withVariantSelector(VariantSelector.emptyConfiguration),
             fullCrossVersion = true,
             withPlatformSuffix = false,
             exclude = Set.empty
@@ -521,7 +523,8 @@ object DependencyParserTests extends TestSuite {
         case Right((dep, params)) =>
           assert(params.isEmpty)
           val expected = JavaOrScalaDependency.ScalaDependency(
-            Dependency(mod"org:name", VersionConstraint("")).withConfiguration(Configuration.empty),
+            Dependency(mod"org:name", VersionConstraint(""))
+              .withVariantSelector(VariantSelector.emptyConfiguration),
             fullCrossVersion = true,
             withPlatformSuffix = false,
             exclude = Set.empty
@@ -537,7 +540,7 @@ object DependencyParserTests extends TestSuite {
           assert(params.isEmpty)
           val expected = JavaOrScalaDependency.ScalaDependency(
             Dependency(mod"org:name", VersionConstraint("ver"))
-              .withConfiguration(Configuration("conf")),
+              .withVariantSelector(VariantSelector.ConfigurationBased(Configuration("conf"))),
             fullCrossVersion = true,
             withPlatformSuffix = false,
             exclude = Set.empty
@@ -553,7 +556,7 @@ object DependencyParserTests extends TestSuite {
           assert(params.isEmpty)
           val expected = JavaOrScalaDependency.ScalaDependency(
             Dependency(mod"org:name", VersionConstraint(""))
-              .withConfiguration(Configuration("conf")),
+              .withVariantSelector(VariantSelector.ConfigurationBased(Configuration("conf"))),
             fullCrossVersion = true,
             withPlatformSuffix = false,
             exclude = Set.empty

--- a/modules/sbt-maven-repository/shared/src/main/scala/coursier/maven/SbtMavenRepository.scala
+++ b/modules/sbt-maven-repository/shared/src/main/scala/coursier/maven/SbtMavenRepository.scala
@@ -98,7 +98,7 @@ object SbtMavenRepository {
         .getOrElse(Right(Map.empty[(Module, VersionConstraint), Map[String, String]]))
     } yield {
 
-      val adaptedDependencies = project.dependencies.map {
+      val adaptedDependencies = project.dependencies0.map {
         case (config, dep0) =>
           val dep = extraAttrs.get(dep0.moduleVersionConstraint).fold(dep0) { attrs =>
             // For an sbt plugin, we remove the suffix from the name and we add the sbtVersion
@@ -114,7 +114,7 @@ object SbtMavenRepository {
           config -> dep
       }
 
-      project.withDependencies(adaptedDependencies)
+      project.withDependencies0(adaptedDependencies)
     }
 }
 

--- a/modules/tests/jvm/src/test/scala/coursier/tests/IvyTests.scala
+++ b/modules/tests/jvm/src/test/scala/coursier/tests/IvyTests.scala
@@ -2,12 +2,20 @@ package coursier.tests
 
 import java.io.File
 
-import coursier.core.{Attributes, Classifier, Configuration, Dependency, Module, Type}
+import coursier.core.{
+  Attributes,
+  Classifier,
+  Configuration,
+  Dependency,
+  Module,
+  Type,
+  VariantSelector
+}
 import coursier.ivy.IvyRepository
 import coursier.tests.compatibility.executionContext
 import coursier.util.StringInterpolators._
-import utest._
 import coursier.version.VersionConstraint
+import utest._
 
 object IvyTests extends TestSuite {
 
@@ -138,7 +146,7 @@ object IvyTests extends TestSuite {
 
       test("test conf") {
         "no attributes" - runner.withArtifacts(
-          dep = dep.withConfiguration(Configuration.test),
+          dep = dep.withVariantSelector(VariantSelector.ConfigurationBased(Configuration.test)),
           extraRepos = Seq(repo),
           classifierOpt = None
         ) { artifacts =>
@@ -149,7 +157,7 @@ object IvyTests extends TestSuite {
 
         "attributes" - runner.withArtifacts(
           dep = dep
-            .withConfiguration(Configuration.test)
+            .withVariantSelector(VariantSelector.ConfigurationBased(Configuration.test))
             .withAttributes(Attributes(Type.jar, Classifier.empty)),
           extraRepos = Seq(repo),
           classifierOpt = None

--- a/modules/tests/shared/src/test/scala/coursier/tests/CentralTests.scala
+++ b/modules/tests/shared/src/test/scala/coursier/tests/CentralTests.scala
@@ -11,7 +11,8 @@ import coursier.core.{
   Dependency,
   Extension,
   Resolution,
-  Type
+  Type,
+  VariantSelector
 }
 import coursier.graph.{Conflict, ModuleTree}
 import coursier.maven.{MavenRepository, MavenRepositoryLike}
@@ -273,7 +274,7 @@ abstract class CentralTests extends TestSuite {
 
       def intransitiveCompiler(config: Configuration) =
         dep"org.scala-lang:scala-compiler:2.11.8"
-          .withConfiguration(config)
+          .withVariantSelector(VariantSelector.ConfigurationBased(config))
           .withAttributes(Attributes(Type.jar, Classifier.empty))
           .withTransitive(false)
 

--- a/modules/tests/shared/src/test/scala/coursier/tests/TestRunner.scala
+++ b/modules/tests/shared/src/test/scala/coursier/tests/TestRunner.scala
@@ -12,7 +12,8 @@ import coursier.core.{
   Module,
   Repository,
   Resolution,
-  ResolutionProcess
+  ResolutionProcess,
+  VariantSelector
 }
 import coursier.maven.MavenRepository
 import coursier.testcache.TestCache
@@ -148,7 +149,8 @@ class TestRunner[F[_]: Gather: ToFuture](
   ): Future[Resolution] =
     async {
 
-      val dep = Dependency(module, version).withConfiguration(configuration)
+      val dep = Dependency(module, version)
+        .withVariantSelector(VariantSelector.ConfigurationBased(configuration))
       val res = await {
         resolve(
           Seq(dep),
@@ -175,7 +177,7 @@ class TestRunner[F[_]: Gather: ToFuture](
             dep0.module.organization.value,
             dep0.module.nameWithAttributes,
             dep0.versionConstraint.asString,
-            dep0.configuration.value
+            dep0.variantSelector.repr
           )
         }
         .distinct

--- a/modules/tests/shared/src/test/scala/coursier/tests/TestUtil.scala
+++ b/modules/tests/shared/src/test/scala/coursier/tests/TestUtil.scala
@@ -1,6 +1,17 @@
 package coursier.tests
 
-import coursier.core.{Configuration, Dependency, Info, Module, Overrides, Profile, Resolution, Type}
+import coursier.core.{
+  Configuration,
+  Dependency,
+  Info,
+  Module,
+  Overrides,
+  Profile,
+  Resolution,
+  Type,
+  Variant,
+  VariantSelector
+}
 import coursier.version.{Version, VersionConstraint}
 
 import scala.collection.compat._
@@ -8,7 +19,9 @@ import scala.collection.compat._
 object TestUtil {
 
   implicit class DependencyOps(val underlying: Dependency) extends AnyVal {
-    def withDefaultScope: Dependency = underlying.withConfiguration(Configuration.defaultRuntime)
+    def withDefaultScope: Dependency = underlying.withVariantSelector(
+      VariantSelector.ConfigurationBased(Configuration.defaultRuntime)
+    )
   }
 
   private val projectProperties = Set(
@@ -93,7 +106,7 @@ object TestUtil {
     def apply(
       module: Module,
       version: String,
-      dependencies: Seq[(Configuration, Dependency)] = Seq.empty,
+      dependencies: Seq[(Variant, Dependency)] = Seq.empty,
       parent0: Option[(Module, String)] = None,
       dependencyManagement: Seq[(Configuration, Dependency)] = Seq.empty,
       configurations: Map[Configuration, Seq[Configuration]] = Map.empty,
@@ -103,7 +116,7 @@ object TestUtil {
       snapshotVersioning: Option[coursier.core.SnapshotVersioning] = None,
       packaging: Option[Type] = None,
       relocated: Boolean = false,
-      publications: Seq[(Configuration, coursier.core.Publication)] = Nil
+      publications: Seq[(Variant, coursier.core.Publication)] = Nil
     ): Project =
       coursier.core.Project(
         module,

--- a/modules/tests/shared/src/test/scala/coursier/tests/util/InterpolatorsTests.scala
+++ b/modules/tests/shared/src/test/scala/coursier/tests/util/InterpolatorsTests.scala
@@ -1,11 +1,11 @@
 package coursier.tests.util
 
-import coursier.core.{Configuration, Dependency, Module}
+import coursier.core.{Configuration, Dependency, Module, VariantSelector}
 import coursier.ivy.{IvyRepository, Pattern}
 import coursier.maven.MavenRepository
 import coursier.util.StringInterpolators._
-import utest._
 import coursier.version.VersionConstraint
+import utest._
 
 object InterpolatorsTests extends TestSuite {
 
@@ -39,7 +39,7 @@ object InterpolatorsTests extends TestSuite {
         val expected = Dependency(
           Module(org"org.scalatest", name"scalatest_2.12", Map.empty),
           VersionConstraint("3.0.1")
-        ).withConfiguration(Configuration.test)
+        ).withVariantSelector(VariantSelector.ConfigurationBased(Configuration.test))
         assert(dep == expected)
       }
     }

--- a/modules/tests/shared/src/test/scala/coursier/tests/util/PrintTests.scala
+++ b/modules/tests/shared/src/test/scala/coursier/tests/util/PrintTests.scala
@@ -1,6 +1,14 @@
 package coursier.tests.util
 
-import coursier.core.{Attributes, Classifier, Configuration, Dependency, Reconciliation, Type}
+import coursier.core.{
+  Attributes,
+  Classifier,
+  Configuration,
+  Dependency,
+  Reconciliation,
+  Type,
+  VariantSelector
+}
 import coursier.tests.TestRunner
 import coursier.graph.{DependencyTree, ReverseModuleTree}
 import coursier.util.{Print, Tree}
@@ -27,7 +35,7 @@ object PrintTests extends TestSuite {
   val tests = Tests {
     test("ignoreAttributes") {
       val dep = dep"org:name:0.1"
-        .withConfiguration(Configuration("foo"))
+        .withVariantSelector(VariantSelector.ConfigurationBased(Configuration("foo")))
       val deps = Seq(
         dep,
         dep.withAttributes(Attributes(Type("fooz"), Classifier.empty))

--- a/modules/web/src/main/scala/coursier/web/App.scala
+++ b/modules/web/src/main/scala/coursier/web/App.scala
@@ -1,6 +1,15 @@
 package coursier.web
 
-import coursier.core.{Configuration, Dependency, Module, ModuleName, Organization, Resolution, Type}
+import coursier.core.{
+  Configuration,
+  Dependency,
+  Module,
+  ModuleName,
+  Organization,
+  Resolution,
+  Type,
+  VariantSelector
+}
 import coursier.maven.{MavenRepository, MavenRepositoryLike}
 import coursier.util.StringInterpolators._
 import coursier.version.{Version, VersionConstraint}
@@ -10,7 +19,7 @@ import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 
 import scala.scalajs.js
-import js.Dynamic.{global => g}
+import scala.scalajs.js.Dynamic.{global => g}
 
 object App {
 
@@ -50,8 +59,9 @@ object App {
               s"${finalVersion.asString} (for ${dep.versionConstraint.asString})"
             )),
             <.td(TagMod(
-              if (dep.configuration == Configuration.compile) TagMod()
-              else TagMod(infoLabel(dep.configuration.value)),
+              if (dep.variantSelector == VariantSelector.ConfigurationBased(Configuration.compile))
+                TagMod()
+              else TagMod(infoLabel(dep.variantSelector.repr)),
               if (dep.attributes.`type`.isEmpty || dep.attributes.`type` == Type.jar) TagMod()
               else TagMod(infoLabel(dep.attributes.`type`.value)),
               if (dep.attributes.classifier.isEmpty) TagMod()

--- a/modules/web/src/main/scala/coursier/web/Backend.scala
+++ b/modules/web/src/main/scala/coursier/web/Backend.scala
@@ -54,7 +54,7 @@ final class Backend($ : BackendScope[_, State]) {
       Seq(
         dep.module.organization,
         dep.module.name,
-        dep.configuration
+        dep.variantSelector.repr
       ).mkString(":")
 
     for {


### PR DESCRIPTION
`Variant` and `VariantSelector` are substitutes for `Configuration`. A `Variant` corresponds to a concrete configuration - a project exposes various artifacts and dependency sets in various configurations (for `compile`, `runtime`, etc.). A `VariantSelector` allows to pick a `Variant` in a project - a dependency has a `VariantSelector`, that will be used to pick a `Variant` in the dependency's project.

This parallels `Version` and `VersionConstraint` - `Version` is a concrete version, like `1.2.3`, while `VersionConstraint` allows to pick a `Version`, and can look like `1.2.3` but also like `[1.2,1.3)` or `latest.release`. A project has a specific `Version`, while a `Dependency` has a `VersionConstraint`, that will be used to pick a concrete `Version` and get the associated `Project`.

As ADTs, `Variant` and `VariantSelector` only have one case in this PR, corresponding to `Configuration`. This PR is mainly about the refactoring required to replace `Configuration` by either `Variant` or `VariantSelector`. A subsequent PR is going add one for Gradle module variants, where the distinction between `Variant` and `VariantSelector` will be required.