### PR TITLE
Various things

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -294,6 +294,7 @@ trait CacheJvm extends CacheJvmBase {
     Deps.plexusArchiver,
     Deps.plexusContainerDefault,
     Deps.scalaCliConfig,
+    Deps.tika,
     Deps.windowsAnsi
   )
   def compileIvyDeps = super.compileIvyDeps() ++ Agg(
@@ -314,6 +315,9 @@ trait CacheJvm extends CacheJvmBase {
       Deps.osLib,
       Deps.pprint,
       Deps.scalaAsync
+    )
+    def compileIvyDeps = super.compileIvyDeps() ++ Agg(
+      Deps.jsoniterMacros
     )
     def forkEnv = super.forkEnv() ++ Seq(
       "COURSIER_CUSTOMPROTOCOL_BASE" -> T.workspace.toString

--- a/build.sc
+++ b/build.sc
@@ -589,6 +589,7 @@ trait Jvm extends CrossSbtModule with CsModule
     Deps.svm
   )
   def ivyDeps = super.ivyDeps() ++ Agg(
+    Deps.jna,
     Deps.jsoniterCore
   )
   object test extends CrossSbtTests with CsTests with CsResourcesTests {

--- a/modules/cache/jvm/src/main/scala/coursier/cache/ArchiveCache.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/ArchiveCache.scala
@@ -144,7 +144,9 @@ object ArchiveCache {
 
   private def archiveType(url: String): ArchiveType =
     // TODO Case-insensitive comparisons?
-    if (url.endsWith(".tar.gz") || url.endsWith(".tgz") || url.endsWith(".apk"))
+    if (url.endsWith(".tar"))
+      ArchiveType.Tar
+    else if (url.endsWith(".tar.gz") || url.endsWith(".tgz") || url.endsWith(".apk"))
       ArchiveType.Tgz
     else if (url.endsWith(".tar.bz2") || url.endsWith(".tbz2"))
       ArchiveType.Tbz2

--- a/modules/cache/jvm/src/main/scala/coursier/cache/ArchiveCache.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/ArchiveCache.scala
@@ -210,6 +210,10 @@ object ArchiveCache {
   def apply[F[_]]()(implicit S: Sync[F] = Task.sync): ArchiveCache[F] =
     ArchiveCache(CacheDefaults.archiveCacheLocation)(S)
 
+  def priviledged[F[_]]()(implicit S: Sync[F] = Task.sync): ArchiveCache[F] =
+    ArchiveCache(CacheDefaults.priviledgedArchiveCacheLocation)(S)
+      .withUnArchiver(UnArchiver.priviledged())
+
   private def deleteRecursive(f: File): Unit = {
     if (f.isDirectory)
       f.listFiles().foreach(deleteRecursive)

--- a/modules/cache/jvm/src/main/scala/coursier/cache/ArchiveCache.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/ArchiveCache.scala
@@ -1,15 +1,11 @@
 package coursier.cache
 
-import coursier.util.Artifact
+import coursier.paths.CachePath
+import coursier.util.{Artifact, Sync, Task}
 import coursier.util.Monad.ops._
 import dataclass._
 
-import coursier.util.Sync
-import coursier.paths.CachePath
-import coursier.util.Task
-
 import java.io.File
-import java.nio.file.attribute.FileTime
 import java.nio.file.{Files, StandardCopyOption}
 
 @data class ArchiveCache[F[_]](

--- a/modules/cache/jvm/src/main/scala/coursier/cache/ArchiveCache.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/ArchiveCache.scala
@@ -27,7 +27,7 @@ import scala.util.Using
     CachePath.localFile(
       artifact.url,
       location,
-      artifact.authentication.map(_.user).orNull,
+      artifact.authentication.flatMap(_.userOpt).orNull,
       true
     )
 

--- a/modules/cache/jvm/src/main/scala/coursier/cache/ArchiveType.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/ArchiveType.scala
@@ -10,6 +10,7 @@ object ArchiveType {
 
   case object Zip  extends ArchiveType
   case object Ar   extends ArchiveType
+  case object Tar  extends Tar
   case object Tgz  extends Tar
   case object Tbz2 extends Tar
   case object Txz  extends Tar
@@ -25,6 +26,7 @@ object ArchiveType {
     input match {
       case "zip"  => Some(Zip)
       case "ar"   => Some(Ar)
+      case "tar"  => Some(Tar)
       case "tgz"  => Some(Tgz)
       case "tbz2" => Some(Tbz2)
       case "txz"  => Some(Txz)

--- a/modules/cache/jvm/src/main/scala/coursier/cache/ArchiveType.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/ArchiveType.scala
@@ -7,6 +7,10 @@ sealed abstract class ArchiveType extends Product with Serializable {
 object ArchiveType {
 
   sealed abstract class Tar extends ArchiveType
+  sealed abstract class Compressed extends ArchiveType {
+    override def singleFile: Boolean = true
+    def tar: Tar
+  }
 
   case object Zip  extends ArchiveType
   case object Ar   extends ArchiveType
@@ -15,11 +19,11 @@ object ArchiveType {
   case object Tbz2 extends Tar
   case object Txz  extends Tar
   case object Tzst extends Tar
-  case object Gzip extends ArchiveType {
-    override def singleFile: Boolean = true
+  case object Gzip extends Compressed {
+    def tar = Tgz
   }
-  case object Xz extends ArchiveType {
-    override def singleFile: Boolean = true
+  case object Xz extends Compressed {
+    def tar = Txz
   }
 
   def parse(input: String): Option[ArchiveType] =
@@ -34,5 +38,12 @@ object ArchiveType {
       case "gz"   => Some(Gzip)
       case "xz"   => Some(Xz)
       case _      => None
+    }
+  def fromMimeType(mimeType: String): Option[ArchiveType] =
+    mimeType match {
+      case "application/gzip" | "application/x-gzip"                      => Some(Gzip)
+      case "application/xz" | "application/x-xz"                          => Some(Xz)
+      case "application/tar" | "application/x-tar" | "application/x-gtar" => Some(Tar)
+      case _                                                              => None
     }
 }

--- a/modules/cache/jvm/src/main/scala/coursier/cache/CacheDefaults.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/CacheDefaults.scala
@@ -20,6 +20,8 @@ object CacheDefaults {
 
   lazy val archiveCacheLocation: File = CachePath.defaultArchiveCacheDirectory()
 
+  lazy val digestBasedCacheLocation: File = CachePath.defaultDigestBasedCacheDirectory()
+
   @deprecated(
     "Legacy cache location support was dropped, this method does nothing.",
     "2.0.0-RC6-22"

--- a/modules/cache/jvm/src/main/scala/coursier/cache/CacheDefaults.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/CacheDefaults.scala
@@ -20,6 +20,9 @@ object CacheDefaults {
 
   lazy val archiveCacheLocation: File = CachePath.defaultArchiveCacheDirectory()
 
+  lazy val priviledgedArchiveCacheLocation: File =
+    CachePath.defaultPriviledgedArchiveCacheDirectory()
+
   lazy val digestBasedCacheLocation: File = CachePath.defaultDigestBasedCacheDirectory()
 
   @deprecated(

--- a/modules/cache/jvm/src/main/scala/coursier/cache/DigestArtifact.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/DigestArtifact.scala
@@ -1,0 +1,10 @@
+package coursier.cache
+
+import dataclass.data
+
+import java.nio.file.Path
+
+@data class DigestArtifact(
+  digest: String,
+  path: Path
+)

--- a/modules/cache/jvm/src/main/scala/coursier/cache/DigestBasedArchiveCache.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/DigestBasedArchiveCache.scala
@@ -1,0 +1,23 @@
+package coursier.cache
+
+import coursier.util.Sync
+import dataclass.data
+
+import java.io.File
+
+@data class DigestBasedArchiveCache[F[_]](
+  archiveCache: ArchiveCache[F]
+)(implicit
+  sync: Sync[F]
+) {
+  private def S = sync
+  def get(artifact: DigestArtifact) =
+    archiveCache.get0(
+      new File(
+        archiveCache.location,
+        s"digest/${artifact.digest.take(2)}/${artifact.digest.drop(2)}"
+      ),
+      None,
+      S.point(Right(artifact.path.toFile))
+    )
+}

--- a/modules/cache/jvm/src/main/scala/coursier/cache/DigestBasedCache.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/DigestBasedCache.scala
@@ -1,0 +1,58 @@
+package coursier.cache
+
+import coursier.cache.DigestArtifact
+import coursier.cache.internal.Retry
+import coursier.util.{Sync, Task}
+import dataclass.data
+
+import java.nio.file.{Files, Path}
+import java.nio.file.StandardCopyOption
+
+@data class DigestBasedCache[F[_]](
+  location: Path,
+  retry: Retry =
+    Retry(
+      CacheDefaults.retryCount,
+      CacheDefaults.retryBackoffInitialDelay,
+      CacheDefaults.retryBackoffMultiplier
+    )
+)(implicit
+  sync: Sync[F]
+) {
+  private def pathFor(digest: String): Path = {
+    assert(digest.length > 2)
+    location.resolve(s"${digest.take(2)}/${digest.drop(2)}")
+  }
+  def `import`(artifact: DigestArtifact): Path = {
+    val path = pathFor(artifact.digest)
+    if (Files.exists(path)) path
+    else
+      CacheLocks.withLockOr(location.toFile, path.toFile, retry)(
+        {
+          if (!Files.exists(path)) {
+            Files.createDirectories(path.getParent)
+            val tmpPath = path.getParent.resolve("." + path.getFileName.toString + ".tmp")
+            try {
+              Files.deleteIfExists(tmpPath)
+              Files.copy(artifact.path, tmpPath)
+              Files.move(tmpPath, path, StandardCopyOption.ATOMIC_MOVE)
+            }
+            finally
+              Files.deleteIfExists(tmpPath)
+          }
+          path
+        },
+        None
+      )
+  }
+  def get(digest: String): Option[Path] = {
+    val path = pathFor(digest)
+    if (Files.exists(path)) Some(path)
+    else None
+  }
+}
+
+object DigestBasedCache {
+  def apply(): DigestBasedCache[Task] =
+    new DigestBasedCache(CacheDefaults.digestBasedCacheLocation.toPath)
+}

--- a/modules/cache/jvm/src/main/scala/coursier/cache/FileCache.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/FileCache.scala
@@ -136,11 +136,11 @@ import scala.util.control.NonFatal
     sumType: String
   ): EitherT[F, ArtifactError, Unit] = {
 
-    val localFile0 = localFile(artifact.url, artifact.authentication.map(_.user))
+    val localFile0 = localFile(artifact.url, artifact.authentication.flatMap(_.userOpt))
 
     val headerSumFile = Seq(auxiliaryFile(localFile0, sumType))
     val downloadedSumFile = artifact.checksumUrls.get(sumType).map { sumUrl =>
-      localFile(sumUrl, artifact.authentication.map(_.user))
+      localFile(sumUrl, artifact.authentication.flatMap(_.userOpt))
     }
 
     EitherT {
@@ -260,7 +260,7 @@ import scala.util.control.NonFatal
         validateChecksum(artifact, c).map(_ => f)
     }.leftFlatMap {
       case err: ArtifactError.WrongChecksum =>
-        val badFile         = localFile(artifact.url, artifact.authentication.map(_.user))
+        val badFile         = localFile(artifact.url, artifact.authentication.flatMap(_.userOpt))
         val badChecksumFile = new File(err.sumFile)
         val foundBadFileInCache = {
           val location0 = location.getCanonicalPath.stripSuffix(File.separator) + File.separator

--- a/modules/cache/jvm/src/main/scala/coursier/cache/UnArchiver.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/UnArchiver.scala
@@ -97,6 +97,8 @@ object UnArchiver {
                   }
               }
             Right(unArc)
+          case ArchiveType.Tar =>
+            Right(new TarUnArchiver)
           case ArchiveType.Tgz =>
             Right(new TarGZipUnArchiver)
           case ArchiveType.Tbz2 =>

--- a/modules/cache/jvm/src/test/scala/coursier/cache/DigestBasedArchiveCacheTests.scala
+++ b/modules/cache/jvm/src/test/scala/coursier/cache/DigestBasedArchiveCacheTests.scala
@@ -1,0 +1,46 @@
+package coursier.cache
+
+import coursier.cache.TestUtil._
+import coursier.core.Authentication
+import coursier.util.{Artifact, Task}
+import utest._
+
+import java.nio.file.Files
+
+object DigestBasedArchiveCacheTests extends TestSuite {
+
+  val tests = Tests {
+
+    test("simple") {
+      withTmpDir { tmpDir =>
+        val archiveCache0 = ArchiveCacheTests.archiveCache(tmpDir / "arc")
+        val digestBased   = DigestBasedArchiveCache(archiveCache0)
+        val cache         = archiveCache0.cache
+
+        val repoName = "library/hello-world"
+        val auth = Authentication.byNameBearerToken(
+          DockerTestUtil.token(repoName)
+        )
+
+        val sha256 = "c9c5fd25a1bdc181cb012bc4fbb1ab272a975728f54064b7ae3ee8e77fd28c46"
+        val file = cache.file(
+          Artifact(s"https://registry-1.docker.io/v2/$repoName/blobs/sha256:$sha256")
+            .withAuthentication(Some(auth))
+        )
+          .run.unsafeRun()(cache.ec)
+          .toTry.get
+          .toPath
+
+        val dir = digestBased.get(DigestArtifact(sha256, file))
+          .unsafeRun()(cache.ec)
+          .toTry.get
+          .toPath
+
+        assert(Files.exists(dir.resolve("hello")))
+        assert(Files.isRegularFile(dir.resolve("hello")))
+      }
+    }
+
+  }
+
+}

--- a/modules/cache/jvm/src/test/scala/coursier/cache/DigestBasedCacheTests.scala
+++ b/modules/cache/jvm/src/test/scala/coursier/cache/DigestBasedCacheTests.scala
@@ -1,0 +1,41 @@
+package coursier.cache
+
+import coursier.cache.TestUtil._
+import coursier.core.Authentication
+import coursier.util.{Artifact, Task}
+import utest._
+
+object DigestBasedCacheTests extends TestSuite {
+
+  val tests = Tests {
+
+    test("simple") {
+      withTmpDir { dir =>
+        // To force re-download things, use this instead:
+        // ArchiveCacheTests.sandboxedCache
+        val cache       = FileCache()
+        val digestBased = DigestBasedCache[Task]((dir / "digest").toNIO)
+
+        val repoName = "library/hello-world"
+        val auth = Authentication.byNameBearerToken(
+          DockerTestUtil.token(repoName)
+        )
+
+        val sha256 = "f1f77a0f96b7251d7ef5472705624e2d76db64855b5b121e1cbefe9dc52d0f86"
+        val file = cache.file(
+          Artifact(s"https://registry-1.docker.io/v2/$repoName/blobs/sha256:$sha256")
+            .withAuthentication(Some(auth))
+        )
+          .run.unsafeRun()(cache.ec)
+          .toTry.get
+
+        val digestCachedFile     = digestBased.`import`(DigestArtifact(sha256, file.toPath))
+        val digestCachedFile0Opt = digestBased.get(sha256)
+
+        assert(digestCachedFile0Opt.contains(digestCachedFile))
+      }
+    }
+
+  }
+
+}

--- a/modules/cache/jvm/src/test/scala/coursier/cache/DockerTestUtil.scala
+++ b/modules/cache/jvm/src/test/scala/coursier/cache/DockerTestUtil.scala
@@ -1,0 +1,27 @@
+package coursier.cache
+
+import com.github.plokhotnyuk.jsoniter_scala.core.{JsonValueCodec, readFromArray}
+import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
+import coursier.cache.internal.FileUtil
+
+import java.net.URL
+
+object DockerTestUtil {
+
+  def token(repoName: String): String = {
+    // FIXME repo escaping
+    val url =
+      s"https://auth.docker.io/token?service=registry.docker.io&scope=repository:$repoName:pull"
+    val conn = new URL(url).openConnection()
+    val b    = FileUtil.readFully(conn.getInputStream())
+    readFromArray(b)(tokenResponseCodec).token
+  }
+
+  private final case class TokenResponse(
+    token: String
+  )
+
+  private implicit lazy val tokenResponseCodec: JsonValueCodec[TokenResponse] =
+    JsonCodecMaker.make
+
+}

--- a/modules/cache/jvm/src/test/scala/coursier/cache/PriviledgedArchiveCacheTests.scala
+++ b/modules/cache/jvm/src/test/scala/coursier/cache/PriviledgedArchiveCacheTests.scala
@@ -1,0 +1,11 @@
+package coursier.cache
+
+import coursier.util.Task
+
+object PriviledgedArchiveCacheTests extends ArchiveCacheTests {
+  override def archiveCache(location: os.Path): ArchiveCache[Task] =
+    ArchiveCache.priviledged[Task]()
+      .withLocation(location.toIO)
+      .withUnArchiver(UnArchiver.priviledgedTestMode())
+  override def notOnWindows = true
+}

--- a/modules/cli/src/test/scala/coursier/cli/FetchTests.scala
+++ b/modules/cli/src/test/scala/coursier/cli/FetchTests.scala
@@ -681,7 +681,7 @@ object FetchTests extends TestSuite {
             |</project>
             |""".stripMargin
 
-        pomPath.getParentFile.mkdirs()
+        Files.createDirectories(pomPath.getParentFile.toPath)
         Files.write(pomPath.toPath, pomContent.getBytes(StandardCharsets.UTF_8))
         // wrong sha-1
         Files.write(

--- a/modules/jvm/src/main/java/coursier/jvm/Execve.java
+++ b/modules/jvm/src/main/java/coursier/jvm/Execve.java
@@ -1,13 +1,36 @@
 package coursier.jvm;
 
+import com.sun.jna.Library;
+import com.sun.jna.Native;
+
+import java.util.Locale;
+
+// bits of this file were written with OpenAI o3-mini
+
 public final class Execve {
 
+  public interface LibC extends Library {
+    LibC INSTANCE = Native.load("c", LibC.class);
+
+    /**
+     * Maps the execve system call:
+     * int execve(const char *filename, char *const argv[], char *const envp[]);
+     *
+     * @param filename the path to the executable
+     * @param argv     the argument array (must be null-terminated)
+     * @param envp     the environment variable array (must be null-terminated)
+     * @return only returns on error (returns -1) because on success the process image is replaced.
+     */
+    int execve(String filename, String[] argv, String[] envp);
+  }
+
   public static boolean available() {
-    return false;
+    String osName = System.getProperty("os.name").toLowerCase(Locale.ROOT);
+    return osName.contains("linux") || osName.contains("mac");
   }
 
   public static void execve(String path, String[] command, String[] env) throws ErrnoException {
-    // Not supported on the JVM, returning immediately
+    LibC.INSTANCE.execve(path, command, env);
   }
 
 }

--- a/modules/paths/src/main/java/coursier/paths/CachePath.java
+++ b/modules/paths/src/main/java/coursier/paths/CachePath.java
@@ -120,6 +120,10 @@ public class CachePath {
         return CoursierPaths.archiveCacheDirectory();
     }
 
+    public static File defaultPriviledgedArchiveCacheDirectory() throws IOException {
+        return CoursierPaths.priviledgedArchiveCacheDirectory();
+    }
+
     public static File defaultDigestBasedCacheDirectory() throws IOException {
         return CoursierPaths.digestBasedCacheDirectory();
     }

--- a/modules/paths/src/main/java/coursier/paths/CachePath.java
+++ b/modules/paths/src/main/java/coursier/paths/CachePath.java
@@ -120,6 +120,10 @@ public class CachePath {
         return CoursierPaths.archiveCacheDirectory();
     }
 
+    public static File defaultDigestBasedCacheDirectory() throws IOException {
+        return CoursierPaths.digestBasedCacheDirectory();
+    }
+
     // Trying to limit the calls to String.intern via this map (https://shipilev.net/jvm/anatomy-quarks/10-string-intern/)
     private static ConcurrentHashMap<String, Object> internedStrings = new ConcurrentHashMap<>();
 

--- a/modules/paths/src/main/java/coursier/paths/CoursierPaths.java
+++ b/modules/paths/src/main/java/coursier/paths/CoursierPaths.java
@@ -29,6 +29,7 @@ public final class CoursierPaths {
     private static final Object cacheDirectoryLock = new Object();
     private static volatile File cacheDirectory0 = null;
     private static volatile File archiveCacheDirectory0 = null;
+    private static volatile File priviledgedArchiveCacheDirectory0 = null;
     private static volatile File digestBasedCacheDirectory0 = null;
     private static volatile File jvmCacheDirectory0 = null;
 
@@ -46,6 +47,10 @@ public final class CoursierPaths {
 
     private static String computeArchiveCacheDirectory() throws IOException {
         return computeCacheDirectory("COURSIER_ARCHIVE_CACHE", "coursier.archive.cache", "arc");
+    }
+
+    private static String computePriviledgedArchiveCacheDirectory() throws IOException {
+        return computeCacheDirectory("COURSIER_PRIVILEDGED_ARCHIVE_CACHE", "coursier.priviledged.archive.cache", "priv");
     }
 
     private static String computeDigestBasedCacheDirectory() throws IOException {
@@ -95,6 +100,18 @@ public final class CoursierPaths {
             }
 
         return archiveCacheDirectory0;
+    }
+
+    public static File priviledgedArchiveCacheDirectory() throws IOException {
+
+        if (priviledgedArchiveCacheDirectory0 == null)
+            synchronized (cacheDirectoryLock) {
+                if (priviledgedArchiveCacheDirectory0 == null) {
+                    priviledgedArchiveCacheDirectory0 = new File(computePriviledgedArchiveCacheDirectory()).getAbsoluteFile();
+                }
+            }
+
+        return priviledgedArchiveCacheDirectory0;
     }
 
     public static File digestBasedCacheDirectory() throws IOException {

--- a/modules/paths/src/main/java/coursier/paths/CoursierPaths.java
+++ b/modules/paths/src/main/java/coursier/paths/CoursierPaths.java
@@ -29,6 +29,7 @@ public final class CoursierPaths {
     private static final Object cacheDirectoryLock = new Object();
     private static volatile File cacheDirectory0 = null;
     private static volatile File archiveCacheDirectory0 = null;
+    private static volatile File digestBasedCacheDirectory0 = null;
     private static volatile File jvmCacheDirectory0 = null;
 
     private static final Object configDirectoryLock = new Object();
@@ -45,6 +46,10 @@ public final class CoursierPaths {
 
     private static String computeArchiveCacheDirectory() throws IOException {
         return computeCacheDirectory("COURSIER_ARCHIVE_CACHE", "coursier.archive.cache", "arc");
+    }
+
+    private static String computeDigestBasedCacheDirectory() throws IOException {
+        return computeCacheDirectory("COURSIER_DIGEST_BASED_CACHE", "coursier.digest-based.cache", "digest");
     }
 
     private static String computeJvmCacheDirectory() throws IOException {
@@ -90,6 +95,18 @@ public final class CoursierPaths {
             }
 
         return archiveCacheDirectory0;
+    }
+
+    public static File digestBasedCacheDirectory() throws IOException {
+
+        if (digestBasedCacheDirectory0 == null)
+            synchronized (cacheDirectoryLock) {
+                if (digestBasedCacheDirectory0 == null) {
+                    digestBasedCacheDirectory0 = new File(computeDigestBasedCacheDirectory()).getAbsoluteFile();
+                }
+            }
+
+        return digestBasedCacheDirectory0;
     }
 
     public static File jvmCacheDirectory() throws IOException {

--- a/modules/util/shared/src/main/scala/coursier/core/Authentication.scala
+++ b/modules/util/shared/src/main/scala/coursier/core/Authentication.scala
@@ -6,7 +6,7 @@ import java.util.Base64
 import dataclass.data
 
 @data class Authentication(
-  user: String,
+  userOpt: Option[String],
   passwordOpt: Option[String],
   httpHeaders: Seq[(String, String)],
   optional: Boolean,
@@ -15,12 +15,41 @@ import dataclass.data
   passOnRedirect: Boolean
 ) {
 
+  @deprecated("Use the override accepting an Option[String] as user", "2.1.25")
+  def this(
+    user: String,
+    passwordOpt: Option[String],
+    httpHeaders: Seq[(String, String)],
+    optional: Boolean,
+    realmOpt: Option[String],
+    httpsOnly: Boolean,
+    passOnRedirect: Boolean
+  ) =
+    this(
+      Some(user),
+      passwordOpt,
+      httpHeaders,
+      optional,
+      realmOpt,
+      httpsOnly,
+      passOnRedirect
+    )
+
+  @deprecated("Use userOpt instead", "2.1.25")
+  def user: String =
+    userOpt.getOrElse {
+      sys.error("Deprecated method not supported when userOpt is empty")
+    }
+
+  def withUser(newUser: String): Authentication =
+    withUserOpt(Some(newUser))
+
   override def toString: String = {
     val headersStr = httpHeaders.map {
       case (k, v) =>
         (k, "****")
     }
-    s"Authentication($user, ****, $headersStr, $optional, $realmOpt, $httpsOnly, $passOnRedirect)"
+    s"Authentication($userOpt, ****, $headersStr, $optional, $realmOpt, $httpsOnly, $passOnRedirect)"
   }
 
   def withPassword(password: String): Authentication =
@@ -29,13 +58,17 @@ import dataclass.data
     withRealmOpt(Some(realm))
 
   def userOnly: Boolean =
-    this == Authentication(user)
+    userOpt.forall { user =>
+      this == Authentication(user)
+    }
 
   def allHttpHeaders: Seq[(String, String)] = {
-    val basicAuthHeader = passwordOpt.toSeq.map { p =>
-      ("Authorization", "Basic " + Authentication.basicAuthenticationEncode(user, p))
-    }
-    basicAuthHeader ++ httpHeaders
+    val basicAuthHeader =
+      for {
+        user     <- userOpt
+        password <- passwordOpt
+      } yield ("Authorization", "Basic " + Authentication.basicAuthenticationEncode(user, password))
+    basicAuthHeader.toSeq ++ httpHeaders
   }
 
 }
@@ -44,7 +77,7 @@ object Authentication {
 
   def apply(user: String): Authentication =
     Authentication(
-      user,
+      Some(user),
       None,
       Nil,
       optional = false,
@@ -54,7 +87,7 @@ object Authentication {
     )
   def apply(user: String, password: String): Authentication =
     Authentication(
-      user,
+      Some(user),
       Some(password),
       Nil,
       optional = false,
@@ -71,7 +104,7 @@ object Authentication {
     httpsOnly: Boolean,
     passOnRedirect: Boolean
   ): Authentication =
-    new Authentication(user, passwordOpt, Nil, optional, realmOpt, httpsOnly, passOnRedirect)
+    new Authentication(Some(user), passwordOpt, Nil, optional, realmOpt, httpsOnly, passOnRedirect)
 
   def apply(
     user: String,
@@ -81,11 +114,11 @@ object Authentication {
     httpsOnly: Boolean,
     passOnRedirect: Boolean
   ): Authentication =
-    Authentication(user, Some(password), Nil, optional, realmOpt, httpsOnly, passOnRedirect)
+    Authentication(Some(user), Some(password), Nil, optional, realmOpt, httpsOnly, passOnRedirect)
 
   def apply(httpHeaders: Seq[(String, String)]): Authentication =
     Authentication(
-      "",
+      Some(""),
       None,
       httpHeaders,
       optional = false,
@@ -101,7 +134,27 @@ object Authentication {
     httpsOnly: Boolean,
     passOnRedirect: Boolean
   ): Authentication =
-    Authentication("", None, httpHeaders, optional, realmOpt, httpsOnly, passOnRedirect)
+    Authentication(Some(""), None, httpHeaders, optional, realmOpt, httpsOnly, passOnRedirect)
+
+  @deprecated("Use the override accepting an Option[String] as user", "2.1.25")
+  def apply(
+    user: String,
+    passwordOpt: Option[String],
+    httpHeaders: Seq[(String, String)],
+    optional: Boolean,
+    realmOpt: Option[String],
+    httpsOnly: Boolean,
+    passOnRedirect: Boolean
+  ): Authentication =
+    Authentication(
+      Some(user),
+      passwordOpt,
+      httpHeaders,
+      optional,
+      realmOpt,
+      httpsOnly,
+      passOnRedirect
+    )
 
   private[coursier] def basicAuthenticationEncode(user: String, password: String): String =
     Base64.getEncoder.encodeToString(

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -57,6 +57,7 @@ object Deps {
   def shapeless                = ivy"com.chuusai::shapeless:2.3.12"
   def slf4JNop                 = ivy"org.slf4j:slf4j-nop:2.0.16"
   def svm                      = ivy"org.graalvm.nativeimage:svm:21.3.13"
+  def tika                     = ivy"org.apache.tika:tika-core:3.0.0"
   def ujson                    = ivy"com.lihaoyi::ujson:4.1.0"
   def utest                    = ivy"com.lihaoyi::utest::0.8.5"
   def versions                 = ivy"io.get-coursier::versions::0.5.0"

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -22,6 +22,7 @@ object Deps {
   def isTerminal        = ivy"io.github.alexarchambault:is-terminal:0.1.2"
   def java8Compat       = ivy"org.scala-lang.modules::scala-java8-compat:1.0.2"
   def jimfs             = ivy"com.google.jimfs:jimfs:1.3.0"
+  def jna               = ivy"net.java.dev.jna:jna:5.12.1"
   def jniUtils          = ivy"io.get-coursier.jniutils:windows-jni-utils:${Versions.jniUtils}"
   def jniUtilsBootstrap =
     ivy"io.get-coursier.jniutils:windows-jni-utils-bootstrap:${Versions.jniUtils}"


### PR DESCRIPTION
This adds
- the ability to detect the archive type in `ArchiveCache`, if the type cannot be determined from the file name
- support for bearer tokens as authentication (only usable from the API for now)
- new shades of caches
  - digest based, to keep things in cache via their sha256
  - digest-based archive cache, to extract archives identified by their sha256
  - priviledged archive cache, to extract archives as root (via `sudo`) and keep their user and group details intact

(That prepares the ground for upcoming fancy stuff)