### PR TITLE
Add experimental cache server stuff for agent-based development

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -62,6 +62,8 @@ object cache extends Module {
   object jvm    extends Cross[CacheJvm](ScalaVersions.all)
   object js     extends Cross[CacheJs](ScalaVersions.all)
 }
+object `cache-server` extends Cross[CacheServer](Seq(ScalaVersions.scala213))
+
 object `archive-cache`      extends Cross[ArchiveCache](ScalaVersions.all)
 object launcher             extends Cross[Launcher](ScalaVersions.all)
 object env                  extends Cross[Env](ScalaVersions.all)
@@ -840,7 +842,8 @@ trait Cli extends CsModule
     install(cliScalaVersion213Compat),
     jvm(cliScalaVersion213Compat),
     docker(cliScalaVersion),
-    launcherModule(cliScalaVersion213Compat)
+    launcherModule(cliScalaVersion213Compat),
+    `cache-server`(cliScalaVersion213Compat)
   )
   def artifactName = "coursier-cli"
   def mvnDeps = super.mvnDeps() ++ Seq(
@@ -1630,4 +1633,18 @@ object docs extends ScalaModule {
 
     ()
   }
+}
+
+trait CacheServer extends CrossSbtModule with CsModule with CoursierPublishModule with CsMima {
+  def artifactName = "coursier-cache-server"
+  def moduleDeps = super.moduleDeps ++ Seq(
+    cache.jvm()
+  )
+  def mvnDeps = super.mvnDeps() ++ Seq(
+    Deps.osLib,
+    Deps.undertow
+  )
+  def compileMvnDeps = super.compileMvnDeps() ++ Seq(
+    Deps.jsoniterMacros
+  )
 }

--- a/build.mill
+++ b/build.mill
@@ -76,6 +76,8 @@ object `benchmark` extends ScalaModule with JmhModule {
   def jmhCoreVersion = "1.35"
 }
 
+object `cache-server` extends Cross[CacheServer](ScalaVersions.all)
+
 object launcher             extends Cross[Launcher](ScalaVersions.all)
 object env                  extends Cross[Env](ScalaVersions.all)
 object `launcher-native_04` extends LauncherNative04
