### PR TITLE
Read repositories in config files from Resolve.defaultRepositories

### DIFF
--- a/modules/cli-tests/src/main/scala/coursier/clitests/FetchTests.scala
+++ b/modules/cli-tests/src/main/scala/coursier/clitests/FetchTests.scala
@@ -51,7 +51,7 @@ abstract class FetchTests extends TestSuite {
       }
     }
 
-    test("default repositories") {
+    test("conf file default repositories") {
       TestUtil.withTempDir { tmpDir0 =>
         val tmpDir = os.Path(tmpDir0, os.pwd)
         val cache  = tmpDir / "cache"
@@ -90,6 +90,64 @@ abstract class FetchTests extends TestSuite {
         val gcsPrefix =
           os.rel / "https" / "maven-central.storage-download.googleapis.com" / "maven2"
         assert(jars1.forall(_.startsWith(gcsPrefix)))
+      }
+    }
+
+    test("extra repo and conf file default repositories") {
+
+      // checks that config.json only overrides the default repositories, not the user-added ones
+
+      TestUtil.withTempDir { tmpDir0 =>
+        val tmpDir = os.Path(tmpDir0, os.pwd)
+        val cache  = tmpDir / "cache"
+
+        val args = Seq(
+          "-r",
+          "google",
+          "androidx.compose.animation:animation-core:1.1.1",
+          "--enable-gradle-modules",
+          "--variant",
+          "org.jetbrains.kotlin.platform.type=jvm"
+        )
+        val res0 =
+          os.proc(launcher, "fetch", args, "--cache", cache)
+            .call()
+        val jars0 = res0.out.text()
+          .linesIterator
+          .toVector
+          .map(os.Path(_).relativeTo(cache))
+
+        val centralPrefix = os.rel / "https" / "repo1.maven.org" / "maven2"
+        val googlePrefix  = os.rel / "https" / "maven.google.com"
+        assert(jars0.exists(_.startsWith(centralPrefix)))
+        assert(jars0.exists(_.startsWith(googlePrefix)))
+        assert(jars0.forall(jar => jar.startsWith(centralPrefix) || jar.startsWith(googlePrefix)))
+
+        val configContent =
+          s"""{
+             |  "repositories": {
+             |    "default": [
+             |      "https://maven-central.storage-download.googleapis.com/maven2"
+             |    ]
+             |  }
+             |}
+             |""".stripMargin
+        val configFile = tmpDir / "config.json"
+        os.write(configFile, configContent)
+
+        val res1 =
+          os.proc(launcher, "fetch", args, "--cache", cache)
+            .call(env = Map("SCALA_CLI_CONFIG" -> configFile.toString))
+        val jars1 = res1.out.text()
+          .linesIterator
+          .toVector
+          .map(os.Path(_).relativeTo(cache))
+
+        val gcsPrefix =
+          os.rel / "https" / "maven-central.storage-download.googleapis.com" / "maven2"
+        assert(jars1.exists(_.startsWith(gcsPrefix)))
+        assert(jars1.exists(_.startsWith(googlePrefix)))
+        assert(jars1.forall(jar => jar.startsWith(gcsPrefix) || jar.startsWith(googlePrefix)))
       }
     }
 

--- a/modules/coursier/jvm/src/main/scala/coursier/PlatformResolve.scala
+++ b/modules/coursier/jvm/src/main/scala/coursier/PlatformResolve.scala
@@ -82,19 +82,25 @@ abstract class PlatformResolve {
       .filter(_.nonEmpty)
       .flatMap(fromString(_, "environment variable COURSIER_REPOSITORIES"))
 
-    val fromPropsOpt = sys.props
+    def fromPropsOpt = sys.props
       .get("coursier.repositories")
       .map(_.trim)
       .filter(_.nonEmpty)
       .flatMap(fromString(_, "Java property coursier.repositories"))
 
-    val default = Seq(
+    def fromConfFiles = defaultConfFiles
+      .iterator
+      .flatMap(confFileRepositories(_).iterator)
+      .find(_ => true)
+
+    def default = Seq(
       LocalRepositories.ivy2Local,
       Repositories.central
     )
 
     fromEnvOpt
       .orElse(fromPropsOpt)
+      .orElse(fromConfFiles)
       .getOrElse(default)
   }
 


### PR DESCRIPTION
This makes the repositories added in `config.json` be used instead of the default repositories (the hard-coded ivy2local and Maven Central), but not instead of the user-added repositories. This was a problem in https://github.com/com-lihaoyi/mill/issues/5229, where an in-memory repository was added, but ended up being ignored when users had a `config.json`.