### PR TITLE
Fix pre-2.1.25 Versions.latest (no tests)

### DIFF
--- a/modules/core/shared/src/main/scala/coursier/core/Versions.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Versions.scala
@@ -120,7 +120,7 @@ import dataclass.data
 
   @deprecated("Use the override accepting a coursier.version.Latest instead", "2.1.25")
   def latest(kind: Latest): Option[String] =
-    latest(Latest0(kind.name).get).map(_.asString)
+    Latest0("latest." + kind.name).flatMap(latest).map(_.asString)
 
   def candidatesInInterval(itv: VersionInterval0)
     : Iterator[Version0] = {


### PR DESCRIPTION
Fixes https://github.com/coursier/coursier/issues/3342

This is just the fix from https://github.com/coursier/coursier/pull/3343, but without the tests.
The tests from the other PR do pass on my local, but seem to hang on the CI, I'm clueless as to why and how to fix them (commented there: https://github.com/coursier/coursier/pull/3343#issuecomment-2747139649).

The bug is a blocker fur bumping `coursier` in Scala CLI, so I think it'd be beneficial to get it fixed even without a dedicated test.
If we do care about having the test, I need pointers on what's wrong in https://github.com/coursier/coursier/pull/3343

cc @alexarchambault 