### PR TITLE
More micro-optimizations for `entityIdx`

### DIFF
--- a/modules/core/jvm/src/main/scala/coursier/core/compatibility/package.scala
+++ b/modules/core/jvm/src/main/scala/coursier/core/compatibility/package.scala
@@ -27,14 +27,16 @@ package object compatibility {
 
   private def entityIdx(s: String, fromIdx: Int): (Int, Int) = {
     val len = s.length
-    var i = s.indexOf('&', fromIdx)
+    var i   = s.indexOf('&', fromIdx)
 
     while (i >= 0 && i <= len - 3) { // Need at least &X; (3 chars)
       var j = i + 1
-      while (j < len && {
-        val c = s.charAt(j)
-        (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
-      }) j += 1
+      while (
+        j < len && {
+          val c = s.charAt(j)
+          (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+        }
+      ) j += 1
 
       if (j > i + 1 && j < len && s.charAt(j) == ';')
         return (i, j + 1)
@@ -43,7 +45,6 @@ package object compatibility {
     }
     null
   }
-
 
   private def substituteEntities(s: String): String = {
 


### PR DESCRIPTION
Follow on for https://github.com/coursier/coursier/pull/3468. Without this PR, `entityIdx` still seems to be taking substantial amounts of time when running `./mill clean _ && ./mill __.compile` on the netty codebase

<img width="976" height="652" alt="Screenshot 2025-12-09 at 2 13 23 PM" src="https://github.com/user-attachments/assets/f28ab5e4-c920-4928-95c7-0ad5f44bec0c" />

With this PR published locally, it seems to have dropped off the profiles
