### PR TITLE
Add .gitattributes to recognize .mill files as Scala

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.mill linguist-language=Scala


### PR DESCRIPTION
For GitHub syntax highlight 

https://github.com/com-lihaoyi/mill/blob/b79ae7dd4bd3576ef95223f218e9a9127cc332cc/.gitattributes

<img width="457" height="560" alt="image" src="https://github.com/user-attachments/assets/1cd9174d-19b0-4807-8a58-dd7e8d5ebae0" />
