### PR TITLE
Compile cli sources with Scala 3

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -201,7 +201,7 @@ object install extends Cross[Install](ScalaVersions.all)
 object cli extends Cli {
   object test extends SbtTests with CsTests with CsResourcesTests {
     def moduleDeps = super.moduleDeps ++ Seq(
-      coursier.jvm(sv).test
+      coursier.jvm(cliScalaVersion213Compat).test
     )
     def ivyDeps = super.ivyDeps() ++ Agg(
       Deps.ujson
@@ -367,15 +367,15 @@ trait Env extends CrossSbtModule with CsModule
   }
 }
 
-def cliScalaVersion = ScalaVersions.scala213
-def launcherModule  = launcher
+def cliScalaVersion          = ScalaVersions.scala3
+def cliScalaVersion213Compat = ScalaVersions.scala213
+def launcherModule           = launcher
 trait LauncherNative04 extends CsModule
     with CoursierPublishModule {
-  private def sv   = cliScalaVersion
-  def scalaVersion = sv
+  def scalaVersion = cliScalaVersion
   def artifactName = "coursier-launcher-native_0.4"
   def compileModuleDeps = Seq(
-    launcherModule(sv)
+    launcherModule(cliScalaVersion213Compat)
   )
   def ivyDeps = super.ivyDeps() ++ Agg(
     Deps.scalaNativeTools040
@@ -607,23 +607,20 @@ trait Jvm extends CrossSbtModule with CsModule
 
 trait Cli extends CsModule
     with CoursierPublishModule with Launchers {
-  protected def sv = cliScalaVersion
-  def scalaVersion = sv
+  def scalaVersion = cliScalaVersion
   def moduleDeps = super.moduleDeps ++ Seq(
-    coursier.jvm(sv),
-    `sbt-maven-repository`.jvm(sv),
-    install(sv),
-    jvm(sv),
-    launcherModule(sv)
+    coursier.jvm(cliScalaVersion213Compat),
+    `sbt-maven-repository`.jvm(cliScalaVersion213Compat),
+    install(cliScalaVersion213Compat),
+    jvm(cliScalaVersion213Compat),
+    launcherModule(cliScalaVersion213Compat)
   )
   def artifactName = "coursier-cli"
   def ivyDeps = super.ivyDeps() ++ Agg(
     Deps.caseApp,
-    Deps.catsCore,
-    Deps.catsFree,
+    Deps.catsFree213,
     Deps.classPathUtil,
     Deps.collectionCompat,
-    Deps.dataClass,
     Deps.noCrcZis,
     Deps.slf4JNop
   )
@@ -661,10 +658,9 @@ trait Cli extends CsModule
 
 trait CliTests extends CsModule
     with CoursierPublishModule { self =>
-  private def sv   = cliScalaVersion
-  def scalaVersion = sv
+  def scalaVersion = cliScalaVersion
   def moduleDeps = super.moduleDeps ++ Seq(
-    coursier.jvm(sv)
+    coursier.jvm(cliScalaVersion213Compat)
   )
   def ivyDeps = super.ivyDeps() ++ Agg(
     Deps.caseApp,

--- a/modules/cli-tests/src/main/scala/coursier/clitests/TestUtil.scala
+++ b/modules/cli-tests/src/main/scala/coursier/clitests/TestUtil.scala
@@ -3,7 +3,9 @@ package coursier.clitests
 import java.io.{File, FileWriter}
 import java.nio.file.Files
 
+import coursier.core.{Dependency, Module, ModuleName, Organization}
 import coursier.util.StringInterpolators._
+import coursier.version.VersionConstraint
 
 object TestUtil {
 
@@ -34,7 +36,10 @@ object TestUtil {
       )
   }
 
-  val propsDep    = dep"io.get-coursier:props:1.0.2"
+  val propsDep = Dependency(
+    Module(Organization("io.get-coursier"), ModuleName("props"), Map.empty),
+    VersionConstraint("1.0.2")
+  )
   val propsDepStr = s"${propsDep.module}:${propsDep.versionConstraint.asString}"
   lazy val propsCp = coursier.Fetch()
     .addDependencies(propsDep)

--- a/modules/cli/src/main/scala/coursier/cli/Coursier.scala
+++ b/modules/cli/src/main/scala/coursier/cli/Coursier.scala
@@ -1,5 +1,6 @@
 package coursier.cli
 
+import caseapp.core.Scala3Helpers._
 import caseapp.core.app.CommandsEntryPoint
 import caseapp.core.help.HelpFormat
 import caseapp.RemainingArgs

--- a/modules/cli/src/main/scala/coursier/cli/CoursierCommand.scala
+++ b/modules/cli/src/main/scala/coursier/cli/CoursierCommand.scala
@@ -1,6 +1,7 @@
 package coursier.cli
 
 import caseapp._
+import caseapp.core.Scala3Helpers._
 import caseapp.core.help.HelpFormat
 import coursier.cli.options.OptionGroup
 

--- a/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapSpecificOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/bootstrap/BootstrapSpecificOptions.scala
@@ -105,7 +105,6 @@ final case class BootstrapSpecificOptions(
 }
 
 object BootstrapSpecificOptions {
-  lazy val parser: Parser[BootstrapSpecificOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[BootstrapSpecificOptions, parser.D] = parser
-  implicit lazy val help: Help[BootstrapSpecificOptions]                      = Help.derive
+  implicit lazy val parser: Parser[BootstrapSpecificOptions] = Parser.derive
+  implicit lazy val help: Help[BootstrapSpecificOptions]     = Help.derive
 }

--- a/modules/cli/src/main/scala/coursier/cli/install/Install.scala
+++ b/modules/cli/src/main/scala/coursier/cli/install/Install.scala
@@ -43,7 +43,7 @@ object Install extends CoursierCommand[InstallOptions] {
     val noUpdateCoursierCache =
       params.cache.cache(pool, params.output.logger(), overrideTtl = Some(Duration.Inf))
 
-    val graalvmHome = { version: String =>
+    val graalvmHome = { (version: String) =>
       params.sharedJava.javaHome(
         cache,
         noUpdateCoursierCache,

--- a/modules/cli/src/main/scala/coursier/cli/install/Update.scala
+++ b/modules/cli/src/main/scala/coursier/cli/install/Update.scala
@@ -31,7 +31,7 @@ object Update extends CoursierCommand[UpdateOptions] {
     val noUpdateCoursierCache =
       params.cache.cache(pool, params.output.logger(), overrideTtl = Some(Duration.Inf))
 
-    val graalvmHome = { version: String =>
+    val graalvmHome = { (version: String) =>
       params.sharedJava.javaHome(
         cache,
         noUpdateCoursierCache,

--- a/modules/cli/src/main/scala/coursier/cli/native/NativeLauncherOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/native/NativeLauncherOptions.scala
@@ -131,7 +131,6 @@ final case class NativeLauncherOptions(
 }
 
 object NativeLauncherOptions {
-  lazy val parser: Parser[NativeLauncherOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[NativeLauncherOptions, parser.D] = parser
-  implicit lazy val help: Help[NativeLauncherOptions]                      = Help.derive
+  implicit lazy val parser: Parser[NativeLauncherOptions] = Parser.derive
+  implicit lazy val help: Help[NativeLauncherOptions]     = Help.derive
 }

--- a/modules/cli/src/main/scala/coursier/cli/options/ArtifactOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/ArtifactOptions.scala
@@ -95,7 +95,6 @@ final case class ArtifactOptions(
 }
 
 object ArtifactOptions {
-  lazy val parser: Parser[ArtifactOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[ArtifactOptions, parser.D] = parser
-  implicit lazy val help: Help[ArtifactOptions]                      = Help.derive
+  implicit lazy val parser: Parser[ArtifactOptions] = Parser.derive
+  implicit lazy val help: Help[ArtifactOptions]     = Help.derive
 }

--- a/modules/cli/src/main/scala/coursier/cli/options/CacheOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/CacheOptions.scala
@@ -182,7 +182,6 @@ final case class CacheOptions(
 }
 
 object CacheOptions {
-  lazy val parser: Parser[CacheOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[CacheOptions, parser.D] = parser
-  implicit lazy val help: Help[CacheOptions]                      = Help.derive
+  implicit lazy val parser: Parser[CacheOptions] = Parser.derive
+  implicit lazy val help: Help[CacheOptions]     = Help.derive
 }

--- a/modules/cli/src/main/scala/coursier/cli/options/DependencyOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/DependencyOptions.scala
@@ -61,7 +61,6 @@ final case class DependencyOptions(
 // format: on
 
 object DependencyOptions {
-  lazy val parser: Parser[DependencyOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[DependencyOptions, parser.D] = parser
-  implicit lazy val help: Help[DependencyOptions]                      = Help.derive
+  implicit lazy val parser: Parser[DependencyOptions] = Parser.derive
+  implicit lazy val help: Help[DependencyOptions]     = Help.derive
 }

--- a/modules/cli/src/main/scala/coursier/cli/options/OutputOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/OutputOptions.scala
@@ -36,7 +36,6 @@ final case class OutputOptions(
 // format: on
 
 object OutputOptions {
-  lazy val parser: Parser[OutputOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[OutputOptions, parser.D] = parser
-  implicit lazy val help: Help[OutputOptions]                      = Help.derive
+  implicit lazy val parser: Parser[OutputOptions] = Parser.derive
+  implicit lazy val help: Help[OutputOptions]     = Help.derive
 }

--- a/modules/cli/src/main/scala/coursier/cli/options/RepositoryOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/RepositoryOptions.scala
@@ -31,7 +31,6 @@ final case class RepositoryOptions(
 // format: on
 
 object RepositoryOptions {
-  lazy val parser: Parser[RepositoryOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[RepositoryOptions, parser.D] = parser
-  implicit lazy val help: Help[RepositoryOptions]                      = Help.derive
+  implicit lazy val parser: Parser[RepositoryOptions] = Parser.derive
+  implicit lazy val help: Help[RepositoryOptions]     = Help.derive
 }

--- a/modules/cli/src/main/scala/coursier/cli/options/ResolutionOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/ResolutionOptions.scala
@@ -237,7 +237,6 @@ final case class ResolutionOptions(
 }
 
 object ResolutionOptions {
-  lazy val parser: Parser[ResolutionOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[ResolutionOptions, parser.D] = parser
-  implicit lazy val help: Help[ResolutionOptions]                      = Help.derive
+  implicit lazy val parser: Parser[ResolutionOptions] = Parser.derive
+  implicit lazy val help: Help[ResolutionOptions]     = Help.derive
 }

--- a/modules/cli/src/main/scala/coursier/cli/options/SharedLaunchOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/SharedLaunchOptions.scala
@@ -107,7 +107,6 @@ final case class SharedLaunchOptions(
 }
 
 object SharedLaunchOptions {
-  lazy val parser: Parser[SharedLaunchOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[SharedLaunchOptions, parser.D] = parser
-  implicit lazy val help: Help[SharedLaunchOptions]                      = Help.derive
+  implicit lazy val parser: Parser[SharedLaunchOptions] = Parser.derive
+  implicit lazy val help: Help[SharedLaunchOptions]     = Help.derive
 }

--- a/modules/cli/src/main/scala/coursier/cli/options/SharedLoaderOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/options/SharedLoaderOptions.scala
@@ -40,7 +40,6 @@ final case class SharedLoaderOptions(
 // format: on
 
 object SharedLoaderOptions {
-  lazy val parser: Parser[SharedLoaderOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[SharedLoaderOptions, parser.D] = parser
-  implicit lazy val help: Help[SharedLoaderOptions]                      = Help.derive
+  implicit lazy val parser: Parser[SharedLoaderOptions] = Parser.derive
+  implicit lazy val help: Help[SharedLoaderOptions]     = Help.derive
 }

--- a/modules/cli/src/main/scala/coursier/cli/params/SharedLoaderParams.scala
+++ b/modules/cli/src/main/scala/coursier/cli/params/SharedLoaderParams.scala
@@ -3,8 +3,9 @@ package coursier.cli.params
 import cats.data.{Validated, ValidatedNel}
 import cats.implicits._
 import coursier.cli.options.SharedLoaderOptions
+import coursier.core.{Dependency, Module, ModuleName, Organization}
 import coursier.parse.{DependencyParser, JavaOrScalaDependency, ModuleParser}
-import coursier.util.StringInterpolators._
+import coursier.version.VersionConstraint
 
 final case class SharedLoaderParams(
   loaderNames: Seq[String],
@@ -65,7 +66,13 @@ object SharedLoaderParams {
           case Left(err) =>
             Validated.invalidNel(s"$d: $err")
           case Right(m) =>
-            val asDep = JavaOrScalaDependency(m, dep"_:_:_") // actual version shouldn't matter
+            val asDep = JavaOrScalaDependency(
+              m,
+              Dependency(
+                Module(Organization("_"), ModuleName("_"), Map.empty),
+                VersionConstraint("_")
+              )
+            ) // actual version shouldn't matter
             Validated.validNel(target -> asDep)
         }
       }

--- a/modules/cli/src/main/scala/coursier/cli/resolve/SharedResolveOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/resolve/SharedResolveOptions.scala
@@ -68,7 +68,6 @@ final case class SharedResolveOptions(
 }
 
 object SharedResolveOptions {
-  lazy val parser: Parser[SharedResolveOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[SharedResolveOptions, parser.D] = parser
-  implicit lazy val help: Help[SharedResolveOptions]                      = Help.derive
+  implicit lazy val parser: Parser[SharedResolveOptions] = Parser.derive
+  implicit lazy val help: Help[SharedResolveOptions]     = Help.derive
 }

--- a/modules/cli/src/main/scala/coursier/cli/setup/Confirm.scala
+++ b/modules/cli/src/main/scala/coursier/cli/setup/Confirm.scala
@@ -4,7 +4,6 @@ import java.io.{InputStream, PrintStream}
 import java.util.{Locale, Scanner}
 
 import coursier.util.Task
-import dataclass.data
 
 import scala.annotation.tailrec
 
@@ -14,11 +13,10 @@ trait Confirm {
 
 object Confirm {
 
-  @data class ConsoleInput(
+  case class ConsoleInput(
     in: InputStream = System.in,
     out: PrintStream = System.err,
     locale: Locale = Locale.getDefault,
-    @since
     indent: Int = 0
   ) extends Confirm {
     private val marginOpt = if (indent > 0) Some(" " * indent) else None
@@ -59,7 +57,7 @@ object Confirm {
       }
   }
 
-  @data class YesToAll(
+  case class YesToAll(
     out: PrintStream = System.err
   ) extends Confirm {
     def confirm(message: String, default: Boolean): Task[Boolean] =

--- a/modules/cli/src/main/scala/coursier/cli/setup/MaybeInstallApps.scala
+++ b/modules/cli/src/main/scala/coursier/cli/setup/MaybeInstallApps.scala
@@ -2,9 +2,8 @@ package coursier.cli.setup
 
 import coursier.install.{Channels, InstallDir}
 import coursier.util.Task
-import dataclass.data
 
-@data class MaybeInstallApps(
+case class MaybeInstallApps(
   installDir: InstallDir,
   channels: Channels,
   appIds: Seq[String]

--- a/modules/cli/src/main/scala/coursier/cli/setup/MaybeInstallJvm.scala
+++ b/modules/cli/src/main/scala/coursier/cli/setup/MaybeInstallJvm.scala
@@ -6,9 +6,8 @@ import coursier.cache.Cache
 import coursier.env.{EnvironmentUpdate, ProfileUpdater, WindowsEnvVarUpdater}
 import coursier.jvm.{JvmCacheLogger, JavaHome}
 import coursier.util.Task
-import dataclass.data
 
-@data class MaybeInstallJvm(
+case class MaybeInstallJvm(
   coursierCache: Cache[Task],
   envVarUpdaterOpt: Option[Either[WindowsEnvVarUpdater, ProfileUpdater]],
   javaHome: JavaHome,

--- a/modules/cli/src/main/scala/coursier/cli/setup/MaybeSetupPath.scala
+++ b/modules/cli/src/main/scala/coursier/cli/setup/MaybeSetupPath.scala
@@ -5,9 +5,8 @@ import java.nio.file.Path
 import coursier.env.{EnvironmentUpdate, ProfileUpdater, WindowsEnvVarUpdater}
 import coursier.install.InstallDir
 import coursier.util.Task
-import dataclass.data
 
-@data class MaybeSetupPath(
+case class MaybeSetupPath(
   installDir: InstallDir,
   envVarUpdaterOpt: Option[Either[WindowsEnvVarUpdater, ProfileUpdater]],
   getEnv: String => Option[String],

--- a/modules/cli/src/main/scala/coursier/cli/setup/Setup.scala
+++ b/modules/cli/src/main/scala/coursier/cli/setup/Setup.scala
@@ -40,7 +40,7 @@ object Setup extends CoursierCommand[SetupOptions] {
       if (params.env.env) None
       else Some(params.env.envVarUpdater)
 
-    val graalvmHome = { version: String =>
+    val graalvmHome = { (version: String) =>
       javaHome.get(s"graalvm:$version")
     }
 
@@ -56,7 +56,7 @@ object Setup extends CoursierCommand[SetupOptions] {
       if (params.yes)
         Confirm.YesToAll()
       else
-        Confirm.ConsoleInput().withIndent(2)
+        Confirm.ConsoleInput().copy(indent = 2)
 
     val tasks = Seq(
       MaybeInstallJvm(

--- a/modules/cli/src/test/scala/coursier/cli/ParamsTests.scala
+++ b/modules/cli/src/test/scala/coursier/cli/ParamsTests.scala
@@ -4,11 +4,24 @@ import java.io.{File, FileWriter}
 
 import coursier.cli.options.DependencyOptions
 import coursier.cli.params.DependencyParams
-import coursier.parse.JavaOrScalaModule
-import coursier.util.StringInterpolators._
+import coursier.core.Module
+import coursier.parse.{JavaOrScalaModule, ModuleParser}
 import utest._
 
 object ParamsTests extends TestSuite {
+
+  implicit class StringStuff(val sc: StringContext) extends AnyVal {
+    def mod(args: Any*): Module = {
+      val str = sc.s(args: _*)
+      ModuleParser.module(
+        str,
+        scala.util.Properties.versionNumberString
+      ) match {
+        case Left(err)   => sys.error(s"Malformed module '$str': $err")
+        case Right(mod0) => mod0
+      }
+    }
+  }
 
   def withFile(content: String)(testCode: (File, FileWriter) => Any): Unit = {
     val file   = File.createTempFile("hello", "world") // create the fixture

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -4,7 +4,7 @@ object Deps {
   def argonautShapeless = ivy"com.github.alexarchambault::argonaut-shapeless_6.3::1.3.1"
   def caseApp           = ivy"com.github.alexarchambault::case-app:2.1.0-M30"
   def catsCore          = ivy"org.typelevel::cats-core:${Versions.cats}"
-  def catsFree          = ivy"org.typelevel::cats-free:${Versions.cats}"
+  def catsFree213       = ivy"org.typelevel:cats-free_2.13:${Versions.cats}"
   def catsEffect        = ivy"org.typelevel::cats-effect::3.5.7"
   def classPathUtil     = ivy"io.get-coursier::class-path-util:0.1.4"
   def collectionCompat  = ivy"org.scala-lang.modules::scala-collection-compat::2.13.0"
@@ -82,6 +82,7 @@ def scalaCliVersion = "1.5.1"
 def csDockerVersion = "2.1.23"
 
 object ScalaVersions {
+  def scala3   = "3.3.5"
   def scala213 = "2.13.16"
   def scala212 = "2.12.20"
   val all      = Seq(scala213, scala212)

--- a/project/modules/shared.sc
+++ b/project/modules/shared.sc
@@ -213,10 +213,12 @@ trait CsScalaModule extends ScalaModule {
     val scala213Opts =
       if (sv.startsWith("2.13.")) Seq("-Ymacro-annotations", "-Wunused:nowarn")
       else Nil
-    super.scalacOptions() ++ scala212Opts ++ scala213Opts ++ Seq(
+    val scala2Opts =
+      if (sv.startsWith("2.")) Seq("-Xasync")
+      else Nil
+    super.scalacOptions() ++ scala212Opts ++ scala213Opts ++ scala2Opts ++ Seq(
       "-deprecation",
       "-feature",
-      "-Xasync",
       "--release",
       "8"
     )


### PR DESCRIPTION
Running into weird issues with shapeless (via the case-app macros) when building native images with newer GraalVM versions. Scala 3 gets rid of that