### PR TITLE
Catch and retry ConnectException on downloads

### DIFF
--- a/modules/cache/jvm/src/main/scala/coursier/cache/internal/Downloader.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/internal/Downloader.scala
@@ -858,6 +858,7 @@ object Downloader {
       case _: AccessDeniedException if Properties.isWin =>
       case _: javax.net.ssl.SSLException                =>
       case _: java.net.SocketException                  =>
+      case _: java.net.ConnectException                 =>
       // TODO Allow to log that exception.
     }
 


### PR DESCRIPTION
Attempts to mitigate around flakiness we've been seeing in the Mill build e.g. https://github.com/com-lihaoyi/mill/actions/runs/21331184494/job/61396181574

```
1/1, 1 FAILED] ./mill selective.run example.thirdparty[{acyclic,fansi,gatling}].native.daemon 551s
6921] [error] libs.kotlinlib.worker.resolvedMvnDeps
java.lang.RuntimeException: Failed to load dependencies
  download error: Caught java.net.ConnectException (Operation timed out) while downloading https://repo1.maven.org/maven2/org/jetbrains/annotations/23.0.0/annotations-23.0.0.jar
  scala.sys.package$.error(package.scala:28)
  mill.api.daemon.Result$Failure.get(Result.scala:60)
  mill.api.daemon.Result$Failure.get(Result.scala:60)
  mill.javalib.CoursierModule$Resolver.classpath(CoursierModule.scala:268)
  mill.javalib.JavaModule.resolvedMvnDeps0$$anonfun$1(JavaModule.scala:1070)
  mill.api.Task$Anon.evaluate(Task.scala:471)
```