### PR TITLE
Add repository and mirror parser methods returning only ADTs / case classes

### DIFF
--- a/modules/core/shared/src/main/scala/coursier/maven/MavenRepository.scala
+++ b/modules/core/shared/src/main/scala/coursier/maven/MavenRepository.scala
@@ -26,6 +26,21 @@ object MavenRepository {
       versionsCheckHasModule = true,
       checkModule = false
     )
+
+  def apply(
+    root: String,
+    authentication: Option[Authentication],
+    changing: Option[Boolean],
+    versionsCheckHasModule: Boolean,
+    checkModule: Boolean
+  ): MavenRepository =
+    MavenRepository(
+      root,
+      authentication,
+      changing,
+      versionsCheckHasModule,
+      checkModule
+    )
 }
 
 @data(apply = false) class MavenRepository(

--- a/modules/coursier/js/src/main/scala/coursier/PlatformResolve.scala
+++ b/modules/coursier/js/src/main/scala/coursier/PlatformResolve.scala
@@ -15,7 +15,7 @@ abstract class PlatformResolve {
   def defaultMirrors: Seq[Mirror] =
     Nil
 
-  def confFileMirrors(confFile: Path): Seq[Mirror] =
+  def confFileMirrors(confFile: Path): Seq[Mirror.StandardMirror] =
     Nil
   def confFileRepositories(confFile: Path): Option[Seq[Repository]] =
     None

--- a/modules/coursier/js/src/main/scala/coursier/internal/PlatformRepositoryParser.scala
+++ b/modules/coursier/js/src/main/scala/coursier/internal/PlatformRepositoryParser.scala
@@ -1,10 +1,14 @@
 package coursier.internal
 
 import coursier.core.Repository
+import coursier.parse.StandardRepository
 
 abstract class PlatformRepositoryParser {
 
   def repository(input: String): Either[String, Repository] =
     SharedRepositoryParser.repository(input)
+
+  def repositoryAsStandard(input: String): Either[String, StandardRepository] =
+    SharedRepositoryParser.repositoryAsStandard(input)
 
 }

--- a/modules/coursier/jvm/src/main/scala/coursier/PlatformResolve.scala
+++ b/modules/coursier/jvm/src/main/scala/coursier/PlatformResolve.scala
@@ -26,6 +26,9 @@ abstract class PlatformResolve {
 
   /** Default value for mirror repositories */
   lazy val defaultMirrors: Seq[Mirror] =
+    defaultMirrorsAsStandard.map(_.mirror)
+
+  private[coursier] lazy val defaultMirrorsAsStandard: Seq[Mirror.StandardMirror] =
     CoursierEnv.defaultMirrors(
       CoursierEnv.mirrors.read(),
       CoursierEnv.mirrorsExtra.read(),
@@ -33,18 +36,18 @@ abstract class PlatformResolve {
       CacheEnv.configDir.read()
     )
 
-  def confFileMirrors(confFile: Path): Seq[Mirror] =
+  def confFileMirrors(confFile: Path): Seq[Mirror.StandardMirror] =
     CoursierEnv.confFileMirrors(confFile)
 
   def confFileRepositories(confFile: Path): Option[Seq[Repository]] =
-    CoursierEnv.confFileRepositories(confFile)
+    CoursierEnv.confFileRepositories(confFile).map(_.map(_.repository))
 
   /** Default value for repositories */
   lazy val defaultRepositories: Seq[Repository] =
     CoursierEnv.defaultRepositories(
       CoursierEnv.repositories.read(),
       CoursierEnv.scalaCliConfig.read()
-    )
+    ).map(_.repository)
 
   def proxySetup(): Unit =
     if (!SetupProxy.setup()) {

--- a/modules/coursier/jvm/src/main/scala/coursier/internal/PlatformMirrorConfFile.scala
+++ b/modules/coursier/jvm/src/main/scala/coursier/internal/PlatformMirrorConfFile.scala
@@ -11,7 +11,10 @@ abstract class PlatformMirrorConfFile {
   def path: String
   def optional: Boolean
 
-  def mirrors(): Seq[Mirror] = {
+  def mirrors(): Seq[Mirror] =
+    mirrorsAsStandard().map(_.mirror)
+
+  def mirrorsAsStandard(): Seq[Mirror.StandardMirror] = {
 
     val f = new File(path)
 
@@ -22,9 +25,9 @@ abstract class PlatformMirrorConfFile {
         .map { m =>
           m.`type`() match {
             case coursier.paths.Mirror.Types.MAVEN =>
-              MavenMirror(m.from().asScala.toVector, m.to())
+              Mirror.StandardMirror.Maven(MavenMirror(m.from().asScala.toVector, m.to()))
             case coursier.paths.Mirror.Types.TREE =>
-              TreeMirror(m.from().asScala.toVector, m.to())
+              Mirror.StandardMirror.Tree(TreeMirror(m.from().asScala.toVector, m.to()))
             case other =>
               sys.error(s"Unrecognized mirror type $other")
           }

--- a/modules/coursier/shared/src/main/scala/coursier/Resolve.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/Resolve.scala
@@ -198,7 +198,7 @@ import scala.language.higherKinds
   private def allMirrors0 =
     mirrors ++
       mirrorConfFiles.flatMap(_.mirrors()) ++
-      confFiles.flatMap(Resolve.confFileMirrors)
+      confFiles.flatMap(Resolve.confFileMirrors).map(_.mirror)
 
   def allMirrors: F[Seq[Mirror]] =
     S.delay(allMirrors0)

--- a/modules/coursier/shared/src/main/scala/coursier/internal/SharedRepositoryParser.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/internal/SharedRepositoryParser.scala
@@ -4,64 +4,69 @@ import coursier.Repositories
 import coursier.core.Repository
 import coursier.ivy.IvyRepository
 import coursier.maven.MavenRepository
+import coursier.parse.StandardRepository
+import coursier.parse.StandardRepository.syntax._
 
 object SharedRepositoryParser {
 
   def repository(s: String): Either[String, Repository] =
+    repositoryAsStandard(s).map(_.repository)
+
+  def repositoryAsStandard(s: String): Either[String, StandardRepository] =
     if (s == "central")
-      Right(Repositories.central)
+      Right(Repositories.central.asStandard)
     else if (s.startsWith("sonatype:"))
-      Right(Repositories.sonatype(s.stripPrefix("sonatype:")))
+      Right(Repositories.sonatype(s.stripPrefix("sonatype:")).asStandard)
     else if (s.startsWith("sonatype-s01:"))
-      Right(Repositories.sonatypeS01(s.stripPrefix("sonatype-s01:")))
+      Right(Repositories.sonatypeS01(s.stripPrefix("sonatype-s01:")).asStandard)
     else if (s.startsWith("bintray:")) {
       val s0 = s.stripPrefix("bintray:")
       val id =
         if (s.contains("/")) s0
         else s0 + "/maven"
 
-      Right(Repositories.bintray(id))
+      Right(Repositories.bintray(id).asStandard)
     }
     else if (s.startsWith("bintray-ivy:"))
-      Right(Repositories.bintrayIvy(s.stripPrefix("bintray-ivy:")))
+      Right(Repositories.bintrayIvy(s.stripPrefix("bintray-ivy:")).asStandard)
     else if (s.startsWith("typesafe:ivy-"))
-      Right(Repositories.typesafeIvy(s.stripPrefix("typesafe:ivy-")))
+      Right(Repositories.typesafeIvy(s.stripPrefix("typesafe:ivy-")).asStandard)
     else if (s.startsWith("typesafe:"))
-      Right(Repositories.typesafe(s.stripPrefix("typesafe:")))
+      Right(Repositories.typesafe(s.stripPrefix("typesafe:")).asStandard)
     else if (s.startsWith("sbt-maven:"))
-      Right(Repositories.sbtMaven(s.stripPrefix("sbt-maven:")))
+      Right(Repositories.sbtMaven(s.stripPrefix("sbt-maven:")).asStandard)
     else if (s.startsWith("sbt-plugin:"))
-      Right(Repositories.sbtPlugin(s.stripPrefix("sbt-plugin:")))
+      Right(Repositories.sbtPlugin(s.stripPrefix("sbt-plugin:")).asStandard)
     else if (s == "scala-integration" || s == "scala-nightlies")
-      Right(Repositories.scalaIntegration)
+      Right(Repositories.scalaIntegration.asStandard)
     else if (s.startsWith("ivy:")) {
       val s0     = s.stripPrefix("ivy:")
       val sepIdx = s0.indexOf('|')
       if (sepIdx < 0)
-        IvyRepository.parse(s0)
+        IvyRepository.parse(s0).map(_.asStandard)
       else {
         val mainPart     = s0.substring(0, sepIdx)
         val metadataPart = s0.substring(sepIdx + 1)
-        IvyRepository.parse(mainPart, Some(metadataPart))
+        IvyRepository.parse(mainPart, Some(metadataPart)).map(_.asStandard)
       }
     }
     else if (s == "jitpack")
-      Right(Repositories.jitpack)
+      Right(Repositories.jitpack.asStandard)
     else if (s == "clojars")
-      Right(Repositories.clojars)
+      Right(Repositories.clojars.asStandard)
     else if (s == "jcenter")
-      Right(Repositories.jcenter)
+      Right(Repositories.jcenter.asStandard)
     else if (s == "google")
-      Right(Repositories.google)
+      Right(Repositories.google.asStandard)
     else if (s == "gcs")
-      Right(Repositories.centralGcs)
+      Right(Repositories.centralGcs.asStandard)
     else if (s == "gcs-eu")
-      Right(Repositories.centralGcsEu)
+      Right(Repositories.centralGcsEu.asStandard)
     else if (s == "gcs-asia")
-      Right(Repositories.centralGcsAsia)
+      Right(Repositories.centralGcsAsia.asStandard)
     else if (s.startsWith("apache:"))
-      Right(Repositories.apache(s.stripPrefix("apache:")))
+      Right(Repositories.apache(s.stripPrefix("apache:")).asStandard)
     else
-      Right(MavenRepository(s))
+      Right(MavenRepository(s).asStandard)
 
 }

--- a/modules/coursier/shared/src/main/scala/coursier/parse/StandardRepository.scala
+++ b/modules/coursier/shared/src/main/scala/coursier/parse/StandardRepository.scala
@@ -1,0 +1,25 @@
+package coursier.parse
+
+import coursier.core.Repository
+import coursier.ivy.IvyRepository
+import coursier.maven.MavenRepository
+
+sealed abstract class StandardRepository extends Product with Serializable {
+  def repository: Repository
+}
+
+object StandardRepository {
+  final case class Maven(repository: MavenRepository) extends StandardRepository
+  final case class Ivy(repository: IvyRepository)     extends StandardRepository
+
+  object syntax {
+    implicit class MavenRepositoryAsStandard(private val repo: MavenRepository) {
+      def asStandard: StandardRepository =
+        Maven(repo)
+    }
+    implicit class IvyRepositoryAsStandard(private val repo: IvyRepository) {
+      def asStandard: StandardRepository =
+        Ivy(repo)
+    }
+  }
+}


### PR DESCRIPTION
Currently, `Repository` and `Mirror` are open abstract classes, which hinders deriving codecs at compile-time for them (via upickle or other). The changes here adds ADTs that parallel the main implementations of `Repository` and `Mirror`, and adds parser methods returning those rather than just `Repository` or `Mirror`. That way, when only parsed repositories or mirrors are involved, we can derive codecs at compile-time for those.

Not sure I'll merge right now, actually. This was meant to be used in https://github.com/com-lihaoyi/mill/pull/5350, but might end up not being used there (https://github.com/com-lihaoyi/mill/pull/5350#discussion_r2172063109).