### PR TITLE
Tweak integration tests port use

### DIFF
--- a/modules/cli-tests/src/main/scala/coursier/clitests/BootstrapTests.scala
+++ b/modules/cli-tests/src/main/scala/coursier/clitests/BootstrapTests.scala
@@ -669,7 +669,7 @@ abstract class BootstrapTests extends TestSuite with LauncherOptions {
         val nopeM2Dir = tmpDir / "m2-nope"
         os.write(
           nopeM2Dir / "settings.xml",
-          TestAuthProxy.m2Settings(9083, "wrong", "nope"),
+          TestAuthProxy.m2Settings(9088, "wrong", "nope"),
           createFolders = true
         )
 

--- a/modules/cli-tests/src/main/scala/coursier/clitests/GetTests.scala
+++ b/modules/cli-tests/src/main/scala/coursier/clitests/GetTests.scala
@@ -96,7 +96,7 @@ abstract class GetTests extends TestSuite {
         val nopeM2Dir = tmpDir / "m2-nope"
         os.write(
           nopeM2Dir / "settings.xml",
-          TestAuthProxy.m2Settings(9083, "wrong", "nope"),
+          TestAuthProxy.m2Settings(9087, "wrong", "nope"),
           createFolders = true
         )
 

--- a/modules/cli-tests/src/main/scala/coursier/clitests/util/TestAuthProxy.scala
+++ b/modules/cli-tests/src/main/scala/coursier/clitests/util/TestAuthProxy.scala
@@ -7,7 +7,7 @@ import scala.concurrent.duration._
 
 object TestAuthProxy {
 
-  def defaultPort = 9083
+  def defaultPort = 9085
 
   private lazy val imageId = sys.props.getOrElse(
     "coursier.test.auth-proxy-image",


### PR DESCRIPTION
Saw a transient issue on CI with an already-in-use port. Hoping this should work around that.