### PR TITLE
Experiment with looser version constraints from dependency management

### DIFF
--- a/modules/core/shared/src/main/scala/coursier/core/Definitions.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Definitions.scala
@@ -489,7 +489,8 @@ object Attributes {
       .toVector
     val baseRetainedVariants = retainedVariantsFor(attr)
     def isModuleBasedBom =
-      dependencies0.isEmpty && (dependencyManagement0.nonEmpty || !overrides.isEmpty) &&
+      dependencies0.isEmpty &&
+      (dependencyManagement0.nonEmpty || !overrides.isEmpty) &&
       variants.nonEmpty
     val (actualAttr, retainedVariants) =
       if (

--- a/modules/core/shared/src/main/scala/coursier/core/Resolution.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Resolution.scala
@@ -504,6 +504,18 @@ object Resolution {
             dep.versionConstraint.asString.isEmpty ||
             overridesOpt.exists(_.contains(dep0.depManagementKey))
           )
+          if (
+            useManagedVersion && mgmtValues.reconcileVersionConstraint && dep.versionConstraint.asString.nonEmpty && dep.versionConstraint.asString != mgmtValues.versionConstraint.asString
+          ) {
+            val reconciled = ConstraintReconciliation.Default.reconcile(Seq(
+              mgmtValues.versionConstraint,
+              dep.versionConstraint
+            ))
+            // if (!reconciled.contains(mgmtValues.versionConstraint)) {
+            pprint.err.log(dep.versionConstraint.asString)
+            pprint.err.log(mgmtValues.versionConstraint.asString)
+            // }
+          }
           if (useManagedVersion)
             dep = dep.withVersionConstraint(mgmtValues.versionConstraint)
 

--- a/modules/core/shared/src/main/scala/coursier/core/Resolution.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Resolution.scala
@@ -478,7 +478,8 @@ object Resolution {
                   newConfig,
                   newVersion,
                   v.minimizedExclusions,
-                  optional = false
+                  optional = false,
+                  reconcileVersionConstraint = v.reconcileVersionConstraint
                 )
               else
                 v

--- a/modules/core/shared/src/main/scala/coursier/maven/GradleModule.scala
+++ b/modules/core/shared/src/main/scala/coursier/maven/GradleModule.scala
@@ -17,11 +17,11 @@ import coursier.core.{
   Publication,
   Type,
   Variant,
+  VariantPublication,
   VariantSelector
 }
 import coursier.version.{Version, VersionConstraint}
 import dataclass.data
-import coursier.core.VariantPublication
 
 @data class GradleModule(
   formatVersion: String,

--- a/modules/core/shared/src/main/scala/coursier/maven/GradleModule.scala
+++ b/modules/core/shared/src/main/scala/coursier/maven/GradleModule.scala
@@ -20,7 +20,7 @@ import coursier.core.{
   VariantPublication,
   VariantSelector
 }
-import coursier.version.{Version, VersionConstraint}
+import coursier.version.{Version, VersionConstraint, VersionInterval}
 import dataclass.data
 
 @data class GradleModule(
@@ -63,8 +63,28 @@ import dataclass.data
                 if (prefersOpt.isEmpty) versionMap
                 else versionMap - "prefers"
               val version = versionMap0.toSeq match {
-                case Seq(("requires" | "strictly", req)) => VersionConstraint(req)
-                case Seq()                               => VersionConstraint.empty
+                case Seq(("requires", req)) =>
+                  VersionConstraint(req)
+                case Seq(("strictly", req)) =>
+                  val c = VersionConstraint(req)
+                  c.preferred match {
+                    case Some(preferred)
+                        if c.latest.isEmpty && c.interval == VersionInterval.zero =>
+                      VersionConstraint.from(
+                        VersionInterval(
+                          from = Some(preferred),
+                          to = Some(preferred),
+                          fromIncluded = true,
+                          toIncluded = true
+                        ),
+                        None,
+                        None
+                      )
+                    case _ =>
+                      c
+                  }
+                case Seq() =>
+                  VersionConstraint.empty
                 case _ =>
                   val mainDep =
                     s"${actualComponent.group}:${actualComponent.module}:${actualComponent.version}"

--- a/modules/coursier/shared/src/main/scala/coursier/parse/JavaOrScalaDependency.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/parse/JavaOrScalaDependency.scala
@@ -342,7 +342,8 @@ object JavaOrScalaDependency {
                 Configuration.empty,
                 VersionConstraint(overrideDep.version),
                 MinimizedExclusions.zero,
-                optional = false
+                optional = false,
+                reconcileVersionConstraint = false
               )
             ))
           else

--- a/modules/coursier/shared/src/main/scala/coursier/util/StringInterpolators.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/util/StringInterpolators.scala
@@ -185,7 +185,8 @@ object StringInterpolators {
                     ${values.versionConstraint.asString}
                   ),
                   _root_.coursier.core.MinimizedExclusions(_root_.scala.collection.immutable.Set[(_root_.coursier.core.Organization, _root_.coursier.core.ModuleName)](..$excls)),
-                  ${values.optional}
+                  ${values.optional},
+                  ${values.reconcileVersionConstraint}
                 )"""
                 q"_root_.scala.Tuple2($key0, $values0)"
             }

--- a/modules/coursier/shared/src/test/scala/coursier/tests/parse/DependencyParserTests.scala
+++ b/modules/coursier/shared/src/test/scala/coursier/tests/parse/DependencyParserTests.scala
@@ -361,7 +361,8 @@ object DependencyParserTests extends TestSuite {
           Configuration.empty,
           VersionConstraint("1.2"),
           MinimizedExclusions.zero,
-          optional = false
+          optional = false,
+          reconcileVersionConstraint = false
         )
       )
       val res = DependencyParser.dependencyParams(
@@ -395,7 +396,8 @@ object DependencyParserTests extends TestSuite {
               Configuration.empty,
               VersionConstraint("1.2"),
               MinimizedExclusions.zero,
-              optional = false
+              optional = false,
+              reconcileVersionConstraint = false
             )
           ),
           (
@@ -409,7 +411,8 @@ object DependencyParserTests extends TestSuite {
               Configuration.empty,
               VersionConstraint("2.1"),
               MinimizedExclusions.zero,
-              optional = false
+              optional = false,
+              reconcileVersionConstraint = false
             )
           )
         )

--- a/project/modules/core0.sc
+++ b/project/modules/core0.sc
@@ -13,6 +13,7 @@ trait Core extends CsModule with CsCrossJvmJsModule with CoursierPublishModule {
   def ivyDeps = super.ivyDeps() ++ Agg(
     Deps.fastParse,
     Deps.jsoniterCore,
+    Deps.pprint,
     Deps.versions
   )
 


### PR DESCRIPTION
The goal of this PR is to let version constraints from Gradle Module platforms (the Gradle Module equivalent of BOMs) be reconciled with actual versions, rather than blindly override them. That way, these constraints can only bump versions, not downgrade them.

It seems there's no such occurrence of a version downgrade because of a platform in the coursier tests, as the debugging messages show when running things like `./mill 'coursier.jvm[2.13.16].test' "coursier.tests.ResolveTests.gradle modules"`.