### PR TITLE
Retry connect exceptions, part deux

### DIFF
--- a/modules/cache/jvm/src/main/scala/coursier/cache/internal/Downloader.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/internal/Downloader.scala
@@ -858,12 +858,7 @@ object Downloader {
           )
           Some(Left(ex))
       }
-    } {
-      case _: AccessDeniedException if Properties.isWin =>
-      case _: javax.net.ssl.SSLException                =>
-      case _: java.net.SocketException                  =>
-      // TODO Allow to log that exception.
-    }
+    } (PartialFunction.empty)
 
   private object UnknownProtocol {
     def unapply(t: Throwable): Option[(MalformedURLException, String)] = t match {

--- a/modules/cache/jvm/src/main/scala/coursier/cache/internal/Downloader.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/internal/Downloader.scala
@@ -847,6 +847,10 @@ object Downloader {
 
           Some(Left(ex))
 
+        case e: AccessDeniedException if Properties.isWin => throw e
+        case e: javax.net.ssl.SSLException                => throw e
+        case e: java.net.SocketException                  => throw e
+
         case NonFatal(e) =>
           val ex = new ArtifactError.DownloadError(
             s"Caught ${e.getClass().getName()}${Option(e.getMessage).fold("")(" (" + _ + ")")} while downloading $url",

--- a/modules/cache/jvm/src/main/scala/coursier/cache/internal/Downloader.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/internal/Downloader.scala
@@ -828,6 +828,10 @@ object Downloader {
         }
       }
       catch {
+        case _: AccessDeniedException if Properties.isWin => None
+        case _: javax.net.ssl.SSLException                => None
+        case _: java.net.SocketException                  => None
+
         case NonFatal(e) if throwExceptions =>
           val ex = new ArtifactError.DownloadError(
             s"Caught ${e.getClass().getName()}${Option(e.getMessage).fold("")(" (" + _ + ")")} while downloading $url",
@@ -847,10 +851,6 @@ object Downloader {
 
           Some(Left(ex))
 
-        case e: AccessDeniedException if Properties.isWin => throw e
-        case e: javax.net.ssl.SSLException                => throw e
-        case e: java.net.SocketException                  => throw e
-
         case NonFatal(e) =>
           val ex = new ArtifactError.DownloadError(
             s"Caught ${e.getClass().getName()}${Option(e.getMessage).fold("")(" (" + _ + ")")} while downloading $url",
@@ -862,7 +862,6 @@ object Downloader {
       case _: AccessDeniedException if Properties.isWin =>
       case _: javax.net.ssl.SSLException                =>
       case _: java.net.SocketException                  =>
-      case _: java.net.ConnectException                 =>
       // TODO Allow to log that exception.
     }
 


### PR DESCRIPTION
Vibe Coded - Attempts to fixes `download error: Caught java.net.ConnectException (Operation timed out) errors when downloading from Maven Central`, e.g. https://github.com/com-lihaoyi/mill/actions/runs/23975310829/job/69931352633?pr=6985

> What Retry provides: Two retry mechanisms — returning `None` from `f` (retry), or letting an exception escape `f` to be caught by `catchEx` (retry). Both result in sleeping + retrying.                                                                
                                                                                                                          
> The problem: `downloading()` has a comprehensive inner catch block that catches everything — retryable exceptions return `None`, non-retryable ones return `Some(Left(error))` or `throw`. No exception ever escapes `f`, so the `catchEx` partial function was dead code listing the same exceptions already handled inside.                                                      
                                                                  
> Changes made:
> 1. Retryable exceptions (lines 831-833) return `None` directly — works regardless of `throwExceptions` since `retryOpt` always retries on `None`
> 2. Moved retryable cases above `NonFatal(e)` if `throwExceptions` so they take priority in both modes
> 3. Replaced the dead `catchEx` block with `PartialFunction.empty` — makes it explicit that downloading handles everything    internally                                                                                                              
> 4. Removed redundant `ConnectException` case (`ConnectException` extends `SocketException`)                                   
                                                                                                                          
> The other callers (`FileCache.readAllBytes`, `CacheLocks`, etc.) use `retry.retry` with simple function bodies and legitimately need `catchEx` — those are fine as-is.                     