### PR TITLE
feat: Parallelize reverseDependencies computation for faster resolution

### DIFF
--- a/modules/core/js/src/main/scala/coursier/core/compatibility/package.scala
+++ b/modules/core/js/src/main/scala/coursier/core/compatibility/package.scala
@@ -7,6 +7,13 @@ import org.scalajs.dom.{Node, NodeList}
 import coursier.util.{SaxHandler, Xml}
 
 package object compatibility {
+
+  /** Sequential flatMap for JS - Scala.js doesn't support parallel collections. This provides the
+    * same API as the JVM version for cross-platform compatibility.
+    */
+  def parFlatMap[A, B](seq: Seq[A])(f: A => Seq[B]): Seq[B] =
+    seq.flatMap(f)
+
   def option[A](a: js.Dynamic): Option[A] =
     if (js.typeOf(a) == "undefined") None
     else Some(a.asInstanceOf[A])

--- a/modules/core/js/src/main/scala/coursier/core/compatibility/package.scala
+++ b/modules/core/js/src/main/scala/coursier/core/compatibility/package.scala
@@ -14,6 +14,9 @@ package object compatibility {
   def parFlatMap[A, B](seq: Seq[A])(f: A => Seq[B]): Seq[B] =
     seq.flatMap(f)
 
+  def parMap[A, B](seq: Seq[A])(f: A => B): Seq[B] =
+    seq.map(f)
+
   def option[A](a: js.Dynamic): Option[A] =
     if (js.typeOf(a) == "undefined") None
     else Some(a.asInstanceOf[A])

--- a/modules/core/jvm/src/main/scala/coursier/core/compatibility/package.scala
+++ b/modules/core/jvm/src/main/scala/coursier/core/compatibility/package.scala
@@ -42,6 +42,9 @@ package object compatibility {
     }
   }
 
+  def parMap[A, B](seq: Seq[A])(f: A => B): Seq[B] =
+    parFlatMap(seq)(a => Seq(f(a)))
+
   implicit class RichChar(val c: Char) extends AnyVal {
     def letterOrDigit = c.isLetterOrDigit
     def letter        = c.isLetter

--- a/modules/core/shared/src/main/scala/coursier/core/Resolution.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Resolution.scala
@@ -1483,9 +1483,9 @@ object Resolution {
     */
   lazy val transitiveDependenciesAndErrors
     : (Seq[(Dependency, DependencyError)], Seq[Dependency]) = {
-    val l = (dependencySet.minimizedSet -- conflicts)
-      .toVector
-      .map(dep => finalDependencies0(dep).left.map((dep, _)))
+    val l = compatibility.parMap((dependencySet.minimizedSet -- conflicts).toVector) { dep =>
+      finalDependencies0(dep).left.map((dep, _))
+    }
     val errors = l.collect {
       case Left(depAndError) => depAndError
     }

--- a/modules/core/shared/src/main/scala/coursier/core/Resolution.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Resolution.scala
@@ -2380,7 +2380,7 @@ object Resolution {
       )
 
     @tailrec def helper(current: Set[Dependency]): Either[DependencyError, Set[Dependency]] = {
-      val extraDepsOrErrors = current.toSeq.map(finalDependencies0)
+      val extraDepsOrErrors = compatibility.parMap(current.toVector)(finalDependencies0)
       val errors = extraDepsOrErrors.collect {
         case Left(err) => err
       }


### PR DESCRIPTION
This is more of a discussion to see how to potentially improve the performance of resolving a large set of dependencies.

We operate a monorepo using Bazel and rules_jvm_external which uses Coursier to resolve a dependency tree. Since we have a very large number of dependencies, the resolution part has been slow. When examining how Coursier works, we find that a single threaded operation takes very long to finish. Pairing up with Claude, we get this change and would like to discuss with you folks. As we are not familiar with this code base, we have no idea whether Claude is doing the right thing or just messing it up.

From Claude:
-------------------------
Problem:
- Thread dump showed single thread spending 168+ seconds in reverseDependencies
- Scala 2 lazy val holds object lock via synchronized(this) during entire computation
- Sequential iteration through hundreds of dependencies calling finalDependencies0
- Each call invokes substituteProps (CPU-intensive string parsing)
- No parallelism possible due to lazy val locking semantics

Solution:
- Add platform-specific parFlatMap helper to compatibility package
- JVM: Creates FixedThreadPool sized to min(numElements, availableProcessors)
- JS: Sequential fallback (Scala.js doesn't support parallel execution)
- Threads named "coursier-resolution-worker-{id}" for jstack visibility
- Uses executor.invokeAll() to run tasks in parallel, collect results after

Concurrency safety analysis:
- substituteProps: Pure function, local variables only - safe
- finalDependencies: Immutable inputs, local variables - safe
- projectCache/finalDependenciesCache: Immutable Scala Maps - safe
- finalDependenciesCache0: Per-instance ConcurrentHashMap - safe
- parFlatMap: ArrayBuffer accessed sequentially after invokeAll - safe
- Benign race in finalDependencies0: Multiple threads may compute same result for same dep, but computation is deterministic so result is identical. ConcurrentHashMap.put() is atomic. Wasteful but correct.

Files changed:
- modules/core/jvm/.../compatibility/package.scala: Add parallel parFlatMap
- modules/core/js/.../compatibility/package.scala: Add sequential parFlatMap
- modules/core/shared/.../Resolution.scala: Use parFlatMap in reverseDependencies

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>