### PR TITLE
Allow users to disable FFM use via a global Java property

### DIFF
--- a/modules/paths/src/main/java/coursier/paths/CoursierPaths.java
+++ b/modules/paths/src/main/java/coursier/paths/CoursierPaths.java
@@ -162,10 +162,19 @@ public final class CoursierPaths {
 
     public static ProjectDirectories directoriesInstance(String name) {
         Supplier<Windows> windows;
-        if (coursier.paths.Util.useJni())
-            windows = WindowsJni.getJdkAwareSupplier();
-        else
-            windows = Windows.getDefaultSupplier();
+
+        if (Boolean.getBoolean("coursier.windows.disable-ffm")) {
+            if (coursier.paths.Util.useJni())
+                windows = () -> new dev.dirs.jni.WindowsJni();
+            else
+                windows = () -> new dev.dirs.impl.WindowsPowerShell();
+        }
+        else {
+            if (coursier.paths.Util.useJni())
+                windows = WindowsJni.getJdkAwareSupplier();
+            else
+                windows = Windows.getDefaultSupplier();
+        }
         return ProjectDirectories.from(null, null, name, windows);
     }
 


### PR DESCRIPTION
Meant to be used temporarily by Mill, in order to bump the coursier version, until some more work there allows not to disable this any more