@@ -413,6 +415,10 @@ trait CacheJvm extends CacheJvmBase {
     def sources = Task {
       super.sources() ++ cache.shared.testSources()
     }
+    def moduleDeps = super.moduleDeps ++ Seq(
+      coursier.jvm(),
+      `cache-server`(crossValue)
+    )
     def mvnDeps = super.mvnDeps() ++ Seq(
       Deps.http4sBlazeServer,
       Deps.http4sDsl,
@@ -891,7 +897,8 @@ trait Cli extends CsModule
     install(cliScalaVersion213Compat),
     jvm(cliScalaVersion213Compat),
     docker(cliScalaVersion),
-    launcherModule(cliScalaVersion213Compat)
+    launcherModule(cliScalaVersion213Compat),
+    `cache-server`(cliScalaVersion213Compat)
   )
   def artifactName = "coursier-cli"
   def mvnDeps = super.mvnDeps() ++ Seq(
@@ -1636,5 +1643,35 @@ object docs extends ScalaModule {
       .call(cwd = BuildCtx.workspaceRoot / "docs", stdin = os.Inherit, stdout = os.Inherit)
 
     ()
+  }
+}
+
+trait CacheServer extends CrossSbtModule with CsModule with CoursierPublishModule with CsMima {
+  def artifactName = "coursier-cache-server"
+  def moduleDeps = super.moduleDeps ++ Seq(
+    cache.jvm()
+  )
+  def mvnDeps = super.mvnDeps() ++ Seq(
+    Deps.osLib,
+    Deps.undertow
+  )
+  def compileMvnDeps = super.compileMvnDeps() ++ Seq(
+    Deps.jsoniterMacros
+  )
+
+  def mimaPreviousVersions = Task {
+    import _root_.coursier.version.Version
+    val cutOff = Version("2.1.25")
+    super.mimaPreviousVersions()
+      .map(Version(_))
+      .filter(_ >= cutOff)
+      .map(_.repr)
+  }
+  // Remove once 2.1.25 is out
+  def mimaPreviousArtifacts = Task {
+    val versions     = mimaPreviousVersions()
+    val organization = pomSettings().organization
+    val artifactId0  = artifactId()
+    versions.map(version => mvn"$organization:$artifactId0:$version")
   }
 }

--- a/mill-build/src/coursierbuild/Deps.scala
+++ b/mill-build/src/coursierbuild/Deps.scala
@@ -67,6 +67,7 @@ object Deps {
     def slf4JNop                 = mvn"org.slf4j:slf4j-nop:2.0.17"
     def svm                      = mvn"org.graalvm.nativeimage:svm:21.3.15"
     def tika                     = mvn"org.apache.tika:tika-core:3.2.3"
+    def undertow                 = mvn"io.undertow:undertow-core:2.3.18.Final"
     def ujson                    = mvn"com.lihaoyi::ujson:4.3.2"
     def utest                    = mvn"com.lihaoyi::utest::0.9.1"
     def versions                 = mvn"io.get-coursier::versions::0.5.1"

--- a/mill-build/src/coursierbuild/Deps.scala
+++ b/mill-build/src/coursierbuild/Deps.scala
@@ -68,6 +68,7 @@ object Deps {
     def slf4JNop                 = mvn"org.slf4j:slf4j-nop:2.0.17"
     def svm                      = mvn"org.graalvm.nativeimage:svm:21.3.15"
     def tika                     = mvn"org.apache.tika:tika-core:3.2.3"
+    def undertow                 = mvn"io.undertow:undertow-core:2.3.18.Final"
     def ujson                    = mvn"com.lihaoyi::ujson:4.3.2"
     def utest                    = mvn"com.lihaoyi::utest::0.9.1"
     def versions                 = mvn"io.get-coursier::versions::0.5.3"

--- a/mill-build/src/coursierbuild/modules/CacheJvmBase.scala
+++ b/mill-build/src/coursierbuild/modules/CacheJvmBase.scala
@@ -9,6 +9,10 @@ trait CacheJvmBase extends Cache with CsMima {
 
   def mimaBinaryIssueFilters =
     super.mimaBinaryIssueFilters() ++ Seq(
+      ProblemFilter.exclude[IncompatibleResultTypeProblem](
+        "coursier.cache.PlatformCacheCompanion.default"
+      ),
+      ProblemFilter.exclude[IncompatibleResultTypeProblem]("coursier.cache.Cache.default"),
       // moved a different module (archive-cache, NOT pulled transitively)
       ProblemFilter.exclude[MissingClassProblem]("coursier.cache.ArchiveCache"),
       ProblemFilter.exclude[MissingClassProblem]("coursier.cache.ArchiveCache$"),

--- a/modules/archive-cache/src/main/scala/coursier/cache/ArchiveCache.scala
+++ b/modules/archive-cache/src/main/scala/coursier/cache/ArchiveCache.scala
@@ -17,7 +17,7 @@ import scala.util.Using
 
 @data class ArchiveCache[F[_]](
   location: File,
-  cache: Cache[F] = FileCache(),
+  cache: Cache[F] = Cache.defaultFor[F],
   unArchiver: UnArchiver = UnArchiver.default(),
   @since("2.1.25")
   openStream: UnArchiver.OpenStream = UnArchiver.default(),

--- a/modules/archive-cache/src/test/scala/coursier/cache/ArchiveCacheTests.scala
+++ b/modules/archive-cache/src/test/scala/coursier/cache/ArchiveCacheTests.scala
@@ -57,6 +57,13 @@ abstract class ArchiveCacheTests extends TestSuite {
       }
     }
 
+  private def defaultCache() =
+    Cache.default match {
+      case fc: FileCache[Task] => fc
+      case other =>
+        sys.error(s"Expected default cache to be a FileCache, got $other")
+    }
+
   def actualTests = Tests {
     test("jar") {
       checkArchiveHas(
@@ -175,7 +182,7 @@ abstract class ArchiveCacheTests extends TestSuite {
       truncate: Boolean
     ): Unit =
       withTmpDir { dir =>
-        val cache         = FileCache().withLocation((dir / "cache").toIO)
+        val cache         = defaultCache().withLocation((dir / "cache").toIO)
         val archiveCache0 = archiveCache(dir / "arc").withCache(cache)
 
         val localArchivePath = cache.file(artifact).run.unsafeRun()(cache.ec) match {

--- a/modules/archive-cache/src/test/scala/coursier/cache/ArchiveCacheTests.scala
+++ b/modules/archive-cache/src/test/scala/coursier/cache/ArchiveCacheTests.scala
@@ -57,6 +57,13 @@ abstract class ArchiveCacheTests extends TestSuite {
       }
     }
 
+  private def defaultCache() =
+    Cache.default match {
+      case fc: FileCache[Task] => fc
+      case other =>
+        sys.error(s"Expected default cache to be a FileCache, got $other")
+    }
+
   def actualTests = Tests {
     test("jar") {
       checkArchiveHas(
@@ -206,7 +213,7 @@ abstract class ArchiveCacheTests extends TestSuite {
       truncate: Boolean
     ): Unit =
       withTmpDir { dir =>
-        val cache         = FileCache().withLocation((dir / "cache").toIO)
+        val cache         = defaultCache().withLocation((dir / "cache").toIO)
         val archiveCache0 = archiveCache(dir / "arc").withCache(cache)
 
         val localArchivePath = cache.file(artifact).run.unsafeRun()(cache.ec) match {

--- a/modules/cache-server/src/main/scala/coursier/cache/server/CacheServer.scala
+++ b/modules/cache-server/src/main/scala/coursier/cache/server/CacheServer.scala
@@ -1,0 +1,181 @@
+package coursier.cache.server
+
+import com.github.plokhotnyuk.jsoniter_scala.core._
+import coursier.cache.{ArtifactError, FileCache}
+import coursier.util.Task
+import io.undertow.server.{HttpHandler, HttpServerExchange}
+import io.undertow.util.{Headers, StatusCodes}
+
+import java.util.concurrent.ConcurrentHashMap
+
+import scala.concurrent.{ExecutionContextExecutor, Future, Promise}
+import scala.util.control.NonFatal
+import scala.util.{Failure, Success, Try}
+
+object CacheServer {
+
+  import Model._
+
+  private def internalError(
+    requestBytes: Array[Byte],
+    exchange: HttpServerExchange,
+    t: Throwable
+  ): Unit = {
+    System.err.println(
+      s"Caught exception while processing ${Try(new String(requestBytes))}"
+    )
+    t.printStackTrace(System.err)
+    exchange.getResponseHeaders.put(Headers.CONTENT_TYPE, "text/plain")
+    exchange.setStatusCode(StatusCodes.INTERNAL_SERVER_ERROR)
+    exchange.getResponseSender.send("Internal error")
+  }
+
+  def handler(cache: FileCache[Task], pool: ExecutionContextExecutor): HttpHandler = {
+    val cachePath          = os.Path(cache.location)
+    val onGoingGetRequests = new ConcurrentHashMap[String, Future[_]]
+
+    (exchange: HttpServerExchange) =>
+      if (exchange.getRequestPath == "/get" && exchange.getRequestMethod.toString == "POST")
+        exchange.getRequestReceiver.receiveFullBytes {
+          (exchange: HttpServerExchange, bytes: Array[Byte]) =>
+            exchange.dispatch(
+              pool,
+              () => {
+                val maybeRequest = Try(readFromArray[GetRequest](bytes))
+
+                def proceed(whenDone: () => Unit): Unit = {
+                  val maybeFutureResult = maybeRequest.map { request =>
+                    val artifact = request.artifact.toArtifact
+                    // System.err.println(
+                    //   s"Was asked ${artifact.url}" +
+                    //     request.cachePolicy.map(" (" + _ + ")").getOrElse("")
+                    // )
+                    val fileTask = request.cachePolicy.flatMap(Model.parseCachePolicy) match {
+                      case Some(policy) => cache.filePerPolicy(artifact, policy)
+                      case None         => cache.file(artifact)
+                    }
+                    fileTask.run.future()(cache.ec)
+                  }
+
+                  maybeFutureResult match {
+                    case Success(futureResult) =>
+                      futureResult.onComplete { result =>
+                        whenDone()
+                        val response = result match {
+                          case Success(Right(file)) =>
+                            val relativePath = os.Path(file).subRelativeTo(cachePath).toString
+                            GetResponse(
+                              path = Some(relativePath),
+                              error = None
+                            )
+                          case Success(Left(err: ArtifactError)) =>
+                            GetResponse(
+                              path = None,
+                              error = Some(SerializedArtifactError(
+                                err.`type`,
+                                err.message,
+                                SerializedException.fromThrowable(err)
+                              ))
+                            )
+                          case Failure(t) =>
+                            GetResponse(
+                              path = None,
+                              error = Some(SerializedArtifactError(
+                                "exception",
+                                Option(t.getMessage).getOrElse(""),
+                                SerializedException.fromThrowable(t)
+                              ))
+                            )
+                        }
+
+                        // System.err.println(response)
+
+                        exchange.getResponseHeaders.put(Headers.CONTENT_TYPE, "application/json")
+                        exchange.getResponseSender.send(writeToString(response))
+                      }(pool)
+                    case Failure(t) =>
+                      whenDone()
+                      internalError(bytes, exchange, t)
+                  }
+                }
+
+                maybeRequest match {
+                  case Success(request) =>
+                    val promise = Promise[Unit]()
+                    def attempt(): Unit = {
+                      val f = promise.future
+                      Option(onGoingGetRequests.putIfAbsent(request.artifact.url, f)) match {
+                        case Some(previous) =>
+                          previous.onComplete { _ =>
+                            attempt()
+                          }(pool)
+                        case None =>
+                          proceed { () =>
+                            val result = onGoingGetRequests.remove(request.artifact.url, f)
+                            assert(result)
+                            promise.success(())
+                          }
+                      }
+                    }
+                    attempt()
+                  case Failure(t) =>
+                    internalError(bytes, exchange, t)
+                }
+              }
+            )
+        }
+      else if (exchange.getRequestPath == "/path" && exchange.getRequestMethod.toString == "POST")
+        exchange.getRequestReceiver.receiveFullBytes {
+          (exchange: HttpServerExchange, bytes: Array[Byte]) =>
+            exchange.dispatch(
+              pool,
+              () => {
+                val maybeFutureResult = Try {
+                  val request  = readFromArray[PathRequest](bytes)
+                  val artifact = request.artifact.toArtifact
+                  // System.err.println(s"Was asked the path of ${artifact.url}")
+                  val fileTask = cache.finalLocalPath(artifact)
+                  fileTask.future()(cache.ec)
+                }
+
+                maybeFutureResult match {
+                  case Success(futureResult) =>
+                    futureResult.onComplete { result =>
+                      val response = result match {
+                        case Success(file) =>
+                          // pprint.err.log(file)
+                          val relativePath = os.Path(file).subRelativeTo(cachePath).toString
+                          PathResponse(
+                            path = Some(relativePath),
+                            error = None
+                          )
+                        case Failure(t) =>
+                          PathResponse(
+                            path = None,
+                            error = Some(SerializedArtifactError(
+                              "exception",
+                              Option(t.getMessage).getOrElse(""),
+                              SerializedException.fromThrowable(t)
+                            ))
+                          )
+                      }
+
+                      // System.err.println(response)
+
+                      exchange.getResponseHeaders.put(Headers.CONTENT_TYPE, "application/json")
+                      exchange.getResponseSender.send(writeToString(response))
+                    }(pool)
+                  case Failure(t) =>
+                    internalError(bytes, exchange, t)
+                }
+              }
+            )
+        }
+      else
+        exchange
+          .setStatusCode(404)
+          .getResponseSender
+          .send("Not found")
+  }
+
+}

--- a/modules/cache/js/src/main/scala/coursier/cache/PlatformCache.scala
+++ b/modules/cache/js/src/main/scala/coursier/cache/PlatformCache.scala
@@ -1,3 +1,6 @@
 package coursier.cache
 
-abstract class PlatformCache[F[_]]
+abstract class PlatformCache[F[_]] {
+  def loggerOpt: Option[CacheLogger] =
+    None
+}

--- a/modules/cache/jvm/src/main/scala/coursier/cache/CacheDefaults.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/CacheDefaults.scala
@@ -7,6 +7,7 @@ import coursier.credentials.Credentials
 import coursier.paths.CachePath
 import coursier.util.Sync
 
+import scala.cli.config.Secret
 import scala.concurrent.duration.{Duration, DurationInt, FiniteDuration}
 import scala.util.Try
 
@@ -22,6 +23,19 @@ object CacheDefaults {
     CachePath.defaultPriviledgedArchiveCacheDirectory()
 
   lazy val digestBasedCacheLocation: File = CachePath.defaultDigestBasedCacheDirectory()
+
+  lazy val cacheServerAddress: Option[String] =
+    CacheEnv.defaultServerAddress(CacheEnv.server.read())
+  lazy val cacheServerBasicAuth: Option[Secret[String]] = {
+    val userValues     = CacheEnv.serverUser.read()
+    val passwordValues = CacheEnv.serverPassword.read()
+    val userOpt        = userValues.prop.orElse(userValues.env)
+    val passwordOpt    = passwordValues.prop.orElse(passwordValues.env)
+    if (userOpt.isEmpty && passwordOpt.isEmpty)
+      None
+    else
+      Some(Secret((userOpt.toSeq ++ passwordOpt.toSeq).mkString(":")))
+  }
 
   @deprecated(
     "Legacy cache location support was dropped, this method does nothing.",
@@ -39,7 +53,8 @@ object CacheDefaults {
         defaultConcurrentDownloadCount
       )
 
-  lazy val pool = Sync.fixedThreadPool(concurrentDownloadCount)
+  lazy val pool         = Sync.fixedThreadPool(concurrentDownloadCount)
+  lazy val watchLenPool = Sync.fixedThreadPool(concurrentDownloadCount)
 
   def parseDuration(s: String): Either[Throwable, Duration] =
     CacheEnv.parseDuration(s)

--- a/modules/cache/jvm/src/main/scala/coursier/cache/CacheEnv.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/CacheEnv.scala
@@ -26,6 +26,15 @@ object CacheEnv {
   /** Env var and Java prop names for the archive cache location */
   val archiveCache = EnvEntry("COURSIER_ARCHIVE_CACHE", "coursier.archive.cache")
 
+  /** Env var and Java prop names for the cache server */
+  val server = EnvEntry("COURSIER_CACHE_SERVER", "coursier.cache.server")
+
+  /** Env var and Java prop names for the cache server user */
+  val serverUser = EnvEntry("COURSIER_CACHE_SERVER_USER", "coursier.cache.server.user")
+
+  /** Env var and Java prop names for the cache server password */
+  val serverPassword = EnvEntry("COURSIER_CACHE_SERVER_PASSWORD", "coursier.cache.server.password")
+
   /** Env var and Java prop names for credentials */
   val credentials = EnvEntry("COURSIER_CREDENTIALS", "coursier.credentials")
 
@@ -60,6 +69,11 @@ object CacheEnv {
         "arc"
       )
     )
+
+  /** Computes the default main cache location from the passed env var and Java property */
+  def defaultServerAddress(values: EnvValues): Option[String] =
+    values.prop.map(_.trim).filter(_.nonEmpty)
+      .orElse(values.env.map(_.trim).filter(_.nonEmpty))
 
   private def isPropFile(s: String) =
     s.startsWith("/") || s.startsWith("file:")

--- a/modules/cache/jvm/src/main/scala/coursier/cache/CacheEnv.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/CacheEnv.scala
@@ -26,6 +26,15 @@ object CacheEnv {
   /** Env var and Java prop names for the archive cache location */
   val archiveCache = EnvEntry("COURSIER_ARCHIVE_CACHE", "coursier.archive.cache")
 
+  /** Env var and Java prop names for the cache server */
+  val server = EnvEntry("COURSIER_CACHE_SERVER", "coursier.cache.server")
+
+  /** Env var and Java prop names for the cache server user */
+  val serverUser = EnvEntry("COURSIER_CACHE_SERVER_USER", "coursier.cache.server.user")
+
+  /** Env var and Java prop names for the cache server password */
+  val serverPassword = EnvEntry("COURSIER_CACHE_SERVER_PASSWORD", "coursier.cache.server.password")
+
   /** Env var and Java prop names for credentials */
   val credentials = EnvEntry("COURSIER_CREDENTIALS", "coursier.credentials")
 
@@ -66,6 +75,11 @@ object CacheEnv {
         "arc"
       )
     )
+
+  /** Computes the default main cache location from the passed env var and Java property */
+  def defaultServerAddress(values: EnvValues): Option[String] =
+    values.prop.map(_.trim).filter(_.nonEmpty)
+      .orElse(values.env.map(_.trim).filter(_.nonEmpty))
 
   private def isPropFile(s: String) =
     s.startsWith("/") || s.startsWith("file:")

--- a/modules/cache/jvm/src/main/scala/coursier/cache/FileCache.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/FileCache.scala
@@ -183,7 +183,30 @@ import scala.util.control.NonFatal
     }
   }
 
-  private def filePerPolicy(
+  private[coursier] def finalLocalPath(artifact: Artifact): F[File] = {
+
+    val artifactTask = allCredentials.map { allCredentials =>
+      if (artifact.authentication.isEmpty) {
+        val authOpt = allCredentials
+          .find(_.autoMatches(artifact.url, None))
+          .map(_.authentication)
+        artifact.withAuthentication(authOpt)
+      }
+      else
+        artifact
+    }
+
+    artifactTask.map { artifact0 =>
+      FileCache.localFile0(
+        artifact0.url,
+        location,
+        artifact0.authentication.flatMap(_.userOpt),
+        localArtifactsShouldBeCached
+      )
+    }
+  }
+
+  def filePerPolicy(
     artifact: Artifact,
     policy: CachePolicy,
     retry: Int = retry
@@ -301,7 +324,7 @@ import scala.util.control.NonFatal
         .foldLeft(filePerPolicy(artifact, cachePolicies.head, retry))(_ orElse _)
     }
 
-  private def fetchPerPolicy(
+  private[coursier] def fetchPerPolicy(
     artifact: Artifact,
     policy: CachePolicy
   ): EitherT[F, String, String] = {

--- a/modules/cache/jvm/src/main/scala/coursier/cache/FileCache.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/FileCache.scala
@@ -58,7 +58,7 @@ import scala.util.control.NonFatal
     retryBackoffMultiplier: Double = CacheDefaults.retryBackoffMultiplier
 )(implicit
   sync: Sync[F]
-) extends Cache[F] {
+) extends Cache[F] with Cache.HasLocation with Cache.HasExecutionContext with Cache.WithLogger[F, FileCache[F]] with Cache.Default[F] {
   // format: on
 
   private def S = sync

--- a/modules/cache/jvm/src/main/scala/coursier/cache/FileCache.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/FileCache.scala
@@ -131,6 +131,7 @@ import scala.util.control.NonFatal
       clock
     ).download
 
+  // Should have been private[coursier]
   def validateChecksum(
     artifact: Artifact,
     sumType: String

--- a/modules/cache/jvm/src/main/scala/coursier/cache/FileCache.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/FileCache.scala
@@ -134,6 +134,7 @@ import scala.util.control.NonFatal
       retryBackoffMultiplier = retryBackoffMultiplier
     ).download
 
+  // Should have been private[coursier]
   def validateChecksum(
     artifact: Artifact,
     sumType: String

--- a/modules/cache/jvm/src/main/scala/coursier/cache/FileCache.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/FileCache.scala
@@ -186,7 +186,30 @@ import scala.util.control.NonFatal
     }
   }
 
-  private def filePerPolicy(
+  private[coursier] def finalLocalPath(artifact: Artifact): F[File] = {
+
+    val artifactTask = allCredentials.map { allCredentials =>
+      if (artifact.authentication.isEmpty) {
+        val authOpt = allCredentials
+          .find(_.autoMatches(artifact.url, None))
+          .map(_.authentication)
+        artifact.withAuthentication(authOpt)
+      }
+      else
+        artifact
+    }
+
+    artifactTask.map { artifact0 =>
+      FileCache.localFile0(
+        artifact0.url,
+        location,
+        artifact0.authentication.flatMap(_.userOpt),
+        localArtifactsShouldBeCached
+      )
+    }
+  }
+
+  def filePerPolicy(
     artifact: Artifact,
     policy: CachePolicy,
     retry: Int = retry
@@ -304,7 +327,7 @@ import scala.util.control.NonFatal
         .foldLeft(filePerPolicy(artifact, cachePolicies.head, retry))(_ orElse _)
     }
 
-  private def fetchPerPolicy(
+  private[coursier] def fetchPerPolicy(
     artifact: Artifact,
     policy: CachePolicy
   ): EitherT[F, String, String] = {

--- a/modules/cache/jvm/src/main/scala/coursier/cache/MockCache.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/MockCache.scala
@@ -27,11 +27,14 @@ import scala.util.{Failure, Success, Try}
   @since
     proxy: Option[java.net.Proxy] = None,
   @since("2.1.25")
+    // FIXME Needs to be a sub-directory of base
     baseChangingOpt: Option[Path] = None,
   replaceByNames: Artifact => Boolean = _ => false,
   failsWhenWritingMissing: ConcurrentHashMap[String, ArtifactError] = new ConcurrentHashMap[String, ArtifactError]
 ) extends Cache[F] {
 // format: on
+
+  def location = base.toFile
 
   private implicit def S0: Sync[F] = S
 

--- a/modules/cache/jvm/src/main/scala/coursier/cache/PlatformCache.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/PlatformCache.scala
@@ -9,4 +9,11 @@ abstract class PlatformCache[F[_]] {
   /** This method computes the task needed to get a file. */
   def file(artifact: Artifact): EitherT[F, ArtifactError, File]
 
+  def loggerOpt: Option[CacheLogger] =
+    this match {
+      case withLogger: Cache.WithLogger[_, _] =>
+        Some(withLogger.logger)
+      case _ =>
+        None
+    }
 }

--- a/modules/cache/jvm/src/main/scala/coursier/cache/PlatformCacheCompanion.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/PlatformCacheCompanion.scala
@@ -1,10 +1,38 @@
 package coursier.cache
 
-import coursier.util.Task
+import coursier.util.{Sync, Task}
+
+import java.io.File
+import scala.concurrent.ExecutionContextExecutorService
 
 abstract class PlatformCacheCompanion {
 
-  lazy val default: Cache[Task] = FileCache()
-    .noCredentials
+  final type Default[F[_]] = PlatformCacheCompanion.Default[F]
+
+  def defaultFor[F[_]: Sync]: Default[F] =
+    FileCache[F](CacheDefaults.location)
+
+  lazy val default: Default[Task] =
+    defaultFor[Task]
+
+  trait HasLocation {
+    def location: File
+  }
+
+  trait WithLogger[F[_], +Repr] {
+    def logger: CacheLogger
+    def withLogger(logger: CacheLogger): Repr
+  }
+
+  trait HasExecutionContext {
+    def ec: ExecutionContextExecutorService
+  }
+
+}
+
+object PlatformCacheCompanion {
+
+  trait Default[F[_]] extends Cache[F] with Cache.HasLocation with Cache.HasExecutionContext
+      with Cache.WithLogger[F, Default[F]]
 
 }

--- a/modules/cache/jvm/src/main/scala/coursier/cache/PlatformCacheCompanion.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/PlatformCacheCompanion.scala
@@ -9,8 +9,20 @@ abstract class PlatformCacheCompanion {
 
   final type Default[F[_]] = PlatformCacheCompanion.Default[F]
 
-  def defaultFor[F[_]: Sync]: Default[F] =
+  def defaultLocalCacheFor[F[_]: Sync]: FileCache[F] =
     FileCache[F](CacheDefaults.location)
+
+  def defaultFor[F[_]: Sync]: Default[F] =
+    CacheDefaults.cacheServerAddress match {
+      case Some(serverAddress) =>
+        RemoteCache(serverAddress, CacheDefaults.location)
+          .withBasicAuth(CacheDefaults.cacheServerBasicAuth)
+      case None =>
+        defaultLocalCacheFor[F]
+    }
+
+  def defaultLocalCache: FileCache[Task] =
+    defaultLocalCacheFor[Task]
 
   lazy val default: Default[Task] =
     defaultFor[Task]

--- a/modules/cache/jvm/src/main/scala/coursier/cache/PlatformCacheCompanion.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/PlatformCacheCompanion.scala
@@ -9,8 +9,21 @@ abstract class PlatformCacheCompanion {
 
   final type Default[F[_]] = PlatformCacheCompanion.Default[F]
 
-  def defaultFor[F[_]: Sync]: Default[F] =
+  def defaultLocalCacheFor[F[_]: Sync]: FileCache[F] =
     FileCache[F](CacheDefaults.location)
+
+  def defaultFor[F[_]: Sync]: Default[F] =
+    CacheDefaults.cacheServerAddress match {
+      case Some(serverAddress) =>
+        RemoteCache(serverAddress, CacheDefaults.location)
+          .withBasicAuth(CacheDefaults.cacheServerBasicAuth)
+          .withFileFallback(Some(defaultLocalCacheFor[F]))
+      case None =>
+        defaultLocalCacheFor[F]
+    }
+
+  def defaultLocalCache: FileCache[Task] =
+    defaultLocalCacheFor[Task]
 
   lazy val default: Default[Task] =
     defaultFor[Task]

--- a/modules/cache/jvm/src/main/scala/coursier/cache/RemoteCache.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/RemoteCache.scala
@@ -1,0 +1,293 @@
+package coursier.cache
+
+import com.github.plokhotnyuk.jsoniter_scala.core._
+import coursier.cache.server.Model.{Artifact => ModelArtifact, _}
+import coursier.paths.CachePath
+import coursier.util.{Artifact, EitherT, Sync, Task}
+import dataclass.data
+
+import java.io.{ByteArrayOutputStream, File}
+import java.net.{HttpURLConnection, URI, URL}
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.util.Base64
+import java.util.concurrent.{ConcurrentHashMap, ExecutorService}
+
+import scala.cli.config.Secret
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService}
+import scala.util.Try
+
+@data class RemoteCache[F[_]: Sync](
+  serverUrl: String,
+  location: File,
+  basicAuth: Option[Secret[String]] = None, // user:password
+  pool: ExecutorService = CacheDefaults.pool,
+  logger: CacheLogger = CacheLogger.nop,
+  cachePolicies: Seq[CachePolicy] = CacheDefaults.cachePolicies,
+  watchLenPool: ExecutorService = CacheDefaults.watchLenPool,
+  fileFallback: Option[FileCache[F]] = None
+) extends Cache[F] with Cache.HasLocation with Cache.HasExecutionContext
+    with Cache.WithLogger[F, RemoteCache[F]] with Cache.Default[F] {
+
+  lazy val ec: ExecutionContextExecutorService =
+    ExecutionContext.fromExecutorService(pool)
+
+  private val onGoing = new ConcurrentHashMap[String, RemoteCache.OnGoingDownload]
+
+  private lazy val (getUrl, pathUrl, actualBasicAuthOpt) = {
+    val rawGetUri  = new URI(s"$serverUrl/get")
+    val rawPathUri = new URI(s"$serverUrl/path")
+    Option(rawGetUri.getRawUserInfo) match {
+      case Some(userInfo) =>
+        def strip(uri: URI): URL = new URI(
+          uri.getScheme,
+          null, // userInfo
+          uri.getHost,
+          uri.getPort,
+          uri.getPath,
+          uri.getQuery,
+          uri.getFragment
+        ).toURL
+        (strip(rawGetUri), strip(rawPathUri), Some(Secret(userInfo)))
+      case None =>
+        (rawGetUri.toURL, rawPathUri.toURL, basicAuth)
+    }
+  }
+
+  private def postToUrl[R: JsonValueCodec](
+    url: URL,
+    body: Array[Byte]
+  ): Either[ArtifactError, R] = {
+    val conn = url.openConnection()
+      .asInstanceOf[HttpURLConnection]
+    try {
+      conn.setRequestMethod("POST")
+      conn.setDoOutput(true)
+      conn.setRequestProperty("Content-Type", "application/json")
+      for (secret <- actualBasicAuthOpt)
+        conn.setRequestProperty(
+          "Authorization",
+          "Basic " + Base64.getEncoder.encodeToString(
+            secret.value.getBytes(StandardCharsets.UTF_8)
+          )
+        )
+      conn.getOutputStream.write(body)
+      conn.getOutputStream.close()
+
+      val code   = conn.getResponseCode
+      val stream = if (code >= 400) conn.getErrorStream else conn.getInputStream
+      val baos   = new ByteArrayOutputStream
+      if (stream != null) {
+        val buf = new Array[Byte](8192)
+        var n   = 0
+        while ({ n = stream.read(buf); n != -1 })
+          baos.write(buf, 0, n)
+        stream.close()
+      }
+
+      if (code == 200)
+        Right(readFromArray[R](baos.toByteArray))
+      else
+        Left(
+          new ArtifactError.DownloadError(
+            s"Server returned HTTP $code: ${new String(baos.toByteArray, StandardCharsets.UTF_8)}",
+            None
+          )
+        )
+    }
+    finally
+      conn.disconnect()
+  }
+
+  private def watcher(url: String, entry: RemoteCache.OnGoingDownload): Runnable =
+    () => {
+      var lenOpt     = Option.empty[Long]
+      var currentLen = 0L
+
+      try
+        while (!entry.done && !entry.errored) {
+          Thread.sleep(20L)
+
+          val newLen = entry.tmp.length()
+
+          if (newLen > 0) {
+            if (!entry.started) {
+              entry.started = true
+              logger.downloadingArtifact(url, entry.artifact)
+            }
+
+            if (lenOpt.isEmpty) {
+              if (entry.lenFile.exists() && entry.lenFile.length() == 8L) {
+                val bytes = Files.readAllBytes(entry.lenFile.toPath)
+                if (bytes.length == 8) {
+                  val len = ByteBuffer.wrap(bytes).getLong
+                  lenOpt = Some(len)
+                  logger.downloadLength(url, len, currentLen, watching = true)
+                }
+              }
+            }
+            else if (newLen != currentLen) {
+              currentLen = newLen
+              logger.downloadProgress(url, currentLen)
+            }
+          }
+        }
+      finally {
+        onGoing.remove(url)
+
+        if (entry.started) {
+          if (entry.done && entry.file.exists()) {
+            val len = lenOpt.getOrElse(entry.file.length())
+            if (lenOpt.isEmpty)
+              logger.downloadLength(url, len, len, watching = true)
+            logger.downloadProgress(url, len)
+          }
+
+          if (entry.done || entry.errored)
+            logger.downloadedArtifact(url, success = !entry.errored)
+        }
+      }
+    }
+
+  private def fileWithPolicy(
+    artifact: Artifact,
+    cachePolicy: Option[String]
+  ): EitherT[F, ArtifactError, File] =
+    EitherT {
+      Sync[F].schedule(pool) {
+        val url = artifact.url
+
+        val pathRequest = PathRequest(ModelArtifact.fromArtifact(artifact))
+        val pathBody    = writeToArray(pathRequest)
+
+        val pathInfoEither: Either[ArtifactError, String] =
+          postToUrl[PathResponse](pathUrl, pathBody).flatMap { pathResponse =>
+            pathResponse.error match {
+              case Some(err) =>
+                Left(new ArtifactError.DownloadError(s"${err.`type`}: ${err.message}", None))
+              case None =>
+                pathResponse.path match {
+                  case Some(relativePath) =>
+                    val elems = relativePath.split("/")
+                    if (elems.contains(".") || elems.contains(".."))
+                      Left(new ArtifactError.DownloadError("Server returned an invalid path", None))
+                    else
+                      Right(relativePath)
+                  case None =>
+                    Left(new ArtifactError.DownloadError(
+                      "Server returned no path and no error",
+                      None
+                    ))
+                }
+            }
+          }
+
+        pathInfoEither.flatMap { relativePath =>
+          val request = GetRequest(ModelArtifact.fromArtifact(artifact), cachePolicy)
+          val body    = writeToArray(request)
+
+          val entry = {
+            val file    = new File(location, relativePath)
+            val tmp     = CachePath.temporaryFile(file)
+            val lenFile = new File(tmp.getPath + ".length")
+            new RemoteCache.OnGoingDownload(file, tmp, lenFile, artifact)
+          }
+          val existing = onGoing.putIfAbsent(url, entry)
+          if (existing == null) {
+            if (!entry.file.exists()) {
+              entry.started = true
+              logger.downloadingArtifact(url, artifact)
+            }
+            watchLenPool.submit(watcher(url, entry))
+          }
+
+          var success = false
+          try {
+            val result = postToUrl[GetResponse](getUrl, body).flatMap { response =>
+              response.error match {
+                case Some(err) =>
+                  Left(new ArtifactError.DownloadError(s"${err.`type`}: ${err.message}", None))
+                case None =>
+                  response.path match {
+                    case Some(relativePath) =>
+                      val elems = relativePath.split("/")
+                      if (elems.contains(".") || elems.contains(".."))
+                        Left(new ArtifactError.DownloadError(
+                          "Server returned an invalid path",
+                          None
+                        ))
+                      else
+                        Right(new File(location, relativePath))
+                    case None =>
+                      Left(new ArtifactError.DownloadError(
+                        "Server returned no path and no error",
+                        None
+                      ))
+                  }
+              }
+            }
+            success = result.isRight
+            result
+          }
+          finally
+            if (success) entry.done = true
+            else entry.errored = true
+        }
+      }
+    }
+
+  def file(artifact: Artifact): EitherT[F, ArtifactError, File] =
+    fileFallback.filter(_ => artifact.url.startsWith("file:/")) match {
+      case Some(fallback) =>
+        fallback.file(artifact)
+      case None =>
+        fileWithPolicy(artifact, None)
+    }
+
+  private def fetchWithPolicy(cachePolicy: Option[String]): Cache.Fetch[F] =
+    artifact =>
+      fileWithPolicy(artifact, cachePolicy).leftMap(_.describe).flatMap { f =>
+        EitherT {
+          Sync[F].schedule(pool) {
+            if (!f.exists())
+              Left(s"File not found: $f")
+            else
+              Right(new String(Files.readAllBytes(f.toPath), StandardCharsets.UTF_8))
+          }
+        }
+      }
+
+  def fetch: Cache.Fetch[F] = {
+    val default     = fetchWithPolicy(None)
+    val fallbackOpt = fileFallback.map(_.fetch)
+    art =>
+      val f = fallbackOpt.filter(_ => art.url.startsWith("file:/")).getOrElse(default)
+      f(art)
+  }
+
+  override def fetchs: Seq[Cache.Fetch[F]] =
+    cachePolicies.map { policy =>
+      val default = fetchWithPolicy(Some(policy.toString))
+      val fallback =
+        fileFallback.map(fallback => (art: Artifact) => fallback.fetchPerPolicy(art, policy))
+      (art: Artifact) =>
+        val f = fallback.filter(_ => art.url.startsWith("file:/")).getOrElse(default)
+        f(art)
+    }
+}
+
+object RemoteCache {
+
+  final class OnGoingDownload(
+    val file: File,
+    val tmp: File,
+    val lenFile: File,
+    var artifact: Artifact
+  ) {
+    @volatile var started: Boolean = false
+    @volatile var done: Boolean    = false
+    @volatile var errored: Boolean = false
+  }
+
+}

--- a/modules/cache/jvm/src/main/scala/coursier/cache/RemoteCache.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/RemoteCache.scala
@@ -1,0 +1,314 @@
+package coursier.cache
+
+import com.github.plokhotnyuk.jsoniter_scala.core._
+import coursier.cache.server.Model.{Artifact => ModelArtifact, _}
+import coursier.paths.CachePath
+import coursier.util.{Artifact, EitherT, Sync, Task, WebPage}
+import dataclass.data
+
+import java.io.{ByteArrayOutputStream, File}
+import java.net.{HttpURLConnection, URI, URL}
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.util.Base64
+import java.util.concurrent.{ConcurrentHashMap, ExecutorService}
+
+import scala.cli.config.Secret
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService}
+import scala.util.Try
+
+@data class RemoteCache[F[_]: Sync](
+  serverUrl: String,
+  location: File,
+  basicAuth: Option[Secret[String]] = None, // user:password
+  pool: ExecutorService = CacheDefaults.pool,
+  logger: CacheLogger = CacheLogger.nop,
+  cachePolicies: Seq[CachePolicy] = CacheDefaults.cachePolicies,
+  watchLenPool: ExecutorService = CacheDefaults.watchLenPool,
+  fileFallback: Option[FileCache[F]] = None
+) extends Cache[F] with Cache.HasLocation with Cache.HasExecutionContext
+    with Cache.WithLogger[F, RemoteCache[F]] with Cache.Default[F] {
+
+  lazy val ec: ExecutionContextExecutorService =
+    ExecutionContext.fromExecutorService(pool)
+
+  private val onGoing = new ConcurrentHashMap[String, RemoteCache.OnGoingDownload]
+
+  private lazy val (getUrl, pathUrl, actualBasicAuthOpt) = {
+    val rawGetUri  = new URI(s"$serverUrl/get")
+    val rawPathUri = new URI(s"$serverUrl/path")
+    Option(rawGetUri.getRawUserInfo) match {
+      case Some(userInfo) =>
+        def strip(uri: URI): URL = new URI(
+          uri.getScheme,
+          null, // userInfo
+          uri.getHost,
+          uri.getPort,
+          uri.getPath,
+          uri.getQuery,
+          uri.getFragment
+        ).toURL
+        (strip(rawGetUri), strip(rawPathUri), Some(Secret(userInfo)))
+      case None =>
+        (rawGetUri.toURL, rawPathUri.toURL, basicAuth)
+    }
+  }
+
+  private def postToUrl[R: JsonValueCodec](
+    url: URL,
+    body: Array[Byte]
+  ): Either[ArtifactError, R] = {
+    val conn = url.openConnection()
+      .asInstanceOf[HttpURLConnection]
+    try {
+      conn.setRequestMethod("POST")
+      conn.setDoOutput(true)
+      conn.setRequestProperty("Content-Type", "application/json")
+      for (secret <- actualBasicAuthOpt)
+        conn.setRequestProperty(
+          "Authorization",
+          "Basic " + Base64.getEncoder.encodeToString(
+            secret.value.getBytes(StandardCharsets.UTF_8)
+          )
+        )
+      conn.getOutputStream.write(body)
+      conn.getOutputStream.close()
+
+      val code   = conn.getResponseCode
+      val stream = if (code >= 400) conn.getErrorStream else conn.getInputStream
+      val baos   = new ByteArrayOutputStream
+      if (stream != null) {
+        val buf = new Array[Byte](8192)
+        var n   = 0
+        while ({ n = stream.read(buf); n != -1 })
+          baos.write(buf, 0, n)
+        stream.close()
+      }
+
+      if (code == 200)
+        Right(readFromArray[R](baos.toByteArray))
+      else
+        Left(
+          new ArtifactError.DownloadError(
+            s"Server returned HTTP $code: ${new String(baos.toByteArray, StandardCharsets.UTF_8)}",
+            None
+          )
+        )
+    }
+    finally
+      conn.disconnect()
+  }
+
+  private def watcher(url: String, entry: RemoteCache.OnGoingDownload): Runnable =
+    () => {
+      var lenOpt     = Option.empty[Long]
+      var currentLen = 0L
+
+      try
+        while (!entry.done && !entry.errored) {
+          Thread.sleep(20L)
+
+          val newLen = entry.tmp.length()
+
+          if (newLen > 0) {
+            if (!entry.started) {
+              entry.started = true
+              logger.downloadingArtifact(url, entry.artifact)
+            }
+
+            if (lenOpt.isEmpty) {
+              if (entry.lenFile.exists() && entry.lenFile.length() == 8L) {
+                val bytes = Files.readAllBytes(entry.lenFile.toPath)
+                if (bytes.length == 8) {
+                  val len = ByteBuffer.wrap(bytes).getLong
+                  lenOpt = Some(len)
+                  logger.downloadLength(url, len, currentLen, watching = true)
+                }
+              }
+            }
+            else if (newLen != currentLen) {
+              currentLen = newLen
+              logger.downloadProgress(url, currentLen)
+            }
+          }
+        }
+      finally {
+        onGoing.remove(url)
+
+        if (entry.started) {
+          if (entry.done && entry.file.exists()) {
+            val len = lenOpt.getOrElse(entry.file.length())
+            if (lenOpt.isEmpty)
+              logger.downloadLength(url, len, len, watching = true)
+            logger.downloadProgress(url, len)
+          }
+
+          if (entry.done || entry.errored)
+            logger.downloadedArtifact(url, success = !entry.errored)
+        }
+      }
+    }
+
+  private def fileWithPolicy(
+    artifact: Artifact,
+    cachePolicy: Option[String]
+  ): EitherT[F, ArtifactError, File] =
+    EitherT {
+      Sync[F].schedule(pool) {
+        val url = artifact.url
+
+        val pathRequest = PathRequest(ModelArtifact.fromArtifact(artifact))
+        val pathBody    = writeToArray(pathRequest)
+
+        val pathInfoEither: Either[ArtifactError, String] =
+          postToUrl[PathResponse](pathUrl, pathBody).flatMap { pathResponse =>
+            pathResponse.error match {
+              case Some(err) =>
+                Left(new ArtifactError.DownloadError(s"${err.`type`}: ${err.message}", None))
+              case None =>
+                pathResponse.path match {
+                  case Some(relativePath) =>
+                    val elems = relativePath.split("/")
+                    if (elems.contains(".") || elems.contains(".."))
+                      Left(new ArtifactError.DownloadError("Server returned an invalid path", None))
+                    else
+                      Right(relativePath)
+                  case None =>
+                    Left(new ArtifactError.DownloadError(
+                      "Server returned no path and no error",
+                      None
+                    ))
+                }
+            }
+          }
+
+        pathInfoEither.flatMap { relativePath =>
+          val request = GetRequest(ModelArtifact.fromArtifact(artifact), cachePolicy)
+          val body    = writeToArray(request)
+
+          val entry = {
+            val file    = new File(location, relativePath)
+            val tmp     = CachePath.temporaryFile(file)
+            val lenFile = new File(tmp.getPath + ".length")
+            new RemoteCache.OnGoingDownload(file, tmp, lenFile, artifact)
+          }
+          val existing = onGoing.putIfAbsent(url, entry)
+          if (existing == null) {
+            if (!entry.file.exists()) {
+              entry.started = true
+              logger.downloadingArtifact(url, artifact)
+            }
+            watchLenPool.submit(watcher(url, entry))
+          }
+
+          var success = false
+          try {
+            val result = postToUrl[GetResponse](getUrl, body).flatMap { response =>
+              response.error match {
+                case Some(err) =>
+                  Left(new ArtifactError.DownloadError(s"${err.`type`}: ${err.message}", None))
+                case None =>
+                  response.path match {
+                    case Some(relativePath) =>
+                      val elems = relativePath.split("/")
+                      if (elems.contains(".") || elems.contains(".."))
+                        Left(new ArtifactError.DownloadError(
+                          "Server returned an invalid path",
+                          None
+                        ))
+                      else
+                        Right(new File(location, relativePath))
+                    case None =>
+                      Left(new ArtifactError.DownloadError(
+                        "Server returned no path and no error",
+                        None
+                      ))
+                  }
+              }
+            }
+            success = result.isRight
+            result
+          }
+          finally
+            if (success) entry.done = true
+            else entry.errored = true
+        }
+      }
+    }
+
+  def file(artifact: Artifact): EitherT[F, ArtifactError, File] = {
+    val artifact0 =
+      if (artifact.url.endsWith("/.links")) artifact.withUrl(artifact.url.stripSuffix(".links"))
+      else artifact
+    fileFallback.filter(_ => artifact0.url.startsWith("file:/")) match {
+      case Some(fallback) =>
+        fallback.file(artifact0)
+      case None =>
+        fileWithPolicy(artifact0, None)
+    }
+  }
+
+  private def fetchWithPolicy(cachePolicy: Option[String]): Cache.Fetch[F] =
+    artifact => {
+      val (artifact0, links) =
+        if (artifact.url.endsWith("/.links"))
+          (artifact.withUrl(artifact.url.stripSuffix(".links")), true)
+        else (artifact, false)
+      fileWithPolicy(artifact0, cachePolicy).leftMap(_.describe).flatMap { f =>
+        EitherT {
+          Sync[F].schedule(pool) {
+            if (!f.exists())
+              Left(s"File not found: $f")
+            else if (links) {
+              val linkFile = FileCache.auxiliaryFile(f, "links")
+              if (f.getName == ".directory" && linkFile.isFile)
+                Right(new String(Files.readAllBytes(linkFile.toPath), StandardCharsets.UTF_8))
+              else
+                Right(
+                  WebPage.listElements(
+                    artifact0.url,
+                    new String(Files.readAllBytes(f.toPath), StandardCharsets.UTF_8)
+                  ).mkString("\n")
+                )
+            }
+            else
+              Right(new String(Files.readAllBytes(f.toPath), StandardCharsets.UTF_8))
+          }
+        }
+      }
+    }
+
+  def fetch: Cache.Fetch[F] = {
+    val default     = fetchWithPolicy(None)
+    val fallbackOpt = fileFallback.map(_.fetch)
+    art =>
+      val f = fallbackOpt.filter(_ => art.url.startsWith("file:/")).getOrElse(default)
+      f(art)
+  }
+
+  override def fetchs: Seq[Cache.Fetch[F]] =
+    cachePolicies.map { policy =>
+      val default = fetchWithPolicy(Some(policy.toString))
+      val fallback =
+        fileFallback.map(fallback => (art: Artifact) => fallback.fetchPerPolicy(art, policy))
+      (art: Artifact) =>
+        val f = fallback.filter(_ => art.url.startsWith("file:/")).getOrElse(default)
+        f(art)
+    }
+}
+
+object RemoteCache {
+
+  final class OnGoingDownload(
+    val file: File,
+    val tmp: File,
+    val lenFile: File,
+    var artifact: Artifact
+  ) {
+    @volatile var started: Boolean = false
+    @volatile var done: Boolean    = false
+    @volatile var errored: Boolean = false
+  }
+
+}

--- a/modules/cache/jvm/src/main/scala/coursier/cache/internal/Downloader.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/internal/Downloader.scala
@@ -2,6 +2,7 @@ package coursier.cache.internal
 
 import java.io.{Serializable => _, _}
 import java.net.{HttpURLConnection, URLConnection, MalformedURLException}
+import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.{AccessDeniedException, Files, StandardCopyOption, StandardOpenOption}
 import java.time.Clock
@@ -250,7 +251,8 @@ import scala.util.control.NonFatal
           // Mark http 500 errors as retryable, to mitigate flakiness
           Left(new ArtifactError.RetryableServerError(url, respCodeOpt.get))
         else {
-          for (len0 <- Option(conn.getContentLengthLong) if len0 >= 0L) {
+          val lenOpt = Option(conn.getContentLengthLong).filter(_ >= 0L)
+          for (len0 <- lenOpt) {
             val len = len0 + (if (partialDownload) alreadyDownloaded else 0L)
             logger.downloadLength(url, len, alreadyDownloaded, watching = false)
           }
@@ -275,10 +277,26 @@ import scala.util.control.NonFatal
             new BufferedInputStream(baseStream, bufferSize)
           }
 
+          val tmp0    = tmp.toPath
+          val lenFile = tmp0.getParent.resolve(tmp0.getFileName.toString + ".length")
           val result =
             try {
               val out = CacheLocks.withStructureLock(location) {
-                Util.createDirectories(tmp.toPath.getParent)
+                Util.createDirectories(tmp0.getParent)
+                for (len0 <- lenOpt) {
+                  val lenBytes = ByteBuffer.allocate(8).putLong(len0).array()
+                  val tmpLen = Files.createTempFile(
+                    lenFile.getParent,
+                    lenFile.getFileName.toString.stripSuffix(".length"),
+                    ".length"
+                  )
+                  Files.write(tmpLen, lenBytes)
+                  try Files.move(tmpLen, lenFile, StandardCopyOption.ATOMIC_MOVE)
+                  catch {
+                    case _: java.nio.file.AtomicMoveNotSupportedException =>
+                      Files.move(tmpLen, lenFile)
+                  }
+                }
                 if (partialDownload)
                   Files.newOutputStream(tmp.toPath, StandardOpenOption.APPEND)
                 else
@@ -294,7 +312,11 @@ import scala.util.control.NonFatal
                 )
               finally out.close()
             }
-            finally in.close()
+            finally {
+              in.close()
+              for (len0 <- lenOpt)
+                Files.deleteIfExists(lenFile)
+            }
 
           FileCache.clearAuxiliaryFiles(file)
 

--- a/modules/cache/jvm/src/main/scala/coursier/cache/internal/Downloader.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/internal/Downloader.scala
@@ -2,6 +2,7 @@ package coursier.cache.internal
 
 import java.io.{Serializable => _, _}
 import java.net.{HttpURLConnection, URLConnection, MalformedURLException}
+import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.{AccessDeniedException, Files, StandardCopyOption, StandardOpenOption}
 import java.time.{Clock, Duration => JDuration, Instant}
@@ -267,7 +268,8 @@ import scala.util.control.NonFatal
             )
           )
         else {
-          for (len0 <- Option(conn.getContentLengthLong) if len0 >= 0L) {
+          val lenOpt = Option(conn.getContentLengthLong).filter(_ >= 0L)
+          for (len0 <- lenOpt) {
             val len = len0 + (if (partialDownload) alreadyDownloaded else 0L)
             logger.downloadLength(url, len, alreadyDownloaded, watching = false)
           }
@@ -292,10 +294,26 @@ import scala.util.control.NonFatal
             new BufferedInputStream(baseStream, bufferSize)
           }
 
+          val tmp0    = tmp.toPath
+          val lenFile = tmp0.getParent.resolve(tmp0.getFileName.toString + ".length")
           val result =
             try {
               val out = CacheLocks.withStructureLock(location) {
-                Util.createDirectories(tmp.toPath.getParent)
+                Util.createDirectories(tmp0.getParent)
+                for (len0 <- lenOpt) {
+                  val lenBytes = ByteBuffer.allocate(8).putLong(len0).array()
+                  val tmpLen = Files.createTempFile(
+                    lenFile.getParent,
+                    lenFile.getFileName.toString.stripSuffix(".length"),
+                    ".length"
+                  )
+                  Files.write(tmpLen, lenBytes)
+                  try Files.move(tmpLen, lenFile, StandardCopyOption.ATOMIC_MOVE)
+                  catch {
+                    case _: java.nio.file.AtomicMoveNotSupportedException =>
+                      Files.move(tmpLen, lenFile)
+                  }
+                }
                 if (partialDownload)
                   Files.newOutputStream(tmp.toPath, StandardOpenOption.APPEND)
                 else
@@ -311,7 +329,11 @@ import scala.util.control.NonFatal
                 )
               finally out.close()
             }
-            finally in.close()
+            finally {
+              in.close()
+              for (len0 <- lenOpt)
+                Files.deleteIfExists(lenFile)
+            }
 
           FileCache.clearAuxiliaryFiles(file)
 

--- a/modules/cache/jvm/src/main/scala/coursier/cache/server/Model.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/server/Model.scala
@@ -1,0 +1,119 @@
+package coursier.cache.server
+
+import com.github.plokhotnyuk.jsoniter_scala.core._
+import com.github.plokhotnyuk.jsoniter_scala.macros._
+import coursier.cache.CachePolicy
+
+object Model {
+
+  def parseCachePolicy(name: String): Option[CachePolicy] =
+    name match {
+      case "LocalOnly"           => Some(CachePolicy.LocalOnly)
+      case "LocalOnlyIfValid"    => Some(CachePolicy.LocalOnlyIfValid)
+      case "LocalUpdateChanging" => Some(CachePolicy.LocalUpdateChanging)
+      case "LocalUpdate"         => Some(CachePolicy.LocalUpdate)
+      case "UpdateChanging"      => Some(CachePolicy.UpdateChanging)
+      case "Update"              => Some(CachePolicy.Update)
+      case "FetchMissing"        => Some(CachePolicy.FetchMissing)
+      case "ForceDownload"       => Some(CachePolicy.ForceDownload)
+      case _                     => None
+    }
+
+  final case class GetRequest(
+    artifact: Artifact,
+    cachePolicy: Option[String] = None
+  )
+
+  final case class GetResponse(
+    path: Option[String],
+    error: Option[SerializedArtifactError]
+  )
+
+  final case class PathRequest(
+    artifact: Artifact
+  )
+
+  final case class PathResponse(
+    path: Option[String],
+    error: Option[SerializedArtifactError]
+  )
+
+  final case class Artifact(
+    url: String,
+    checksumUrls: Map[String, String] = Map.empty,
+    extra: Map[String, Artifact] = Map.empty,
+    changing: Boolean = false,
+    optional: Boolean = false
+  ) {
+    def toArtifact: coursier.util.Artifact =
+      coursier.util.Artifact(
+        url = url,
+        checksumUrls = checksumUrls,
+        extra = extra.map { case (k, v) => k -> v.toArtifact },
+        changing = changing,
+        optional = optional,
+        authentication = None
+      )
+  }
+
+  object Artifact {
+    def fromArtifact(artifact: coursier.util.Artifact): Artifact =
+      Artifact(
+        url = artifact.url,
+        checksumUrls = artifact.checksumUrls,
+        extra = artifact.extra.map { case (k, v) => k -> fromArtifact(v) },
+        changing = artifact.changing,
+        optional = artifact.optional
+      )
+  }
+
+  final case class SerializedException(
+    className: String,
+    message: String,
+    stackTrace: Seq[SerializedStackTraceElement],
+    cause: Option[SerializedException]
+  )
+
+  object SerializedException {
+    def fromThrowable(t: Throwable): SerializedException =
+      SerializedException(
+        className = t.getClass.getName,
+        message = Option(t.getMessage).getOrElse(""),
+        stackTrace = t.getStackTrace.toSeq.map { ste =>
+          SerializedStackTraceElement(
+            className = ste.getClassName,
+            methodName = ste.getMethodName,
+            fileName = Option(ste.getFileName),
+            lineNumber = ste.getLineNumber
+          )
+        },
+        cause = Option(t.getCause).map(fromThrowable)
+      )
+  }
+
+  final case class SerializedStackTraceElement(
+    className: String,
+    methodName: String,
+    fileName: Option[String],
+    lineNumber: Int
+  )
+
+  final case class SerializedArtifactError(
+    `type`: String,
+    message: String,
+    exception: SerializedException
+  )
+
+  implicit val getRequestCodec: JsonValueCodec[GetRequest] =
+    JsonCodecMaker.make(CodecMakerConfig.withAllowRecursiveTypes(true))
+
+  implicit val getResponseCodec: JsonValueCodec[GetResponse] =
+    JsonCodecMaker.make(CodecMakerConfig.withAllowRecursiveTypes(true))
+
+  implicit val pathRequestCodec: JsonValueCodec[PathRequest] =
+    JsonCodecMaker.make(CodecMakerConfig.withAllowRecursiveTypes(true))
+
+  implicit val pathResponseCodec: JsonValueCodec[PathResponse] =
+    JsonCodecMaker.make(CodecMakerConfig.withAllowRecursiveTypes(true))
+
+}

--- a/modules/cache/jvm/src/test/resources/logback.xml
+++ b/modules/cache/jvm/src/test/resources/logback.xml
@@ -12,6 +12,18 @@
         <appender-ref ref="CONSOLE"/>
     </logger>
 
+    <logger name="io.undertow" level="off" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
+    <logger name="org.jboss" level="off" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
+    <logger name="org.xnio" level="off" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
     <root level="debug">
         <appender-ref ref="CONSOLE"/>
     </root>

--- a/modules/cache/jvm/src/test/scala/coursier/cache/DigestBasedCacheTests.scala
+++ b/modules/cache/jvm/src/test/scala/coursier/cache/DigestBasedCacheTests.scala
@@ -13,7 +13,7 @@ object DigestBasedCacheTests extends TestSuite {
       withTmpDir { dir =>
         // To force re-download things, use this instead:
         // ArchiveCacheTests.sandboxedCache
-        val cache       = FileCache()
+        val cache       = Cache.default
         val digestBased = DigestBasedCache[Task]((dir / "digest").toNIO)
 
         val repoName = "library/hello-world"

--- a/modules/cache/jvm/src/test/scala/coursier/cache/FileCacheRedirectionTests.scala
+++ b/modules/cache/jvm/src/test/scala/coursier/cache/FileCacheRedirectionTests.scala
@@ -30,7 +30,14 @@ object FileCacheRedirectionTests extends TestSuite {
   override def utestAfterAll() =
     pool.shutdown()
 
-  private def fileCache0() = FileCache()
+  private def defaultCache() =
+    Cache.default match {
+      case fc: FileCache[Task] => fc
+      case other =>
+        sys.error(s"Expected default cache to be a FileCache, got $other")
+    }
+
+  private def fileCache0() = defaultCache()
     .noCredentials
     .withSslSocketFactory(dummyClientSslContext.getSocketFactory)
     .withHostnameVerifier(dummyHostnameVerifier)
@@ -1021,7 +1028,7 @@ object FileCacheRedirectionTests extends TestSuite {
           val artifact = Artifact("unknown.protocol://hostname/file.txt")
 
           val res = await {
-            FileCache()
+            defaultCache()
               .file(artifact)
               .run
               .future()
@@ -1058,7 +1065,7 @@ object FileCacheRedirectionTests extends TestSuite {
             val artifact = Artifact("customprotocol://hostname/README.md")
 
             val res = await {
-              FileCache()
+              defaultCache()
                 .withClassLoaders(Seq(classloader))
                 .withLocation(dir.toFile)
                 .file(artifact)
@@ -1101,7 +1108,7 @@ object FileCacheRedirectionTests extends TestSuite {
 
         test - async {
           val res = await {
-            FileCache()
+            defaultCache()
               .withChecksums(Seq(Some("SHA-1")))
               .file(artifact)
               .run
@@ -1113,7 +1120,7 @@ object FileCacheRedirectionTests extends TestSuite {
 
         test - async {
           val res = await {
-            FileCache()
+            defaultCache()
               .withChecksums(Seq(Some("SHA-256")))
               .file(artifact)
               .run
@@ -1134,7 +1141,7 @@ object FileCacheRedirectionTests extends TestSuite {
 
         test - async {
           val res = await {
-            FileCache()
+            defaultCache()
               .withChecksums(Seq(Some("SHA-512"), Some("SHA-256")))
               .file(artifact)
               .run
@@ -1246,7 +1253,7 @@ object FileCacheRedirectionTests extends TestSuite {
         )
 
         val res =
-          FileCache()
+          defaultCache()
             .withLocation(dir.toString)
             .withChecksums(Seq(Some("SHA-1")))
             .file(artifact)
@@ -1282,7 +1289,7 @@ object FileCacheRedirectionTests extends TestSuite {
           None
         )
 
-        val res = FileCache()
+        val res = defaultCache()
           .withLocation(dir.toString)
           .withChecksums(Seq(Some("MD5")))
           .file(artifact)
@@ -1319,7 +1326,7 @@ object FileCacheRedirectionTests extends TestSuite {
         )
 
         // use default location so our file is considered outside
-        val _ = FileCache()
+        val _ = defaultCache()
           .withChecksums(Seq(Some("MD5")))
           .file(artifact)
           .run
@@ -1345,7 +1352,7 @@ object FileCacheRedirectionTests extends TestSuite {
             None
           )
 
-          FileCache()
+          defaultCache()
             .withLocation(dir.toString)
             .withChecksums(Seq(Some("SHA-1")))
             .file(artifact)
@@ -1372,7 +1379,7 @@ object FileCacheRedirectionTests extends TestSuite {
         val artifact = Artifact(dummyFileUri)
           .withChecksumUrls(Map("SHA-1" -> s"$dummyFileUri.sha1"))
 
-        val res = FileCache()
+        val res = defaultCache()
           .withLocation(dir.toString)
           .file(artifact)
           .run

--- a/modules/cache/jvm/src/test/scala/coursier/cache/RemoteCacheTests.scala
+++ b/modules/cache/jvm/src/test/scala/coursier/cache/RemoteCacheTests.scala
@@ -1,0 +1,132 @@
+package coursier.cache
+
+import java.net.ServerSocket
+import java.util.concurrent.{ExecutorService, Executors}
+
+import scala.concurrent.ExecutionContext
+
+import io.undertow.Undertow
+import utest._
+
+import coursier.{Fetch, Resolve}
+import coursier.cache.TestUtil._
+import coursier.cache.server.CacheServer
+import coursier.maven.MavenRepository
+import coursier.util.{Artifact, Task}
+import coursier.util.StringInterpolators._
+
+object RemoteCacheTests extends TestSuite {
+
+  private val central = "https://repo1.maven.org/maven2"
+  private val scalaLibraryPomUrl =
+    s"$central/org/scala-lang/scala-library/2.13.16/scala-library-2.13.16.pom"
+
+  private def freePort(): Int = {
+    val socket = new ServerSocket(0)
+    try socket.getLocalPort
+    finally socket.close()
+  }
+
+  private def withExecutorService[T](pool: ExecutorService)(f: ExecutorService => T): T =
+    try f(pool)
+    finally pool.shutdownNow()
+
+  private def withCacheServer[T](cache: FileCache[Task])(f: String => T): T =
+    withExecutorService(Executors.newCachedThreadPool()) { requestsPool =>
+      val port = freePort()
+      val server = Undertow.builder()
+        .addHttpListener(port, "localhost")
+        .setHandler(CacheServer.handler(cache, ExecutionContext.fromExecutorService(requestsPool)))
+        .build()
+      server.start()
+      try f(s"http://localhost:$port")
+      finally server.stop()
+    }
+
+  private def withRemoteCache[T](f: (os.Path, RemoteCache[Task]) => T): T =
+    withTmpDir { dir =>
+      withExecutorService(Executors.newFixedThreadPool(4)) { serverPool =>
+        val cacheDir = dir / "cache"
+        val serverCache = FileCache[Task](cacheDir.toIO)
+          .withPool(serverPool)
+
+        withCacheServer(serverCache) { cacheServerUrl =>
+          withExecutorService(Executors.newCachedThreadPool()) { remotePool =>
+            val remoteCache = RemoteCache[Task](cacheServerUrl, cacheDir.toIO)
+              .withPool(remotePool)
+              .withWatchLenPool(remotePool)
+            f(cacheDir, remoteCache)
+          }
+        }
+      }
+    }
+
+  val tests = Tests {
+
+    test("get POM") {
+      withRemoteCache { (_, remoteCache) =>
+        val artifact = Artifact(scalaLibraryPomUrl)
+
+        val file = remoteCache.file(artifact).run
+          .unsafeRun(wrapExceptions = true)(remoteCache.ec)
+          .fold(e => throw e, os.Path(_))
+
+        val content = os.read(file)
+        assert(content.contains("<artifactId>scala-library</artifactId>"))
+        assert(content.contains("<version>2.13.16</version>"))
+      }
+    }
+
+    test("resolve dependency") {
+      withRemoteCache { (_, remoteCache) =>
+        val dependency = dep"org.scala-lang:scala-compiler:2.13.16"
+        val resolution = Resolve()
+          .noMirrors
+          .withRepositories(Seq(MavenRepository(central)))
+          .withCache(remoteCache)
+          .addDependencies(dependency)
+          .run()(remoteCache.ec)
+
+        val deps = resolution.orderedDependencies.map { d =>
+          d.module.repr + ":" + d.versionConstraint.asString
+        }
+        val expectedDeps = Seq(
+          "org.scala-lang:scala-compiler:2.13.16",
+          "org.scala-lang:scala-library:2.13.16",
+          "org.scala-lang:scala-reflect:2.13.16",
+          "io.github.java-diff-utils:java-diff-utils:4.15",
+          "org.jline:jline:3.27.1"
+        )
+
+        assert(deps == expectedDeps)
+      }
+    }
+
+    test("fetch dependency artifacts") {
+      withRemoteCache { (cacheDir, remoteCache) =>
+        val dependency = dep"org.scala-lang:scala-compiler:2.13.16"
+        val result = Fetch()
+          .noMirrors
+          .withRepositories(Seq(MavenRepository(central)))
+          .withCache(remoteCache)
+          .addDependencies(dependency)
+          .runResult()(remoteCache.ec)
+
+        val files = result.files.map(os.Path(_))
+
+        assert(files.forall(_.startsWith(cacheDir)))
+        val files0 = files.map(_.subRelativeTo(cacheDir))
+
+        val expectedFiles = Seq(
+          os.sub / "https/repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.13.16/scala-compiler-2.13.16.jar",
+          os.sub / "https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.16/scala-library-2.13.16.jar",
+          os.sub / "https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.13.16/scala-reflect-2.13.16.jar",
+          os.sub / "https/repo1.maven.org/maven2/io/github/java-diff-utils/java-diff-utils/4.15/java-diff-utils-4.15.jar",
+          os.sub / "https/repo1.maven.org/maven2/org/jline/jline/3.27.1/jline-3.27.1-jdk8.jar"
+        )
+
+        assert(files0 == expectedFiles)
+      }
+    }
+  }
+}

--- a/modules/cache/shared/src/main/scala/coursier/cache/Cache.scala
+++ b/modules/cache/shared/src/main/scala/coursier/cache/Cache.scala
@@ -30,9 +30,6 @@ abstract class Cache[F[_]] extends PlatformCache[F] {
     Seq(fetch)
 
   def ec: ExecutionContext
-
-  def loggerOpt: Option[CacheLogger] =
-    None
 }
 
 object Cache extends PlatformCacheCompanion {

--- a/modules/cli-tests/src/main/scala/coursier/clitests/ServerTests.scala
+++ b/modules/cli-tests/src/main/scala/coursier/clitests/ServerTests.scala
@@ -1,0 +1,174 @@
+package coursier.clitests
+
+import java.io.ByteArrayOutputStream
+import java.net.{HttpURLConnection, ServerSocket, URL}
+import java.nio.charset.StandardCharsets
+import java.util.{Arrays, Base64, UUID}
+
+import utest._
+
+abstract class ServerTests extends TestSuite {
+
+  def launcher: String
+
+  private def freePort(): Int = {
+    val socket = new ServerSocket(0)
+    try socket.getLocalPort
+    finally socket.close()
+  }
+
+  private def waitForServer(host: String, port: Int, maxAttempts: Int = 50): Unit = {
+    var attempts = 0
+    var ready    = false
+    while (!ready && attempts < maxAttempts)
+      try {
+        val conn = new URL(s"http://$host:$port/").openConnection()
+          .asInstanceOf[HttpURLConnection]
+        conn.setConnectTimeout(200)
+        conn.setReadTimeout(200)
+        conn.getResponseCode
+        ready = true
+      }
+      catch {
+        case _: Exception =>
+          attempts += 1
+          Thread.sleep(200)
+      }
+    if (!ready)
+      sys.error(s"Server not ready after $maxAttempts attempts")
+  }
+
+  private def postJson(
+    host: String,
+    port: Int,
+    user: String,
+    password: String,
+    path: String,
+    body: String
+  ): (Int, String) = {
+    val conn = new URL(s"http://$host:$port$path").openConnection()
+      .asInstanceOf[HttpURLConnection]
+    conn.setRequestMethod("POST")
+    conn.setDoOutput(true)
+    conn.setRequestProperty("Content-Type", "application/json")
+    val credentials = Base64.getEncoder.encodeToString(
+      s"$user:$password".getBytes(StandardCharsets.UTF_8)
+    )
+    conn.setRequestProperty("Authorization", s"Basic $credentials")
+    val bytes = body.getBytes(StandardCharsets.UTF_8)
+    conn.getOutputStream.write(bytes)
+    conn.getOutputStream.close()
+    val code = conn.getResponseCode
+    val stream =
+      if (code >= 400) conn.getErrorStream
+      else conn.getInputStream
+    val response =
+      if (stream != null) {
+        val baos = new ByteArrayOutputStream
+        val buf  = new Array[Byte](8192)
+        var n    = 0
+        while ({ n = stream.read(buf); n != -1 })
+          baos.write(buf, 0, n)
+        stream.close()
+        new String(baos.toByteArray, StandardCharsets.UTF_8)
+      }
+      else ""
+    (code, response)
+  }
+
+  private val pomUrl =
+    "https://repo1.maven.org/maven2/org/scala-lang/scala3-library_3/3.8.2/scala3-library_3-3.8.2.pom"
+  private val otherPomUrl =
+    "https://repo1.maven.org/maven2/org/scala-lang/scala3-library_3/3.8.1/scala3-library_3-3.8.1.pom"
+
+  val tests = Tests {
+    test("server get POM") {
+      val tmpDir      = os.temp.dir(prefix = "coursier-cli-test")
+      val serverCache = tmpDir / "server-cache"
+      os.makeDir(serverCache)
+      val port = freePort()
+      val host = "localhost"
+
+      val user     = UUID.randomUUID().toString
+      val password = UUID.randomUUID().toString
+
+      val serverProcess = os.proc(
+        launcher,
+        "server",
+        "--host",
+        host,
+        "--port",
+        port.toString,
+        "--user",
+        "env:COURSIER_CACHE_SERVER_USER",
+        "--password",
+        "env:COURSIER_CACHE_SERVER_PASSWORD"
+      )
+        .spawn(
+          env = Map(
+            "COURSIER_CACHE"                 -> serverCache.toString,
+            "COURSIER_CACHE_SERVER_USER"     -> user,
+            "COURSIER_CACHE_SERVER_PASSWORD" -> password
+          ),
+          stderr = os.Inherit
+        )
+
+      try {
+        waitForServer(host, port)
+
+        val requestBody          = s"""{"artifact":{"url":"$pomUrl"}}"""
+        val (code, responseBody) = postJson(host, port, user, password, "/get", requestBody)
+        assert(code == 200)
+
+        val cachedFileViaHttpReq = {
+          val ujsonResponse = ujson.read(responseBody)
+          val pathOpt = ujsonResponse.obj
+            .get("path")
+            .flatMap(v => if (v.isNull) None else Some(v.str))
+          val errorOpt = ujsonResponse.obj
+            .get("error")
+            .flatMap(v => if (v.isNull) None else Some(v))
+          assert(errorOpt.isEmpty)
+          assert(pathOpt.nonEmpty)
+
+          val cachedFile = serverCache / os.SubPath(pathOpt.get)
+          assert(os.exists(cachedFile))
+          cachedFile
+        }
+
+        // Also fetch the same file with "cs get" using the standard cache
+        val csGetPath = os.Path(
+          os.proc(launcher, "get", pomUrl).call().out.trim()
+        )
+        assert(os.exists(csGetPath))
+        assert(Arrays.equals(os.read.bytes(cachedFileViaHttpReq), os.read.bytes(csGetPath)))
+
+        val cachedViaRemoteCache = {
+          val path = os.proc(launcher, "get", otherPomUrl)
+            .call(
+              env = Map(
+                "COURSIER_CACHE"                 -> serverCache.toString,
+                "COURSIER_CACHE_SERVER"          -> s"http://$host:$port",
+                "COURSIER_CACHE_SERVER_USER"     -> user,
+                "COURSIER_CACHE_SERVER_PASSWORD" -> password
+              )
+            )
+            .out.trim()
+          os.Path(path)
+        }
+        assert(os.exists(cachedViaRemoteCache))
+        assert(cachedViaRemoteCache.startsWith(serverCache))
+
+        val csGetOtherPath = os.Path(
+          os.proc(launcher, "get", otherPomUrl).call().out.trim()
+        )
+        assert(os.exists(csGetOtherPath))
+        assert(Arrays.equals(os.read.bytes(cachedViaRemoteCache), os.read.bytes(csGetOtherPath)))
+      }
+      finally {
+        serverProcess.destroy()
+        os.remove.all(tmpDir)
+      }
+    }
+  }
+}

--- a/modules/cli-tests/src/test/scala/coursier/clitests/PackServerTests.scala
+++ b/modules/cli-tests/src/test/scala/coursier/clitests/PackServerTests.scala
@@ -1,0 +1,5 @@
+package coursier.clitests
+
+object PackServerTests extends ServerTests {
+  val launcher = LauncherTestUtil.launcher
+}

--- a/modules/cli/src/main/resources/META-INF/native-image/io.get-coursier/coursier-cli/reflect-config.json
+++ b/modules/cli/src/main/resources/META-INF/native-image/io.get-coursier/coursier-cli/reflect-config.json
@@ -9,6 +9,30 @@
     "allPublicClasses" : true
   },
   {
+    "name":"io.undertow.UndertowLogger_$logger",
+    "methods":[{"name":"<init>","parameterTypes":["org.jboss.logging.Logger"] }]
+  },
+  {
+    "name":"io.undertow.server.protocol.http.HttpRequestParser$$generated",
+    "methods":[{"name":"<init>","parameterTypes":["org.xnio.OptionMap"] }]
+  },
+  {
+    "name":"io.undertow.util.Headers",
+    "allDeclaredFields":true
+  },
+  {
+    "name":"io.undertow.util.HttpString",
+    "fields":[{"name":"hashCode"}]
+  },
+  {
+    "name":"io.undertow.util.Methods",
+    "allDeclaredFields":true
+  },
+  {
+    "name":"io.undertow.util.Protocols",
+    "allDeclaredFields":true
+  },
+  {
     "name" : "org.apache.commons.compress.archivers.zip.AsiExtraField",
     "allDeclaredConstructors" : true,
     "allPublicConstructors" : true,
@@ -133,5 +157,37 @@
     "allPublicMethods" : true,
     "allDeclaredClasses" : true,
     "allPublicClasses" : true
+  },
+  {
+    "name":"org.xnio._private.Messages_$logger",
+    "methods":[{"name":"<init>","parameterTypes":["org.jboss.logging.Logger"] }]
+  },
+  {
+    "name":"org.xnio.management.XnioProviderMXBean",
+    "allPublicMethods":true
+  },
+  {
+    "name":"org.xnio.management.XnioServerMXBean",
+    "allPublicMethods":true
+  },
+  {
+    "name":"org.xnio.management.XnioWorkerMXBean",
+    "allPublicMethods":true
+  },
+  {
+    "name":"org.xnio.nio.Log_$logger",
+    "methods":[{"name":"<init>","parameterTypes":["org.jboss.logging.Logger"] }]
+  },
+  {
+    "name":"org.xnio.nio.NioTcpServer$1",
+    "allPublicConstructors":true
+  },
+  {
+    "name":"org.xnio.nio.NioXnio$3",
+    "allPublicConstructors":true
+  },
+  {
+    "name":"org.xnio.nio.NioXnioWorker$NioWorkerMetrics",
+    "allPublicConstructors":true
   }
 ]

--- a/modules/cli/src/main/scala/coursier/cli/Coursier.scala
+++ b/modules/cli/src/main/scala/coursier/cli/Coursier.scala
@@ -53,6 +53,7 @@ object Coursier extends CommandsEntryPoint {
     install.List,
     resolve.Resolve,
     search.Search,
+    server.Server,
     setup.Setup,
     version.Version,
     install.Uninstall,

--- a/modules/cli/src/main/scala/coursier/cli/launch/Launch.scala
+++ b/modules/cli/src/main/scala/coursier/cli/launch/Launch.scala
@@ -37,6 +37,7 @@ import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
 import scala.util.{Failure, Properties, Success}
+import coursier.cache.Cache
 
 object Launch extends CoursierCommand[LaunchOptions] {
 
@@ -329,7 +330,7 @@ object Launch extends CoursierCommand[LaunchOptions] {
     props: Seq[(String, String)],
     extraEnv: EnvironmentUpdate,
     userArgs: Seq[String],
-    cache: FileCache[Task]
+    cache: Cache[Task]
   ) = {
 
     val (jlp, jepExtraJar) =

--- a/modules/cli/src/main/scala/coursier/cli/launch/Launch.scala
+++ b/modules/cli/src/main/scala/coursier/cli/launch/Launch.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.ExecutorService
 import ai.kien.python.Python
 import caseapp.core.RemainingArgs
 import cats.data.Validated
-import coursier.cache.{ArchiveCache, FileCache}
+import coursier.cache.{ArchiveCache, Cache}
 import coursier.cli.{CoursierCommand, CommandGroup}
 import coursier.cli.fetch.Fetch
 import coursier.cli.params.{ArtifactParams, SharedLaunchParams, SharedLoaderParams}
@@ -37,7 +37,6 @@ import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
 import scala.util.{Failure, Properties, Success}
-import coursier.cache.Cache
 
 object Launch extends CoursierCommand[LaunchOptions] {
 

--- a/modules/cli/src/main/scala/coursier/cli/params/CacheParams.scala
+++ b/modules/cli/src/main/scala/coursier/cli/params/CacheParams.scala
@@ -50,26 +50,30 @@ final case class CacheParams(
     pool: ExecutorService,
     logger: CacheLogger,
     overrideTtl: Option[Duration] = None
-  ): FileCache[Task] = {
+  ): Cache.Default[Task] =
+    Cache.default match {
+      case fc: FileCache[Task] =>
+        var c = fc
+          .withLocation(cacheLocation)
+          .withCachePolicies(cachePolicies)
+          .withChecksums(checksum)
+          .withLogger(logger)
+          .withPool(pool)
+          .withTtl(overrideTtl.orElse(ttl))
+          .withRetry(retryCount)
+          .withFollowHttpToHttpsRedirections(followHttpToHttpsRedirections)
+          .withLocalArtifactsShouldBeCached(cacheLocalArtifacts)
 
-    var c = FileCache[Task]()
-      .withLocation(cacheLocation)
-      .withCachePolicies(cachePolicies)
-      .withChecksums(checksum)
-      .withLogger(logger)
-      .withPool(pool)
-      .withTtl(overrideTtl.orElse(ttl))
-      .withRetry(retryCount)
-      .withFollowHttpToHttpsRedirections(followHttpToHttpsRedirections)
-      .withLocalArtifactsShouldBeCached(cacheLocalArtifacts)
+        if (!useEnvCredentials)
+          c = c.withCredentials(Nil)
 
-    if (!useEnvCredentials)
-      c = c.withCredentials(Nil)
+        c = c.addCredentials(credentials: _*)
 
-    c = c.addCredentials(credentials: _*)
-
-    c
-  }
+        c
+      case other =>
+        // FIXME Warn users if they customize that aren't going to be used
+        other
+    }
 
   def cache(
     pool: ExecutorService,

--- a/modules/cli/src/main/scala/coursier/cli/params/CacheParams.scala
+++ b/modules/cli/src/main/scala/coursier/cli/params/CacheParams.scala
@@ -50,30 +50,39 @@ final case class CacheParams(
     pool: ExecutorService,
     logger: CacheLogger,
     overrideTtl: Option[Duration] = None
-  ): Cache.Default[Task] =
+  ): Cache.Default[Task] = {
+
+    def basicCustomizations(fc: FileCache[Task]): FileCache[Task] =
+      fc
+        .withLocation(cacheLocation)
+        .withCachePolicies(cachePolicies)
+        .withChecksums(checksum)
+        .withLogger(logger)
+        .withPool(pool)
+        .withTtl(overrideTtl.orElse(ttl))
+        .withRetry(retryCount)
+        .withFollowHttpToHttpsRedirections(followHttpToHttpsRedirections)
+        .withLocalArtifactsShouldBeCached(cacheLocalArtifacts)
+
     Cache.default match {
       case fc: FileCache[Task] =>
-        var c = fc
-          .withLocation(cacheLocation)
-          .withCachePolicies(cachePolicies)
-          .withChecksums(checksum)
-          .withLogger(logger)
-          .withPool(pool)
-          .withTtl(overrideTtl.orElse(ttl))
-          .withRetry(retryCount)
-          .withFollowHttpToHttpsRedirections(followHttpToHttpsRedirections)
-          .withLocalArtifactsShouldBeCached(cacheLocalArtifacts)
-
+        var c = basicCustomizations(fc)
         if (!useEnvCredentials)
           c = c.withCredentials(Nil)
-
         c = c.addCredentials(credentials: _*)
-
         c
+      case rc: RemoteCache[Task] =>
+        rc
+          .withLocation(cacheLocation)
+          .withLogger(logger)
+          .withPool(pool)
+          .withFileFallback(Some(basicCustomizations(Cache.defaultLocalCache)))
+      // .withLocalArtifactsShouldBeCached(cacheLocalArtifacts)
       case other =>
         // FIXME Warn users if they customize that aren't going to be used
         other
     }
+  }
 
   def cache(
     pool: ExecutorService,

--- a/modules/cli/src/main/scala/coursier/cli/server/Server.scala
+++ b/modules/cli/src/main/scala/coursier/cli/server/Server.scala
@@ -1,0 +1,80 @@
+package coursier.cli.server
+
+import caseapp.core.RemainingArgs
+import coursier.cache.FileCache
+import coursier.cache.internal.ThreadUtil
+import coursier.cache.server.CacheServer
+import coursier.cli.CoursierCommand
+import coursier.util.{Sync, Task}
+import io.undertow.Undertow
+import io.undertow.server.{HttpHandler, HttpServerExchange}
+import io.undertow.util.{Headers, StatusCodes}
+
+import java.util.Base64
+import java.util.concurrent.Executors
+import java.util.logging.{Level, Logger}
+
+import scala.concurrent.ExecutionContext
+
+object Server extends CoursierCommand[ServerOptions] {
+
+  private val basicAuthPrefix = "Basic "
+
+  def run(options: ServerOptions, args: RemainingArgs): Unit = {
+
+    val params = ServerParams(options).toEither match {
+      case Left(errors) =>
+        for (e <- errors.toList)
+          System.err.println(e)
+        sys.exit(1)
+      case Right(p) => p
+    }
+
+    val expectedAuthOpt = params.userPassword.map {
+      case (user, password) =>
+        s"${user.value}:${password.value}"
+    }
+
+    val cachePool = Sync.fixedThreadPool(params.cache.parallel)
+    val cache = params.cache.cache(cachePool, params.output.logger()) match {
+      case fc: FileCache[Task] => fc
+      case other =>
+        System.err.println(s"Unexpected cache type: $other")
+        sys.exit(1)
+    }
+    val requestsPool = Executors.newCachedThreadPool(
+      ThreadUtil.daemonThreadFactory("coursier-cache-server-requests")
+    )
+    val baseHandler = CacheServer.handler(cache, ExecutionContext.fromExecutorService(requestsPool))
+    val handler: HttpHandler = expectedAuthOpt match {
+      case None => baseHandler
+      case Some(expectedAuth) =>
+        (exchange: HttpServerExchange) => {
+          val authorized = Option(exchange.getRequestHeaders.getFirst(Headers.AUTHORIZATION))
+            .filter(_.startsWith(basicAuthPrefix))
+            .map(_.substring(basicAuthPrefix.length))
+            .map(Base64.getDecoder.decode)
+            .map(new String(_))
+            .contains(expectedAuth)
+          if (authorized)
+            baseHandler.handleRequest(exchange)
+          else {
+            exchange.getResponseHeaders.put(
+              Headers.WWW_AUTHENTICATE,
+              "Basic realm=\"coursier cache server\""
+            )
+            exchange.setStatusCode(StatusCodes.UNAUTHORIZED)
+            exchange.getResponseSender.send("Unauthorized")
+          }
+        }
+    }
+    Logger.getLogger("").setLevel(Level.WARNING)
+    cache.logger.init()
+    val server = Undertow.builder()
+      .addHttpListener(params.port, params.host)
+      .setHandler(handler)
+      .build()
+    server.start()
+    System.out.println(s"Cache server started on ${params.host}:${params.port}")
+  }
+}

--- a/modules/cli/src/main/scala/coursier/cli/server/Server.scala
+++ b/modules/cli/src/main/scala/coursier/cli/server/Server.scala
@@ -1,0 +1,106 @@
+package coursier.cli.server
+
+import caseapp.core.RemainingArgs
+import coursier.cache.FileCache
+import coursier.cache.internal.ThreadUtil
+import coursier.cache.server.CacheServer
+import coursier.cli.CoursierCommand
+import coursier.util.{Sync, Task}
+import io.undertow.Undertow
+import io.undertow.server.{HttpHandler, HttpServerExchange}
+import io.undertow.util.{Headers, StatusCodes}
+
+import java.util.Base64
+import java.util.concurrent.Executors
+import java.util.logging.{Level, Logger}
+
+import scala.concurrent.ExecutionContext
+
+object Server extends CoursierCommand[ServerOptions] {
+
+  private val basicAuthPrefix = "Basic "
+
+  def run(options: ServerOptions, args: RemainingArgs): Unit = {
+
+    val params = ServerParams(options).toEither match {
+      case Left(errors) =>
+        for (e <- errors.toList)
+          System.err.println(e)
+        sys.exit(1)
+      case Right(p) => p
+    }
+
+    val expectedAuthOpt = params.userPassword.map {
+      case (user, password) =>
+        s"${user.value}:${password.value}"
+    }
+
+    val cachePool = Sync.fixedThreadPool(params.cache.parallel)
+    val cache = params.cache.cache(cachePool, params.output.logger()) match {
+      case fc: FileCache[Task] => fc
+      case other =>
+        System.err.println(s"Unexpected cache type: $other")
+        sys.exit(1)
+    }
+    val requestsPool = Executors.newCachedThreadPool(
+      ThreadUtil.daemonThreadFactory("coursier-cache-server-requests")
+    )
+    val baseHandler = CacheServer.handler(cache, ExecutionContext.fromExecutorService(requestsPool))
+
+    val filteredHandler: HttpHandler =
+      (exchange: HttpServerExchange) => {
+        def checkPrefix(prefix: String): Boolean = {
+          val url = exchange.getRequestURL
+          if (prefix.endsWith("*"))
+            url.startsWith(prefix.dropRight("*".length))
+          else
+            url == prefix ||
+            url.startsWith(prefix + "/")
+        }
+        val allowed =
+          if (params.defaultAllow)
+            !params.disallow.exists(checkPrefix) ||
+            params.allow.exists(checkPrefix)
+          else
+            params.allow.exists(checkPrefix) &&
+            !params.disallow.exists(checkPrefix)
+        if (allowed)
+          baseHandler.handleRequest(exchange)
+        else
+          exchange
+            .setStatusCode(StatusCodes.FORBIDDEN)
+            .getResponseSender.send("Forbidden")
+      }
+
+    val handler: HttpHandler = expectedAuthOpt match {
+      case None => filteredHandler
+      case Some(expectedAuth) =>
+        (exchange: HttpServerExchange) => {
+          val authorized = Option(exchange.getRequestHeaders.getFirst(Headers.AUTHORIZATION))
+            .filter(_.startsWith(basicAuthPrefix))
+            .map(_.substring(basicAuthPrefix.length))
+            .map(Base64.getDecoder.decode)
+            .map(new String(_))
+            .contains(expectedAuth)
+          if (authorized)
+            filteredHandler.handleRequest(exchange)
+          else {
+            exchange.getResponseHeaders.put(
+              Headers.WWW_AUTHENTICATE,
+              "Basic realm=\"coursier cache server\""
+            )
+            exchange.setStatusCode(StatusCodes.UNAUTHORIZED)
+            exchange.getResponseSender.send("Unauthorized")
+          }
+        }
+    }
+    Logger.getLogger("").setLevel(Level.WARNING)
+    cache.logger.init()
+    val server = Undertow.builder()
+      .addHttpListener(params.port, params.host)
+      .setHandler(handler)
+      .build()
+    server.start()
+    System.out.println(s"Cache server started on ${params.host}:${params.port}")
+  }
+}

--- a/modules/cli/src/main/scala/coursier/cli/server/ServerOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/server/ServerOptions.scala
@@ -1,0 +1,37 @@
+package coursier.cli.server
+
+import caseapp._
+import coursier.cli.options.{CacheOptions, OutputOptions}
+import coursier.cli.util.ArgParsers.*
+import scala.cli.config.PasswordOption
+
+// format: off
+@HelpMessage("Start a cache server")
+final case class ServerOptions(
+  @Recurse
+    cache: CacheOptions = CacheOptions(),
+  @Recurse
+    output: OutputOptions = OutputOptions(),
+  @HelpMessage("Host to bind to")
+    host: String = "localhost",
+  @HelpMessage("Port to listen on")
+    port: Int = 9090,
+  @HelpMessage("HTTP basic auth user")
+  @ValueDescription(
+    "value:… or env:ENV_VAR_NAME or file:/path/to/file or command:simple-command or command:[\"json\", \"array\"]"
+  )
+    user: Option[PasswordOption] = None,
+  @HelpMessage("HTTP basic auth password")
+  @ValueDescription(
+    "value:… or env:ENV_VAR_NAME or file:/path/to/file or command:simple-command or command:[\"json\", \"array\"]"
+  )
+    password: Option[PasswordOption] = None,
+  @HelpMessage("Disable authentication")
+    noAuth: Boolean = false
+)
+// format: on
+
+object ServerOptions {
+  implicit lazy val parser: Parser[ServerOptions] = Parser.derive
+  implicit lazy val help: Help[ServerOptions]     = Help.derive
+}

--- a/modules/cli/src/main/scala/coursier/cli/server/ServerOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/server/ServerOptions.scala
@@ -1,0 +1,45 @@
+package coursier.cli.server
+
+import caseapp._
+import coursier.cli.options.{CacheOptions, OutputOptions}
+import coursier.cli.util.ArgParsers.*
+import scala.cli.config.PasswordOption
+
+// format: off
+@HelpMessage("Start a cache server")
+final case class ServerOptions(
+  @Recurse
+    cache: CacheOptions = CacheOptions(),
+  @Recurse
+    output: OutputOptions = OutputOptions(),
+  @HelpMessage("Host to bind to")
+    host: String = "localhost",
+  @HelpMessage("Port to listen on")
+    port: Int = 9090,
+  @HelpMessage("HTTP basic auth user")
+  @ValueDescription(
+    "value:… or env:ENV_VAR_NAME or file:/path/to/file or command:simple-command or command:[\"json\", \"array\"]"
+  )
+    user: Option[PasswordOption] = None,
+  @HelpMessage("HTTP basic auth password")
+  @ValueDescription(
+    "value:… or env:ENV_VAR_NAME or file:/path/to/file or command:simple-command or command:[\"json\", \"array\"]"
+  )
+    password: Option[PasswordOption] = None,
+  @HelpMessage("Disable authentication")
+    noAuth: Boolean = false,
+  @HelpMessage("Default to allowing requests (default behavior)")
+    defaultAllow: Option[Boolean] = None,
+  @HelpMessage("Default to disallowing requests")
+    defaultDisallow: Option[Boolean] = None,
+  @HelpMessage("Allow requests for artifacts whose URL starts with these prefixes (comma-separated)")
+    allow: List[String] = Nil,
+  @HelpMessage("Disallow requests for artifacts whose URL starts with these prefixes (comma-separated)")
+    disallow: List[String] = Nil
+)
+// format: on
+
+object ServerOptions {
+  implicit lazy val parser: Parser[ServerOptions] = Parser.derive
+  implicit lazy val help: Help[ServerOptions]     = Help.derive
+}

--- a/modules/cli/src/main/scala/coursier/cli/server/ServerParams.scala
+++ b/modules/cli/src/main/scala/coursier/cli/server/ServerParams.scala
@@ -1,0 +1,45 @@
+package coursier.cli.server
+
+import cats.data.ValidatedNel
+import cats.implicits._
+import coursier.cli.params.{CacheParams, OutputParams}
+import scala.cli.config.Secret
+
+final case class ServerParams(
+  cache: CacheParams,
+  output: OutputParams,
+  host: String,
+  port: Int,
+  userPassword: Option[(Secret[String], Secret[String])]
+)
+
+object ServerParams {
+  def apply(options: ServerOptions): ValidatedNel[String, ServerParams] = {
+    val cacheV  = options.cache.params
+    val outputV = OutputParams(options.output)
+
+    val userPasswordV: ValidatedNel[String, Option[(Secret[String], Secret[String])]] =
+      if (options.noAuth) None.validNel
+      else
+        (options.user, options.password) match {
+          case (Some(user), Some(password)) =>
+            Some((user.get(), password.get())).validNel
+          case (Some(_), None) =>
+            "Missing --password option".invalidNel
+          case (None, Some(_)) =>
+            "Missing --user option".invalidNel
+          case (None, None) =>
+            "Missing --user and --password options".invalidNel
+        }
+
+    (cacheV, outputV, userPasswordV).mapN { (cache, output, userPassword) =>
+      ServerParams(
+        cache = cache,
+        output = output,
+        host = options.host,
+        port = options.port,
+        userPassword = userPassword
+      )
+    }
+  }
+}

--- a/modules/cli/src/main/scala/coursier/cli/server/ServerParams.scala
+++ b/modules/cli/src/main/scala/coursier/cli/server/ServerParams.scala
@@ -1,0 +1,77 @@
+package coursier.cli.server
+
+import cats.data.ValidatedNel
+import cats.implicits._
+import coursier.cli.params.{CacheParams, OutputParams}
+import scala.cli.config.Secret
+
+final case class ServerParams(
+  cache: CacheParams,
+  output: OutputParams,
+  host: String,
+  port: Int,
+  userPassword: Option[(Secret[String], Secret[String])],
+  defaultAllow: Boolean,
+  allow: List[String],
+  disallow: List[String]
+)
+
+object ServerParams {
+  def apply(options: ServerOptions): ValidatedNel[String, ServerParams] = {
+    val cacheV  = options.cache.params
+    val outputV = OutputParams(options.output)
+
+    val userPasswordV: ValidatedNel[String, Option[(Secret[String], Secret[String])]] =
+      if (options.noAuth) None.validNel
+      else
+        (options.user, options.password) match {
+          case (Some(user), Some(password)) =>
+            Some((user.get(), password.get())).validNel
+          case (Some(_), None) =>
+            "Missing --password option".invalidNel
+          case (None, Some(_)) =>
+            "Missing --user option".invalidNel
+          case (None, None) =>
+            "Missing --user and --password options".invalidNel
+        }
+
+    val defaultAllowV: ValidatedNel[String, Boolean] =
+      options.defaultAllow match {
+        case Some(true) =>
+          options.defaultDisallow match {
+            case Some(true) =>
+              "--default-allow and --default-disallow cannot be specified at the same time".invalidNel
+            case _ =>
+              true.validNel
+          }
+        case Some(false) =>
+          options.defaultDisallow match {
+            case Some(false) =>
+              "--default-allow and --default-disallow cannot be disabled at the same time".invalidNel
+            case _ =>
+              false.validNel
+          }
+        case None =>
+          options.defaultDisallow match {
+            case Some(true) =>
+              false.validNel
+            case _ =>
+              true.validNel
+          }
+      }
+
+    (cacheV, outputV, userPasswordV, defaultAllowV).mapN {
+      (cache, output, userPassword, defaultAllow) =>
+        ServerParams(
+          cache = cache,
+          output = output,
+          host = options.host,
+          port = options.port,
+          userPassword = userPassword,
+          defaultAllow = defaultAllow,
+          allow = options.allow.flatMap(_.split(",")).map(_.trim).filter(_.nonEmpty),
+          disallow = options.disallow.flatMap(_.split(",")).map(_.trim).filter(_.nonEmpty)
+        )
+    }
+  }
+}

--- a/modules/cli/src/main/scala/coursier/cli/util/ArgParsers.scala
+++ b/modules/cli/src/main/scala/coursier/cli/util/ArgParsers.scala
@@ -1,0 +1,40 @@
+// Adapted from https://github.com/VirtusLab/scala-cli/blob/ca3f6e8f59562e1adcf798cd868b0233500f94f1/modules/cli/src/main/scala/scala/cli/util/ArgParsers.scala
+
+package coursier.cli.util
+
+import caseapp.core.argparser.{ArgParser, SimpleArgParser}
+
+import scala.cli.config.PasswordOption
+
+abstract class LowPriorityArgParsers {
+
+  /** case-app [[ArgParser]] for [[PasswordOption]]
+    *
+    * Given a lower priority than the one for `Option[PasswordOption]`, as the latter falls back to
+    * `None` when given an empty string (like in `--password ""`), while letting it be automatically
+    * derived from this one (with the former parser and the generic [[ArgParser]] for `Option[T]`
+    * from case-app) would fail on such empty input.
+    */
+  implicit lazy val passwordOptionArgParser: ArgParser[PasswordOption] =
+    SimpleArgParser.from("password") { str =>
+      PasswordOption.parse(str)
+        .left.map(caseapp.core.Error.Other(_))
+    }
+
+}
+
+object ArgParsers extends LowPriorityArgParsers {
+
+  /** case-app [[ArgParser]] for `Option[PasswordOption]`
+    *
+    * Unlike a parser automatically derived through case-app [[ArgParser]] for `Option[T]`, the
+    * parser here accepts empty input (like in `--password ""`), and returns a `None` value in that
+    * case.
+    */
+  implicit lazy val optionPasswordOptionArgParser
+    : ArgParser[Option[PasswordOption]] =
+    SimpleArgParser.from("password") { str =>
+      if (str.trim.isEmpty) Right(None)
+      else passwordOptionArgParser(None, -1, -1, str).map(Some(_))
+    }
+}

--- a/modules/coursier/jvm/src/it/scala/coursier/tests/AuthenticationTests.scala
+++ b/modules/coursier/jvm/src/it/scala/coursier/tests/AuthenticationTests.scala
@@ -5,11 +5,12 @@ import java.net.URI
 import java.nio.file.{Files, Path}
 
 import coursier.{Repositories, Resolve}
-import coursier.cache.FileCache
+import coursier.cache.{Cache, FileCache}
 import coursier.credentials.{DirectCredentials, FileCredentials}
 import coursier.maven.MavenRepository
 import coursier.parse.CredentialsParser
 import coursier.util.StringInterpolators._
+import coursier.util.Task
 import utest._
 
 object AuthenticationTests extends TestSuite {
@@ -38,6 +39,12 @@ object AuthenticationTests extends TestSuite {
     finally deleteRecursive(dir.toFile)
   }
 
+  private def defaultCache() = Cache.default match {
+    case fc: FileCache[Task] => fc
+    case other =>
+      sys.error(s"Expected default cache to be a FileCache, got $other")
+  }
+
   private def testCredentials(credentials: DirectCredentials): Unit = {
     val result = withTmpDir { dir =>
       Resolve()
@@ -48,7 +55,7 @@ object AuthenticationTests extends TestSuite {
         ))
         .addDependencies(dep"com.abc:test:0.1".withTransitive(false))
         .withCache(
-          FileCache()
+          defaultCache()
             .noCredentials
             .withLocation(dir.toFile)
             .addCredentials(credentials)

--- a/modules/coursier/jvm/src/it/scala/coursier/tests/AuthenticationTests.scala
+++ b/modules/coursier/jvm/src/it/scala/coursier/tests/AuthenticationTests.scala
@@ -5,12 +5,13 @@ import java.net.URI
 import java.nio.file.{Files, Path}
 
 import coursier.{Repositories, Resolve}
-import coursier.cache.FileCache
+import coursier.cache.{Cache, FileCache}
 import coursier.credentials.{DirectCredentials, FileCredentials}
 import coursier.maven.MavenRepository
 import coursier.parse.CredentialsParser
 import coursier.testcache.TestRepositoryServer
 import coursier.util.StringInterpolators._
+import coursier.util.Task
 import utest._
 
 object AuthenticationTests extends TestSuite with TestRepositoryServer.Test {
@@ -33,6 +34,12 @@ object AuthenticationTests extends TestSuite with TestRepositoryServer.Test {
     finally deleteRecursive(dir.toFile)
   }
 
+  private def defaultCache() = Cache.default match {
+    case fc: FileCache[Task] => fc
+    case other =>
+      sys.error(s"Expected default cache to be a FileCache, got $other")
+  }
+
   private def testCredentials(credentials: DirectCredentials): Unit = {
     val result = withTmpDir { dir =>
       Resolve()
@@ -43,7 +50,7 @@ object AuthenticationTests extends TestSuite with TestRepositoryServer.Test {
         ))
         .addDependencies(dep"com.abc:test:0.1".withTransitive(false))
         .withCache(
-          FileCache()
+          defaultCache()
             .noCredentials
             .withLocation(dir.toFile)
             .addCredentials(credentials)

--- a/modules/coursier/jvm/src/test/scala/coursier/tests/FetchCacheTests.scala
+++ b/modules/coursier/jvm/src/test/scala/coursier/tests/FetchCacheTests.scala
@@ -9,6 +9,8 @@ import utest._
 
 import scala.async.Async.{async, await}
 import scala.jdk.CollectionConverters._
+import coursier.cache.Cache
+import coursier.util.Task
 
 object FetchCacheTests extends TestSuite {
 
@@ -45,6 +47,12 @@ object FetchCacheTests extends TestSuite {
     else
       Files.deleteIfExists(d)
 
+  private def defaultCache() = Cache.default match {
+    case fc: FileCache[Task] => fc
+    case other =>
+      sys.error(s"Expected default cache to be a FileCache, got $other")
+  }
+
   val tests = Tests {
 
     import TestHelpers.ec
@@ -75,7 +83,7 @@ object FetchCacheTests extends TestSuite {
             .noMirrors
             .addDependencies(dep"io.get-coursier:coursier-cli_2.12:1.1.0-M8")
             .withCache(
-              FileCache()
+              defaultCache()
                 .noCredentials
                 .withLocation(tmpCache.toFile)
             )

--- a/modules/docker/src/main/scala/coursier/docker/DockerBuild.scala
+++ b/modules/docker/src/main/scala/coursier/docker/DockerBuild.scala
@@ -2,10 +2,10 @@ package coursier.docker
 
 import coursier.cache.{
   ArchiveCache,
+  Cache,
   DigestArtifact,
   DigestBasedArchiveCache,
-  DigestBasedCache,
-  FileCache
+  DigestBasedCache
 }
 import coursier.docker.DockerFile.WithLines
 import coursier.util.Task
@@ -75,7 +75,7 @@ object DockerBuild {
     dockerFile: Option[os.Path],
     vmOpt: Option[Vm],
     authRegistry: String = DockerPull.defaultAuthRegistry,
-    cache: FileCache[Task] = FileCache(),
+    cache: Cache[Task] with Cache.HasLocation = Cache.default,
     os0: String = DockerPull.defaultOs,
     arch: String = DockerPull.defaultArch,
     archVariant: Option[String] = DockerPull.defaultArchVariant
@@ -115,7 +115,7 @@ object DockerBuild {
     fromRepoVersion: String,
     contextDir: os.Path,
     authRegistry: String,
-    cache: FileCache[Task],
+    cache: Cache[Task] with Cache.HasLocation,
     instructions: Seq[WithLines[DockerInstruction.NonHead]],
     dockerFile: String, // for error messages
     os0: String,

--- a/modules/docker/src/main/scala/coursier/docker/DockerPull.scala
+++ b/modules/docker/src/main/scala/coursier/docker/DockerPull.scala
@@ -1,6 +1,6 @@
 package coursier.docker
 
-import coursier.cache.{Cache, CacheLogger, FileCache}
+import coursier.cache.{Cache, CacheLogger}
 import coursier.cache.util.{Cpu, Os}
 import coursier.core.Authentication
 import coursier.util.{Artifact, Task}
@@ -36,7 +36,7 @@ object DockerPull {
     arch: String = defaultArch,
     archVariant: Option[String] = defaultArchVariant,
     authRegistry: String = defaultAuthRegistry,
-    cache: Cache[Task] = FileCache()
+    cache: Cache[Task] = Cache.default
   ): DockerPull.Result = {
 
     lazy val token = DockerUtil.token(authRegistry, repoName)

--- a/modules/docker/src/main/scala/coursier/docker/DockerRun.scala
+++ b/modules/docker/src/main/scala/coursier/docker/DockerRun.scala
@@ -2,7 +2,7 @@ package coursier.docker
 
 import com.github.plokhotnyuk.jsoniter_scala.core.{JsonValueCodec, writeToArray}
 import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
-import coursier.cache.{ArchiveCache, DigestBasedCache, FileCache}
+import coursier.cache.{ArchiveCache, Cache, DigestBasedCache}
 import coursier.exec.Execve
 import coursier.util.{Artifact, Task}
 import io.github.alexarchambault.isterminal.IsTerminal
@@ -170,7 +170,7 @@ object DockerRun {
     JsonCodecMaker.make
 
   def run(
-    cache: FileCache[Task],
+    cache: Cache[Task] with Cache.HasLocation,
     digestCache: DigestBasedCache[Task],
     config: DockerImageConfig.Config,
     layerFiles: () => Seq[os.Path],

--- a/modules/docker/src/main/scala/coursier/docker/DockerVm.scala
+++ b/modules/docker/src/main/scala/coursier/docker/DockerVm.scala
@@ -1,7 +1,7 @@
 package coursier.docker
 
 import com.github.plokhotnyuk.jsoniter_scala.core.writeToArray
-import coursier.cache.{DigestBasedCache, FileCache}
+import coursier.cache.{Cache, DigestBasedCache, FileCache}
 import coursier.util.Task
 import coursier.docker.vm.Vm
 import io.github.alexarchambault.isterminal.IsTerminal
@@ -13,7 +13,7 @@ object DockerVm {
 
   private class Pull(
     workDir: os.Path,
-    cache: FileCache[Task],
+    cache: Cache[Task] with Cache.HasLocation,
     digestCacheOpt: Option[DigestBasedCache[Task]],
     vm: Vm,
     session: Session,
@@ -104,7 +104,7 @@ object DockerVm {
 
   private class Run(
     workDir: os.Path,
-    cache: FileCache[Task],
+    cache: Cache[Task] with Cache.HasLocation,
     digestCache: DigestBasedCache[Task],
     layerFiles: Seq[os.Path],
     rootFsDirName: String,
@@ -231,7 +231,7 @@ object DockerVm {
 
   def pullContainer(
     workDir: os.Path,
-    cache: FileCache[Task],
+    cache: Cache[Task] with Cache.HasLocation,
     layerFiles: Seq[os.Path],
     vm: Vm,
     session: Session,
@@ -253,7 +253,7 @@ object DockerVm {
 
   def runContainer(
     workDir: os.Path,
-    cache: FileCache[Task],
+    cache: Cache[Task] with Cache.HasLocation,
     digestCache: DigestBasedCache[Task],
     layerFiles: Seq[os.Path],
     rootFsDirName: String,

--- a/modules/docker/src/main/scala/coursier/docker/vm/QemuFiles.scala
+++ b/modules/docker/src/main/scala/coursier/docker/vm/QemuFiles.scala
@@ -66,7 +66,7 @@ object QemuFiles {
 
       val biosArtifactOptTask = guestCpu match {
         case Cpu.Arm64 =>
-          val cache = coursier.cache.FileCache()
+          val cache = coursier.cache.Cache.default
           val debIndexArtifact =
             Artifact("https://deb.debian.org/debian/dists/trixie/main/binary-amd64/Packages.gz")
               .withChanging(true)

--- a/modules/docker/src/main/scala/coursier/docker/vm/QemuFiles.scala
+++ b/modules/docker/src/main/scala/coursier/docker/vm/QemuFiles.scala
@@ -68,7 +68,7 @@ object QemuFiles {
 
       val biosArtifactOptTask = guestCpu match {
         case Cpu.Arm64 =>
-          val cache = coursier.cache.FileCache()
+          val cache = coursier.cache.Cache.default
           val debIndexArtifact =
             Artifact("https://deb.debian.org/debian/dists/trixie/main/binary-amd64/Packages.gz")
               .withChanging(true)

--- a/modules/docker/src/main/scala/coursier/docker/vm/Vm.scala
+++ b/modules/docker/src/main/scala/coursier/docker/vm/Vm.scala
@@ -26,6 +26,7 @@ import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
 import java.io.InputStream
 import coursier.cache.util.Cpu
 import coursier.docker.vm.iso.Image
+import coursier.cache.Cache
 
 final class Vm(
   val id: String,
@@ -199,7 +200,7 @@ object Vm {
     def default(
       workDir: os.Path = defaultWorkDir(),
       guestWorkDir: os.SubPath = os.sub / "workdir",
-      cacheLocation: Option[os.Path] = Some(os.Path(FileCache().location, os.pwd)),
+      cacheLocation: Option[os.Path] = Some(os.Path(Cache.default.location, os.pwd)),
       digestCacheLocation: Option[os.Path] = Some(os.Path(DigestBasedCache().location, os.pwd)),
       guestCpu: Cpu = Cpu.get()
     ): Params = Params(
@@ -221,7 +222,7 @@ object Vm {
     def defaultMounts(
       workDir: os.Path = defaultWorkDir(),
       guestWorkDir: os.SubPath = os.sub / "workdir",
-      cacheLocation: Option[os.Path] = Some(os.Path(FileCache().location, os.pwd)),
+      cacheLocation: Option[os.Path] = Some(os.Path(Cache.default.location, os.pwd)),
       digestCacheLocation: Option[os.Path] = Some(os.Path(DigestBasedCache().location, os.pwd))
     ): Seq[Mount] = {
 

--- a/modules/docker/src/main/scala/coursier/docker/vm/Vm.scala
+++ b/modules/docker/src/main/scala/coursier/docker/vm/Vm.scala
@@ -26,8 +26,8 @@ import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
 import java.io.InputStream
 import coursier.cache.util.Cpu
 import coursier.docker.vm.iso.Image
-import java.util.concurrent.TimeoutException
 import scala.annotation.tailrec
+import coursier.cache.Cache
 
 final class Vm(
   val id: String,
@@ -223,7 +223,7 @@ object Vm {
     def default(
       workDir: os.Path = defaultWorkDir(),
       guestWorkDir: os.SubPath = os.sub / "workdir",
-      cacheLocation: Option[os.Path] = Some(os.Path(FileCache().location, os.pwd)),
+      cacheLocation: Option[os.Path] = Some(os.Path(Cache.default.location, os.pwd)),
       digestCacheLocation: Option[os.Path] = Some(os.Path(DigestBasedCache().location, os.pwd)),
       guestCpu: Cpu = Cpu.get()
     ): Params = Params(
@@ -245,7 +245,7 @@ object Vm {
     def defaultMounts(
       workDir: os.Path = defaultWorkDir(),
       guestWorkDir: os.SubPath = os.sub / "workdir",
-      cacheLocation: Option[os.Path] = Some(os.Path(FileCache().location, os.pwd)),
+      cacheLocation: Option[os.Path] = Some(os.Path(Cache.default.location, os.pwd)),
       digestCacheLocation: Option[os.Path] = Some(os.Path(DigestBasedCache().location, os.pwd))
     ): Seq[Mount] = {
 

--- a/modules/docker/src/test/scala/coursier/docker/tests/DockerTests.scala
+++ b/modules/docker/src/test/scala/coursier/docker/tests/DockerTests.scala
@@ -2,7 +2,7 @@ package coursier.docker.tests
 
 import coursier.cache.TestUtil._
 import coursier.cache.util.Cpu
-import coursier.cache.{ArchiveCache, DigestBasedCache, FileCache}
+import coursier.cache.{ArchiveCache, Cache, DigestBasedCache}
 import coursier.docker.{DockerBuild, DockerPull, DockerRun, DockerUnpack}
 import coursier.docker.vm.Vm
 import io.github.alexarchambault.isterminal.IsTerminal
@@ -13,7 +13,7 @@ import coursier.docker.vm.VmFiles
 
 object DockerTests extends TestSuite {
 
-  val cache = FileCache()
+  val cache = Cache.default
 
   // set to true to speed up tests locally
   // needs 'cs vm start' to have been run before that

--- a/modules/install/src/main/scala/coursier/install/Channels.scala
+++ b/modules/install/src/main/scala/coursier/install/Channels.scala
@@ -7,7 +7,7 @@ import java.util.zip.ZipFile
 
 import argonaut.{DecodeJson, Parse}
 import coursier.Fetch
-import coursier.cache.{Cache, FileCache}
+import coursier.cache.Cache
 import coursier.cache.internal.FileUtil
 import coursier.core.{Dependency, Repository}
 import coursier.install.Codecs.{decodeObj, encodeObj}
@@ -22,7 +22,7 @@ import scala.jdk.CollectionConverters._
 @data class Channels(
   channels: Seq[Channel] = Channels.defaultChannels,
   repositories: Seq[Repository] = coursier.Resolve.defaultRepositories,
-  cache: Cache[Task] = FileCache(),
+  cache: Cache[Task] = Cache.default,
   @since
   verbosity: Int = 0,
   @since("2.0.10")

--- a/modules/install/src/main/scala/coursier/install/InstallDir.scala
+++ b/modules/install/src/main/scala/coursier/install/InstallDir.scala
@@ -8,7 +8,7 @@ import java.util.Locale
 import java.util.stream.Stream
 import java.util.zip.ZipEntry
 
-import coursier.cache.{ArchiveCache, ArchiveType, Cache, FileCache}
+import coursier.cache.{ArchiveCache, ArchiveType, Cache}
 import coursier.core.{Dependency, Module, Repository}
 import coursier.env.EnvironmentUpdate
 import coursier.install.error._
@@ -24,7 +24,8 @@ import scala.jdk.CollectionConverters._
 
 @data class InstallDir(
   baseDir: Path = InstallDir.defaultDir,
-  cache: Cache[Task] = FileCache(),
+  @since
+  cache: Cache[Task] = Cache.default,
   @since
   verbosity: Int = 0,
   graalvmParamsOpt: Option[GraalvmParams] = None,

--- a/modules/install/src/test/scala/coursier/install/InstallDirTests.scala
+++ b/modules/install/src/test/scala/coursier/install/InstallDirTests.scala
@@ -66,7 +66,7 @@ object InstallDirTests extends TestSuite {
         createApp(tempDir, ".dot-app-should-be-ignored")
         createApp(tempDir, "app1")
 
-        val installedApps = new InstallDir(tempDir, FileCache()).list()
+        val installedApps = InstallDir(tempDir).list()
         assert(installedApps == Seq("app1"))
       }
       finally

--- a/modules/jvm/src/main/scala/coursier/jvm/JvmIndex.scala
+++ b/modules/jvm/src/main/scala/coursier/jvm/JvmIndex.scala
@@ -212,7 +212,7 @@ object JvmIndex {
     load(cache, coursier.Resolve().repositories, JvmChannel.default(), None, None)
 
   def load(): Task[JvmIndex] =
-    load(FileCache(), coursier.Resolve().repositories, JvmChannel.default(), None, None)
+    load(Cache.default, coursier.Resolve().repositories, JvmChannel.default(), None, None)
 
   @deprecated("Use JvmChannel.currentOs instead", "2.1.15")
   def currentOs: Either[String, String] =

--- a/modules/tests/jvm/src/it/scala/coursier/tests/VersionTests.scala
+++ b/modules/tests/jvm/src/it/scala/coursier/tests/VersionTests.scala
@@ -1,6 +1,6 @@
 package coursier.tests
 
-import coursier.cache.FileCache
+import coursier.cache.Cache
 import coursier.core.{Organization, Module, ModuleName}
 import coursier.Versions
 import utest.{TestSuite, Tests, assert, test}
@@ -9,7 +9,7 @@ import scala.async.Async.{async, await}
 import scala.concurrent.ExecutionContextExecutorService
 
 object VersionTests extends TestSuite {
-  implicit val ec: ExecutionContextExecutorService = FileCache().ec
+  implicit val ec: ExecutionContextExecutorService = Cache.default.ec
   val tests: Tests = Tests {
     test {
       async {

--- a/modules/tests/jvm/src/test/scala/coursier/tests/CacheFetchTests.scala
+++ b/modules/tests/jvm/src/test/scala/coursier/tests/CacheFetchTests.scala
@@ -3,19 +3,26 @@ package coursier.tests
 import java.io.File
 import java.nio.file.Files
 
-import coursier.cache.{CacheUrl, FileCache}
+import coursier.cache.{Cache, CacheUrl, FileCache}
 import coursier.cache.protocol.TestprotocolHandler
 import coursier.core.{Dependency, Repository, Resolution, ResolutionProcess}
 import coursier.maven.MavenRepository
 import coursier.util.StringInterpolators._
+import coursier.util.Task
+import coursier.version.VersionConstraint
 import utest._
 
 import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration.Duration
 import scala.util.Try
-import coursier.version.VersionConstraint
 
 object CacheFetchTests extends TestSuite {
+
+  private def defaultCache() = Cache.default match {
+    case fc: FileCache[Task] => fc
+    case other =>
+      sys.error(s"Expected default cache to be a FileCache, got $other")
+  }
 
   def check(
     extraRepo: Repository,
@@ -47,7 +54,7 @@ object CacheFetchTests extends TestSuite {
         Console.err.println(s"Warning: unable to remove temporary directory $tmpDir")
     }
 
-    val fetchs = FileCache()
+    val fetchs = defaultCache()
       .noCredentials
       .withLocation(tmpDir)
       .withFollowHttpToHttpsRedirections(followHttpToHttpsRedirections)

--- a/modules/tests/jvm/src/test/scala/coursier/tests/ChecksumTests.scala
+++ b/modules/tests/jvm/src/test/scala/coursier/tests/ChecksumTests.scala
@@ -2,13 +2,20 @@ package coursier.tests
 
 import java.math.BigInteger
 
-import coursier.cache.{ArtifactError, CacheChecksum, FileCache}
+import coursier.cache.{ArtifactError, Cache, CacheChecksum, FileCache}
 import coursier.util.{Artifact, Gather, Sync, Task}
 import utest._
 
 import scala.concurrent.{ExecutionContext, Future}
 
 object ChecksumTests extends TestSuite {
+
+  private def defaultCache() = Cache.default match {
+    case fc: FileCache[Task] => fc
+    case other =>
+      sys.error(s"Expected default cache to be a FileCache, got $other")
+  }
+
   val tests = Tests {
 
     test("parse") {
@@ -93,7 +100,7 @@ object ChecksumTests extends TestSuite {
       val cache = HandmadeMetadata.repoBase
 
       def validate(artifact: Artifact, sumType: String): Task[Either[ArtifactError, Unit]] =
-        FileCache()
+        defaultCache()
           .noCredentials
           .withLocation(cache)
           .withPool(Sync.fixedThreadPool(4))


### PR DESCRIPTION
This adds an experimental server, that can be used to share a single coursier cache with containers.

In more detail, one can spin up a coursier server with
```text
cs server --host localhost --port 4928 --user "value:my-user" --password "value:my-password"
```

In other terminals, on macOS, one can do things like
```text
docker run -it --rm \
  -e COURSIER_CACHE_SERVER="http://host.docker.internal:4928" \
  -e COURSIER_CACHE_SERVER_USER="my-user" \
  -e COURSIER_CACHE_SERVER_PASSWORD="my-password" \
  -v "$HOME/Library/Caches/Coursier/v1:/root/.cache/coursier/v1:ro" \
  -v "$HOME/.ivy2/local:/root/.ivy2/local:ro" \
  -v "$(pwd):/data" \
  -w /data \
  ubuntu:latest
```

This command gives you a shell in a container, that can be used to build projects or run coursier commands.

Your machine and the container share a coursier cache, but the container only sees it as read-only.

Because `COURSIER_CACHE_SERVER` is set, coursier will not try to use this cache directly, but will instead ask the server to fetch things for it. The server handles downloading, and returns relative paths in the shared cache. With this relative path, the freshly downloaded file can now be accessed in the read-only shared cache.

This allows to spin many containers all sharing the same coursier cache to do safe Scala development with agents for example.