### PR TITLE
Fix launch command example

### DIFF
--- a/modules/cli/src/main/scala/coursier/cli/launch/LaunchOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/launch/LaunchOptions.scala
@@ -14,7 +14,7 @@ import coursier.cli.options.OptionGroup
   "\n" +
   "Examples:\n" +
   "$ cs launch org.scalameta:scalafmt-cli:2.4.2 -- --version\n" +
-  "$ cs scalafmt -- --version\n"
+  "$ cs launch scalafmt -- --version\n"
 )
 final case class LaunchOptions(
 


### PR DESCRIPTION
```
% cs launch --help | head
Usage: cs launch [options] [org:name:version*|app-name[:version]]
Launch an application from a dependency or an application descriptor.

Examples:
$ cs launch org.scalameta:scalafmt-cli:2.4.2 -- --version
$ cs scalafmt -- --version

Help options:
  --usage                                        Print usage and exit
  -h, -help, --help                              Print help message and exit

% cs scalafmt -- --version       
Usage: cs <COMMAND>

% cs launch scalafmt -- --version
scalafmt 3.8.1
```