### PR TITLE
Integrate benchmarks into build and address bitrot

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -5,6 +5,7 @@ import coursierbuild.Launchers.{Launchers, platformBootstrapExtension}
 import coursierbuild.Relativize.{relativize => doRelativize}
 import coursierbuild.{DocHelpers, GitHubReleaseAssets, Shading, Sync, Workers}
 import coursierbuild.modules._
+import mill.contrib.jmh.JmhModule
 
 import _root_.coursier.getcs.GetCs
 
@@ -62,7 +63,18 @@ object cache extends Module {
   object jvm    extends Cross[CacheJvm](ScalaVersions.all)
   object js     extends Cross[CacheJs](ScalaVersions.all)
 }
-object `archive-cache`      extends Cross[ArchiveCache](ScalaVersions.all)
+object `archive-cache` extends Cross[ArchiveCache](ScalaVersions.all)
+object `benchmark` extends ScalaModule with JmhModule {
+  def scalaVersion: mill.api.Task.Simple[String] = ScalaVersions.scala213
+  def moduleDeps = Seq(
+    coursier.jvm(ScalaVersions.scala213)
+  )
+  def mvnDeps = super.mvnDeps() ++ Seq(
+    mvn"org.apache.maven:maven-model:3.9.11"
+  )
+  def jmhCoreVersion = "1.35"
+}
+
 object launcher             extends Cross[Launcher](ScalaVersions.all)
 object env                  extends Cross[Env](ScalaVersions.all)
 object `launcher-native_04` extends LauncherNative04

--- a/mill-build/build.mill
+++ b/mill-build/build.mill
@@ -10,6 +10,7 @@ object `package` extends MillBuildRootModule {
     mvn"io.get-coursier:coursier-launcher_2.13:2.1.25-M13",
     mvn"io.github.alexarchambault.mill::mill-native-image::0.2.2",
     mvn"org.jsoup:jsoup:1.21.2",
-    mvn"com.eed3si9n.jarjarabrams:jarjar-abrams-core_2.13:1.14.1"
+    mvn"com.eed3si9n.jarjarabrams:jarjar-abrams-core_2.13:1.14.1",
+    mvn"com.lihaoyi::mill-contrib-jmh:1.1.3"
   )
 }

--- a/modules/benchmark/src/main/scala/coursier/benchmark/ProcessingTests.scala
+++ b/modules/benchmark/src/main/scala/coursier/benchmark/ProcessingTests.scala
@@ -14,7 +14,7 @@ class ProcessingTests {
 
     var res = state.initialSparkSqlRes
     for ((m, v, p) <- state.forProjectCache)
-      res = res.addToProjectCache0((m, v) -> (Repositories.central, p))
+      res = res.addToProjectCache((m, v) -> (Repositories.central, p))
 
   }
 

--- a/modules/benchmark/src/main/scala/coursier/benchmark/TestState.scala
+++ b/modules/benchmark/src/main/scala/coursier/benchmark/TestState.scala
@@ -2,6 +2,7 @@ package coursier.benchmark
 
 import coursier.cache.Cache
 import coursier.core.{Configuration, ResolutionProcess}
+import coursier.version.Version
 import coursier.{Repositories, Resolve}
 import coursier.internal.InMemoryCachingFetcher
 import coursier.maven.{MavenRepository, Pom}
@@ -27,13 +28,10 @@ class TestState {
     Repositories.central
   )
 
-  val repositoriesDom = {
-    val l = Seq(
-      MavenRepository("https://repo1.maven.org/maven2")
-    )
-    for (r <- l)
-      r.useSaxParser = false
-    l
+  val repositoriesDom = Seq {
+    val r = MavenRepository("https://repo1.maven.org/maven2")
+    r.internal.useSaxParser = false
+    r
   }
 
   val pool = Sync.fixedThreadPool(6)
@@ -71,9 +69,9 @@ class TestState {
         val name = m.name.value
         val url  = s"https://repo1.maven.org/maven2/${org.replace('.', '/')}/$name/$v/$name-$v.pom"
         val str  = inMemoryCache.fromCache(url)
-        val p    = MavenRepository.parseRawPomDom(str).toOption.get
+        val p    = MavenRepository.parseRawPomSax(str).toOption.get
         val p0 = Pom.addOptionalDependenciesInConfig(
-          p.withActualVersionOpt0(Some(v))
+          p.withActualVersionOpt0(Some(Version(v)))
             .withConfigurations(MavenRepository.defaultConfigurations),
           Set(Configuration.empty, Configuration.default),
           Configuration.optional

--- a/modules/core/shared/src/main/scala/coursier/maven/MavenRepository.scala
+++ b/modules/core/shared/src/main/scala/coursier/maven/MavenRepository.scala
@@ -13,6 +13,9 @@ object MavenRepository {
     coursier.core.compatibility.xmlParseSax(str, new PomParser)
       .project
 
+  private[coursier] def parseRawPomDom(str: String): Either[String, Project] =
+    Pom.project(coursier.core.compatibility.xmlParseDom(str).toOption.get)
+
   private def actualRoot(root: String): String =
     root.stripSuffix("/")
 
@@ -39,7 +42,7 @@ object MavenRepository {
   override val checkModule: Boolean = false
 ) extends MavenRepositoryLike.WithModuleSupport with Repository.VersionApi {
 
-  private val internal = new MavenRepositoryInternal(
+  private[coursier] val internal = new MavenRepositoryInternal(
     root,
     authentication,
     changing,


### PR DESCRIPTION
I'm not very familiar with Mill, nor with the history of the SAX/DOM parser options in Coursier, but this compiles and allows some benchmarks to run again.

```
./mill benchmark.runJmh coursier.benchmark.ResolutionTests.sparkSql -prof jfr:configName=$PWD/out/Profiling.jfc -wi 5 -i 5 -f1

```

Preview of what I'm using this for: 

https://github.com/retronym/coursier/pull/1#issuecomment-4275024457
https://0f693c45.branch-bench-epoch-27.pages.dev/report
