### PR TITLE
Retry on OverlappingFileLockException

### DIFF
--- a/modules/paths/src/main/java/coursier/paths/CachePath.java
+++ b/modules/paths/src/main/java/coursier/paths/CachePath.java
@@ -9,6 +9,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
@@ -199,6 +200,8 @@ public class CachePath {
                         lock = out.getChannel().lock();
                     } catch (FileNotFoundException ex) {
                         throw throwExceptions ? ex : new StructureLockException(ex);
+                    } catch (OverlappingFileLockException ex) {
+                        throw throwExceptions ? ex : new StructureLockException(ex);
                     }
 
                     try {
@@ -269,6 +272,8 @@ public class CachePath {
                     try {
                         lock = channel.lock();
                     } catch (FileNotFoundException ex) {
+                        throw throwExceptions ? ex : new StructureLockException(ex);
+                    } catch (OverlappingFileLockException ex) {
                         throw throwExceptions ? ex : new StructureLockException(ex);
                     }
 


### PR DESCRIPTION
Fixes https://github.com/coursier/coursier/issues/3267

## Problem
On Windows, Coursier is hitting OverlappingFileLockException reliably in some repos. It seems like the the function in question has a retry logic, but OverlappingFileLockException is not checked.

## Solution
This catches OverlappingFileLockException, so it will be retried.