### PR TITLE
Use timestamp to compute snapshot version. Fixes #3416

### DIFF
--- a/modules/core/shared/src/main/scala/coursier/maven/Pom.scala
+++ b/modules/core/shared/src/main/scala/coursier/maven/Pom.scala
@@ -424,7 +424,7 @@ object Pom {
     timestamp: String,
     buildNumber: Int
   ): SnapshotVersion = {
-    val value = Version(s"${version.dropRight("SNAPSHOT".length)}$timestamp-$buildNumber")
+    val value = MavenRepositoryInternal.guessSnapshotVersion(version, timestamp, buildNumber)
     SnapshotVersion(Classifier("*"), Extension("*"), value, None)
   }
 


### PR DESCRIPTION
Hello, as discussed in #3416 here is my take on SNAPSHOT artifact version.

# Test 

As asked, here is the command to fetch a reproducible example:

```shell
./mill -i cli.run resolve com.example:snapshot-artifact:0.1.0-SNAPSHOT -r https://maven.pkg.github.com/iilun/coursier-example-package 
```

In order to be as close as possible from my original problem, this is still on the github maven registry. However, this does create the issue that a github Personnal Access Token (legacy) with read on packages must be used to authenticate, so i add to add this before running the test.

```shell
export COURSIER_CREDENTIALS="                                                                                                           
    maven.pkg.github.com username:github_pat
"
```

The PAT does not need specific access as the artifact is public, but github requires authentication.
I do not know how much of an issue it is to give the token in your CI. If it is too much hassle, I can try to replicate on maven central.

With this command, i now fetch buildNumber 2 instead of 1 when using `cs` cli.

# Notes

During the writing of this PR, I found out that the version computation (removing snapshot suffix, adding timestamp, ...) was actually already present, but only used if no snapshot versions exists. I reused the existing code but moved it since it belonged more in maven code than in Pom in my opinion, but please tell me where you would see it best fit.


As always I am open to any feedback, and thank you for your time.