### PR TITLE
Check for the integrity of archives before attempting to extract them

### DIFF
--- a/modules/archive-cache/src/main/scala/coursier/cache/ArchiveCache.scala
+++ b/modules/archive-cache/src/main/scala/coursier/cache/ArchiveCache.scala
@@ -6,11 +6,13 @@ import coursier.util.Monad.ops._
 import dataclass._
 import org.apache.tika.Tika
 
-import java.io.File
+import java.io.{File, InputStream}
 import java.math.BigInteger
 import java.nio.file.{Files, Path, StandardCopyOption}
 import java.security.MessageDigest
+import java.util.zip.{GZIPInputStream, ZipException, ZipFile}
 
+import scala.jdk.CollectionConverters._
 import scala.util.Using
 
 @data class ArchiveCache[F[_]](
@@ -32,7 +34,17 @@ import scala.util.Using
     * `{location}\https\github.com\graalvm\graalvm-ce-builds\releases\download\jdk-23.0.1\graalvm-community-jdk-23.0.1_windows-x64_bin.zip\`.
     * The latter directory path is used to compute the hash used in the former one.
     */
-  shortPathDirectory: Option[File] = None
+  shortPathDirectory: Option[File] = None,
+  /** Whether to check the integrity of downloaded archives or not
+    *
+    * This checks for the integrity of archives using their compression format checksums. Only
+    * supported for GZIP and ZIP archives for now.
+    *
+    * If the integrity check fails, a new download is attempted.
+    *
+    * Default: true
+    */
+  integrityCheck: Option[Boolean] = None
 )(implicit
   sync: Sync[F]
 ) {
@@ -226,10 +238,86 @@ import scala.util.Using
     }
   }
 
+  private def integrityCheck0(
+    url: String,
+    file: File
+  ): Option[Boolean] = {
+    def readAndDiscard(is: InputStream): Unit = {
+      val buf  = Array.ofDim[Byte](64 * 1024)
+      var read = 0
+      while ({
+        read = is.read(buf)
+        read >= 0
+      }) {}
+    }
+    ArchiveCache.archiveType(url).collect {
+      case ArchiveType.Gzip =>
+        // read uncompressed content fully to validate GZIP checksum
+        var fis: InputStream = null
+        try {
+          fis = Files.newInputStream(file.toPath)
+          val gzis = new GZIPInputStream(fis)
+          try {
+            readAndDiscard(gzis)
+            true
+          }
+          catch {
+            case _: ZipException =>
+              false
+          }
+        }
+        finally
+          if (fis != null)
+            fis.close()
+      case ArchiveType.Zip =>
+        // read all uncompressed entries fully to validate entries' checksums
+        var zf: ZipFile = null
+        try {
+          zf = new ZipFile(file)
+          try {
+            for (ent <- zf.entries().asScala)
+              readAndDiscard(zf.getInputStream(ent))
+            true
+          }
+          catch {
+            case _: ZipException =>
+              false
+          }
+        }
+        finally
+          if (zf != null)
+            zf.close()
+    }
+  }
+
   def get(artifact: Artifact): F[Either[ArtifactError, File]] = {
     val (dir0, subPaths) = localDir(artifact)
     val artifact0        = artifact.withUrl(artifact.url.takeWhile(_ != '!'))
-    val download: F[Either[ArtifactError, File]] = cache.file(artifact0).run
+    val download: F[Either[ArtifactError, File]] = {
+      def doDownload: F[Either[ArtifactError, File]] = cache.file(artifact0).run
+      if (integrityCheck.getOrElse(true)) {
+        val eitherT = for {
+          f <- EitherT(doDownload)
+          invalid <- EitherT(
+            S.delay[Either[ArtifactError, Boolean]] {
+              Right(integrityCheck0(artifact0.url, f).contains(false))
+            }
+          )
+          f0 <- EitherT[F, ArtifactError, File](
+            if (invalid)
+              S.delay {
+                Files.delete(f.toPath)
+                FileCache.clearAuxiliaryFiles(f)
+              }.flatMap(_ => doDownload)
+            else
+              S.point(Right(f))
+          )
+        } yield f0
+        eitherT.run
+      }
+      else
+        doDownload
+    }
 
     val main = get0(
       dir0,

--- a/modules/archive-cache/src/test/scala/coursier/cache/ArchiveCacheTests.scala
+++ b/modules/archive-cache/src/test/scala/coursier/cache/ArchiveCacheTests.scala
@@ -168,6 +168,90 @@ abstract class ArchiveCacheTests extends TestSuite {
         check(useShortBase = false)
       }
     }
+
+    def integrityTest(
+      artifact: Artifact,
+      expectedElems: Seq[os.SubPath]
+    ): Unit =
+      withTmpDir { dir =>
+        val cache         = FileCache().withLocation((dir / "cache").toIO)
+        val archiveCache0 = archiveCache(dir / "arc").withCache(cache)
+
+        val localArchivePath = cache.file(artifact).run.unsafeRun()(cache.ec) match {
+          case Left(err) =>
+            throw new Exception(err)
+          case Right(f) =>
+            os.Path(f)
+        }
+
+        val size = os.size(localArchivePath)
+
+        // corrupt the archive
+        val content = os.read.bytes(localArchivePath)
+        os.write.over(
+          localArchivePath,
+          content.take(content.length / 2) ++
+            Array.fill[Byte](10)(0) ++
+            content.drop(content.length / 2)
+        )
+        val corruptedSize = os.size(localArchivePath)
+        assert(corruptedSize == size + 10)
+
+        val archiveDir = archiveCache0.get(artifact).unsafeRun()(cache.ec) match {
+          case Left(err) =>
+            throw new Exception(err)
+          case Right(path) =>
+            os.Path(path)
+        }
+
+        val finalSize = os.size(localArchivePath)
+        assert(finalSize == size)
+
+        if (os.isDir(archiveDir)) {
+          import scala.math.Ordering.Implicits._
+          val elems = os.walk(archiveDir)
+            .filter(os.isFile)
+            .map(_.relativeTo(archiveDir).asSubPath)
+            // not sure why this ordering isn't the default
+            .sortBy(_.segments)
+          if (elems != expectedElems)
+            pprint.err.log(elems)
+          assert(expectedElems == elems)
+        }
+        else
+          Nil
+      }
+
+    test("zip integrity") {
+      integrityTest(
+        Artifact(
+          "https://repo1.maven.org/maven2/com/lihaoyi/mill-dist/1.0.3/mill-dist-1.0.3-example-androidlib-java-1-hello-world.zip"
+        ),
+        Seq(
+          os.sub / "app/releaseKey.jks",
+          os.sub / "app/src/androidTest/java/com/helloworld/app/ExampleInstrumentedTest.java",
+          os.sub / "app/src/main/AndroidManifest.xml",
+          os.sub / "app/src/main/java/com/helloworld/SampleLogic.java",
+          os.sub / "app/src/main/java/com/helloworld/app/MainActivity.java",
+          os.sub / "app/src/main/res/values/colors.xml",
+          os.sub / "app/src/main/res/values/strings.xml",
+          os.sub / "app/src/test/java/com/helloworld/ExampleUnitTest.java",
+          os.sub / "build.mill",
+          os.sub / "mill",
+          os.sub / "mill.bat"
+        ).map(os.sub / "mill-dist-1.0.3-example-androidlib-java-1-hello-world" / _)
+      )
+    }
+
+    test("gzip integrity") {
+      integrityTest(
+        // random gzip file found on Maven Central
+        Artifact(
+          "https://repo1.maven.org/maven2/org/danbrough/kotlinxtras/curl/binaries/curlLinuxX64/7_86_0/curlLinuxX64-7_86_0.gz"
+        ),
+        Nil
+      )
+    }
   }
 
   val tests =

--- a/modules/cache/jvm/src/main/scala/coursier/cache/FileCache.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/FileCache.scala
@@ -442,7 +442,7 @@ object FileCache {
   private def auxiliaryFilePrefix(file: File): String =
     s".${file.getName}__"
 
-  private[cache] def clearAuxiliaryFiles(file: File): Unit = {
+  private[coursier] def clearAuxiliaryFiles(file: File): Unit = {
     val prefix = auxiliaryFilePrefix(file)
     val filter: FilenameFilter = new FilenameFilter {
       def accept(dir: File, name: String): Boolean =


### PR DESCRIPTION
This ensures the GZIP or ZIP checksums are correct before attempting to extract a ZIP or GZIP-compressed archive. If the checksums are incorrect, the downloaded archive is deleted from the cache, and a new download is attempted.

This tries to re-download an archive only once per call. That is, an archive might be re-downloaded only once if it looks corrupted when asking the coursier CLI or the archive-cache API for the location where an archive is extracted. New calls might attempt to download the archive again if it still looks corrupted.