### PR TITLE
OutOfMemoryException hunt

### DIFF
--- a/.github/scripts/gen-diag-index.py
+++ b/.github/scripts/gen-diag-index.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Generate index.html for the JVM diagnostics artifact."""
+import os
+import glob
+import pathlib
+
+PATTERNS = [
+    "hotspot-pid-*.jfr",
+    "gc_pid*.log",
+    "out/mill-heap.hprof",
+    "out/hs_err_pid*.log",
+    "out/**/*.hprof",
+    "out/**/*.jfr",
+    "out/**/*.log",
+]
+
+files: list[str] = []
+seen: set[str] = set()
+for pattern in PATTERNS:
+    for f in sorted(glob.glob(pattern, recursive=True)):
+        if os.path.isfile(f) and f not in seen:
+            files.append(f)
+            seen.add(f)
+
+if not files:
+    print("No diagnostic files found, skipping index generation")
+    raise SystemExit(0)
+
+
+def insert(tree: dict, parts: tuple, full_path: str) -> None:
+    if len(parts) == 1:
+        tree.setdefault("__files__", []).append((parts[0], full_path))
+    else:
+        insert(tree.setdefault(parts[0], {}), parts[1:], full_path)
+
+
+tree: dict = {}
+for f in files:
+    insert(tree, pathlib.PurePosixPath(f).parts, f)
+
+
+def fmt_size(path: str) -> str:
+    n = os.path.getsize(path)
+    if n >= 1024 * 1024:
+        return f"{n / 1024 / 1024:.1f} MB"
+    return f"{n / 1024:.1f} KB"
+
+
+def render(node: dict) -> list[str]:
+    out: list[str] = []
+    for name, path in sorted(node.get("__files__", [])):
+        out.append(
+            f'<li class="f"><a href="{path}">{name}</a>'
+            f' <small>({fmt_size(path)})</small></li>'
+        )
+    for key in sorted(k for k in node if k != "__files__"):
+        out.append(f'<li class="d"><details open><summary>{key}/</summary><ul>')
+        out.extend(render(node[key]))
+        out.append("</ul></details></li>")
+    return out
+
+
+CSS = """
+  body { font-family: monospace; margin: 2em; color: #222; }
+  h1 { font-size: 1.2em; }
+  p  { color: #666; font-size: .9em; margin: .4em 0 1em; }
+  ul { list-style: none; padding-left: 1.4em; margin: .15em 0; }
+  ul:first-of-type { padding-left: 0; }
+  .d > details > summary { cursor: pointer; font-weight: bold; color: #444; }
+  .d > details > summary:hover { color: #000; }
+  .f { margin: .1em 0; }
+  .f a { color: #1558d6; text-decoration: none; }
+  .f a:hover { text-decoration: underline; }
+  small { color: #888; }
+"""
+
+rows = "\n".join(render(tree))
+html = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>JVM Diagnostics</title>
+  <style>{CSS}</style>
+</head>
+<body>
+  <h1>JVM Diagnostics</h1>
+  <p>{len(files)} file(s)</p>
+  <ul>
+{rows}
+  </ul>
+</body>
+</html>
+"""
+
+with open("index.html", "w") as fh:
+    fh.write(html)
+
+print(f"Generated index.html listing {len(files)} diagnostic file(s)")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,17 +46,6 @@ jobs:
       matrix:
         OS: ["ubuntu-latest"]
         SCALA_VERSION: ["2.13.16"]
-        include:
-          - OS: "ubuntu-24.04-arm"
-            SCALA_VERSION: "2.13.16"
-          - OS: "macos-15-intel"
-            SCALA_VERSION: "2.13.16"
-          - OS: "macos-14"
-            SCALA_VERSION: "2.13.16"
-          - OS: "windows-latest"
-            SCALA_VERSION: "2.13.16"
-          - OS: "ubuntu-latest"
-            SCALA_VERSION: "2.12.20"
     steps:
     - name: Don't convert LF to CRLF during checkout
       if: runner.os == 'Windows'
@@ -83,16 +72,23 @@ jobs:
       env:
         SCALA_VERSION: ${{ matrix.SCALA_VERSION }}
         COURSIER_JNI: force
+    - name: Generate diagnostics index
+      if: always()
+      run: python3 .github/scripts/gen-diag-index.py
     - name: Upload JVM diagnostics (heap dumps + JFR recordings)
       if: always()
       uses: actions/upload-artifact@v5
       with:
         name: jvm-diagnostics-test-${{ matrix.OS }}-scala${{ matrix.SCALA_VERSION }}
         path: |
+          index.html
           hotspot-pid-*.jfr
+          gc_pid*.log
           out/mill-heap.hprof
+          out/hs_err_pid*.log
           out/**/*.hprof
           out/**/*.jfr
+          out/**/*.log
         if-no-files-found: ignore
 
   js-test:
@@ -127,79 +123,27 @@ jobs:
       shell: bash
       env:
         SCALA_VERSION: ${{ matrix.SCALA_VERSION }}
+    - name: Generate diagnostics index
+      if: always()
+      run: python3 .github/scripts/gen-diag-index.py
     - name: Upload JVM diagnostics (heap dumps + JFR recordings)
       if: always()
       uses: actions/upload-artifact@v5
       with:
         name: jvm-diagnostics-js-test-scala${{ matrix.SCALA_VERSION }}
         path: |
+          index.html
           hotspot-pid-*.jfr
+          gc_pid*.log
           out/mill-heap.hprof
+          out/hs_err_pid*.log
           out/**/*.hprof
           out/**/*.jfr
+          out/**/*.log
         if-no-files-found: ignore
 
-  bin-compat:
-    runs-on: ubuntu-latest
-    name: Binary compatibility
-    steps:
-    - uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-        submodules: true
-    - uses: coursier/cache-action@v8.0
-    - uses: coursier/setup-action@v2.0
-      with:
-        jvm: 21
-    - run: ./mill --no-daemon -k __.mimaReportBinaryIssues
-
-  website-check:
-    runs-on: ubuntu-latest
-    name: Website check
-    steps:
-    - name: Don't convert LF to CRLF during checkout
-      if: runner.os == 'Windows'
-      run: |
-        git config --global core.autocrlf false
-        git config --global core.eol lf
-    - uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-        submodules: true
-    - uses: actions/setup-node@v6
-      with:
-        node-version: '18'
-    - uses: coursier/cache-action@v8.0
-    - uses: coursier/setup-action@v2.0
-      with:
-        jvm: 21
-    - run: ./mill --no-daemon docs.mdoc
-      env:
-        COURSIER_JNI: force
-    - run: .github/scripts/setup-mkdocs.sh
-    - run: ./mill --no-daemon docs.mkdocsBuild
-      env:
-        COURSIER_JNI: force
-    - run: ./mill --no-daemon doc.generate --npm-install --yarn-run-build
-      env:
-        COURSIER_JNI: force
-
-  format:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-        submodules: true
-    - uses: coursier/cache-action@v8.0
-    - uses: coursier/setup-action@v2.0
-      with:
-        jvm: 21
-        apps: scalafmt:3.8.3
-    - run: scalafmt --check
-
   publish:
-    needs: ["compile-publish-all", "test", "js-test", "bin-compat", "website-check", "format"]
+    needs: ["compile-publish-all", "test", "js-test"]
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
@@ -220,424 +164,9 @@ jobs:
           MILL_SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           MILL_SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
 
-  generate-native-launchers:
-    name: ${{ matrix.OS }} native
-    runs-on: ${{ matrix.OS }}
-    strategy:
-      fail-fast: false
-      matrix:
-        OS: ["ubuntu-latest"]
-        OSSHORT: ["linux"]
-        include:
-          - OS: "windows-latest"
-            OSSHORT: "windows"
-          - OS: "macos-15-intel"
-            OSSHORT: "mac"
-          - OS: "macos-14"
-            OSSHORT: "mac-arm"
-          - OS: "ubuntu-24.04-arm"
-            OSSHORT: "linux-arm"
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          submodules: true
-      - uses: coursier/cache-action@v8.0
-      - uses: coursier/setup-action@v2.0
-        with:
-          jvm: 21
-      - run: sudo apt-get install -y nailgun
-        if: runner.os == 'Linux'
-      - run: .github/scripts/maybe-with-graalvm-home.sh nativeTests
-        shell: bash
-        timeout-minutes: 20
-      - name: Copy artifacts
-        run: .github/scripts/maybe-with-graalvm-home.sh copyLauncher --directory artifacts/
-        shell: bash
-      - name: Build OS packages
-        run: .github/scripts/generate-os-packages.sh
-        shell: bash
-      - uses: actions/attest-build-provenance@v4
-        if: startsWith(github.ref, 'refs/tags/v')
-        with:
-          subject-path: 'artifacts/*'
-      - uses: actions/upload-artifact@v5
-        with:
-          name: launchers-${{ matrix.OSSHORT }}
-          path: artifacts/
-          if-no-files-found: error
-          retention-days: 2
+  # bin-compat, website-check, format, generate-native-launchers, generate-compat-native-launchers,
+  # generate-native-static-launcher, generate-native-mostly-static-launcher,
+  # generate-native-container-launcher, generate-jar-launchers, upload-launchers,
+  # upload-launchers-special-repo, update-brew-formula, update-website-latest, update-website
+  # removed for local testing — restore before merging.
 
-  generate-compat-native-launchers:
-    name: linux compat native
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          submodules: true
-      - uses: coursier/cache-action@v8.0
-      - uses: coursier/setup-action@v2.0
-        with:
-          jvm: 21
-      - run: sudo apt-get install -y nailgun
-      - run: .github/scripts/maybe-with-graalvm-home.sh nativeCompatTests
-        shell: bash
-      - name: Copy artifacts
-        run: .github/scripts/maybe-with-graalvm-home.sh copyCompatLauncher --directory artifacts/
-        shell: bash
-      - uses: actions/attest-build-provenance@v4
-        if: startsWith(github.ref, 'refs/tags/v')
-        with:
-          subject-path: 'artifacts/*'
-      - uses: actions/upload-artifact@v5
-        with:
-          name: launchers-linux-compat
-          path: artifacts/
-          if-no-files-found: error
-          retention-days: 2
-
-  generate-native-static-launcher:
-    name: ${{ matrix.OS }} static native
-    runs-on: ${{ matrix.OS }}
-    strategy:
-      fail-fast: false
-      matrix:
-        OS: ["ubuntu-latest"]
-        OSSHORT: ["linux"]
-        include:
-          - OS: "ubuntu-24.04-arm"
-            OSSHORT: "linux-arm"
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          submodules: true
-      - uses: coursier/cache-action@v8.0
-      - uses: coursier/setup-action@v2.0
-        with:
-          jvm: 21
-      - run: sudo apt-get install -y nailgun
-        if: runner.os == 'Linux'
-      - run: .github/scripts/maybe-with-graalvm-home.sh nativeStaticTests
-        shell: bash
-      - name: Copy artifacts
-        run: .github/scripts/maybe-with-graalvm-home.sh copyStaticLauncher --directory artifacts/
-        shell: bash
-      - uses: actions/attest-build-provenance@v4
-        if: startsWith(github.ref, 'refs/tags/v')
-        with:
-          subject-path: 'artifacts/*'
-      - uses: actions/upload-artifact@v5
-        with:
-          name: launchers-${{ matrix.OSSHORT }}-static
-          path: artifacts/
-          if-no-files-found: error
-          retention-days: 2
-
-  generate-native-mostly-static-launcher:
-    name: ${{ matrix.OS }} mostly static native
-    runs-on: ${{ matrix.OS }}
-    strategy:
-      fail-fast: false
-      matrix:
-        OS: ["ubuntu-latest"]
-        OSSHORT: ["linux"]
-        include:
-          - OS: "ubuntu-24.04-arm"
-            OSSHORT: "linux-arm"
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          submodules: true
-      - uses: coursier/cache-action@v8.0
-      - uses: coursier/setup-action@v2.0
-        with:
-          jvm: 21
-      - run: sudo apt-get install -y nailgun
-        if: runner.os == 'Linux'
-      - run: .github/scripts/maybe-with-graalvm-home.sh nativeMostlyStaticTests
-        shell: bash
-      - name: Copy artifacts
-        run: .github/scripts/maybe-with-graalvm-home.sh copyMostlyStaticLauncher --directory artifacts/
-        shell: bash
-      - uses: actions/attest-build-provenance@v4
-        if: startsWith(github.ref, 'refs/tags/v')
-        with:
-          subject-path: 'artifacts/*'
-      - uses: actions/upload-artifact@v5
-        with:
-          name: launchers-${{ matrix.OSSHORT }}-mostly-static
-          path: artifacts/
-          if-no-files-found: error
-          retention-days: 2
-
-  generate-native-container-launcher:
-    name: ${{ matrix.OS }} container native
-    runs-on: ${{ matrix.OS }}
-    strategy:
-      fail-fast: false
-      matrix:
-        OS: ["ubuntu-latest"]
-        OSSHORT: ["linux"]
-        include:
-          - OS: "ubuntu-24.04-arm"
-            OSSHORT: "linux-arm"
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          submodules: true
-      - uses: coursier/cache-action@v8.0
-      - uses: coursier/setup-action@v2.0
-        with:
-          jvm: 21
-      - run: sudo apt-get install -y nailgun
-        if: runner.os == 'Linux'
-      - run: .github/scripts/maybe-with-graalvm-home.sh nativeContainerTests
-        shell: bash
-      - name: Copy artifacts
-        run: .github/scripts/maybe-with-graalvm-home.sh copyContainerLauncher --directory artifacts/
-        shell: bash
-      - uses: actions/attest-build-provenance@v4
-        if: startsWith(github.ref, 'refs/tags/v')
-        with:
-          subject-path: 'artifacts/*'
-      - uses: actions/upload-artifact@v5
-        with:
-          name: launchers-${{ matrix.OSSHORT }}-container
-          path: artifacts/
-          if-no-files-found: error
-          retention-days: 2
-
-  generate-jar-launchers:
-    name: Upload JAR launchers
-    needs: publish
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-    steps:
-    - uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-        submodules: true
-    - uses: coursier/cache-action@v8.0
-    - uses: coursier/setup-action@v2.0
-      with:
-        jvm: 21
-    - name: Wait for sync to Central
-      run: ./mill --no-daemon waitForSync
-    - name: Copy artifacts
-      run: ./mill --no-daemon copyJarLaunchers
-    - uses: actions/attest-build-provenance@v4
-      if: startsWith(github.ref, 'refs/tags/v')
-      with:
-        subject-path: 'artifacts/*'
-    - uses: actions/upload-artifact@v5
-      with:
-        name: launchers-jar
-        path: artifacts/
-        if-no-files-found: error
-        retention-days: 2
-
-  upload-launchers:
-    name: Upload launchers to GitHub release assets
-    needs: [generate-native-launchers, generate-compat-native-launchers, generate-native-static-launcher, generate-native-mostly-static-launcher, generate-native-container-launcher, generate-jar-launchers]
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-        submodules: true
-    - uses: coursier/cache-action@v8.0
-    - uses: coursier/setup-action@v2.0
-      with:
-        jvm: 21
-    - uses: actions/download-artifact@v6
-      with:
-        name: launchers-linux
-        path: artifacts/
-    - uses: actions/download-artifact@v6
-      with:
-        name: launchers-linux-compat
-        path: artifacts/
-    - uses: actions/download-artifact@v6
-      with:
-        name: launchers-linux-arm
-        path: artifacts/
-    - uses: actions/download-artifact@v6
-      with:
-        name: launchers-windows
-        path: artifacts/
-    - uses: actions/download-artifact@v6
-      with:
-        name: launchers-mac
-        path: artifacts/
-    - uses: actions/download-artifact@v6
-      with:
-        name: launchers-mac-arm
-        path: artifacts/
-    - uses: actions/download-artifact@v6
-      with:
-        name: launchers-linux-static
-        path: artifacts/
-    - uses: actions/download-artifact@v6
-      with:
-        name: launchers-linux-arm-static
-        path: artifacts/
-    - uses: actions/download-artifact@v6
-      with:
-        name: launchers-linux-mostly-static
-        path: artifacts/
-    - uses: actions/download-artifact@v6
-      with:
-        name: launchers-linux-arm-mostly-static
-        path: artifacts/
-    - uses: actions/download-artifact@v6
-      with:
-        name: launchers-linux-container
-        path: artifacts/
-    - uses: actions/download-artifact@v6
-      with:
-        name: launchers-linux-arm-container
-        path: artifacts/
-    - uses: actions/download-artifact@v6
-      with:
-        name: launchers-jar
-        path: artifacts/
-    - run: ./mill --no-daemon uploadLaunchers --directory artifacts/
-      env:
-        UPLOAD_GH_TOKEN: ${{ secrets.GH_TOKEN }}
-
-  upload-launchers-special-repo:
-    name: Upload launchers to dedicated repository
-    needs: [generate-native-launchers, generate-compat-native-launchers, generate-native-static-launcher, generate-native-mostly-static-launcher, generate-native-container-launcher, generate-jar-launchers]
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-        submodules: true
-    - uses: coursier/cache-action@v8.0
-    - uses: coursier/setup-action@v2.0
-      with:
-        jvm: 21
-    - uses: actions/download-artifact@v6
-      with:
-        name: launchers-linux
-        path: artifacts/
-    - uses: actions/download-artifact@v6
-      with:
-        name: launchers-linux-compat
-        path: artifacts/
-    - uses: actions/download-artifact@v6
-      with:
-        name: launchers-linux-arm
-        path: artifacts/
-    - uses: actions/download-artifact@v6
-      with:
-        name: launchers-windows
-        path: artifacts/
-    - uses: actions/download-artifact@v6
-      with:
-        name: launchers-mac
-        path: artifacts/
-    - uses: actions/download-artifact@v6
-      with:
-        name: launchers-mac-arm
-        path: artifacts/
-    - uses: actions/download-artifact@v6
-      with:
-        name: launchers-linux-static
-        path: artifacts/
-    - uses: actions/download-artifact@v6
-      with:
-        name: launchers-linux-arm-static
-        path: artifacts/
-    - uses: actions/download-artifact@v6
-      with:
-        name: launchers-linux-mostly-static
-        path: artifacts/
-    - uses: actions/download-artifact@v6
-      with:
-        name: launchers-linux-arm-mostly-static
-        path: artifacts/
-    - uses: actions/download-artifact@v6
-      with:
-        name: launchers-linux-container
-        path: artifacts/
-    - uses: actions/download-artifact@v6
-      with:
-        name: launchers-linux-arm-container
-        path: artifacts/
-    - uses: actions/download-artifact@v6
-      with:
-        name: launchers-jar
-        path: artifacts/
-    - run: ./mill --no-daemon uploadLaunchersSpecialRepo --directory artifacts/
-      env:
-        UPLOAD_GH_TOKEN: ${{ secrets.GH_TOKEN }}
-
-  update-brew-formula:
-    name: Update brew formula
-    needs: [upload-launchers]
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          submodules: true
-      - uses: coursier/cache-action@v8.0
-      - uses: coursier/setup-action@v2.0
-        with:
-          jvm: 21
-      - run: .github/scripts/scala-cli.sh .github/scripts/UpdateBrewFormula.scala
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-
-  update-website-latest:
-    name: Update website (snapshot)
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          submodules: true
-      - uses: actions/setup-node@v6
-        with:
-          node-version: '18'
-      - uses: coursier/cache-action@v8.0
-      - uses: coursier/setup-action@v2.0
-        with:
-          jvm: 21
-      - run: .github/scripts/setup-mkdocs.sh
-      - run: npm install --ignore-scripts && ./mill --no-daemon updateWebsite
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-
-  update-website:
-    name: Update website
-    needs: [update-brew-formula, upload-launchers-special-repo]
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          submodules: true
-      - uses: actions/setup-node@v6
-        with:
-          node-version: '18'
-      - uses: coursier/cache-action@v8.0
-      - uses: coursier/setup-action@v2.0
-        with:
-          jvm: 21
-      - run: .github/scripts/setup-mkdocs.sh
-      - run: npm install --ignore-scripts && ./mill --no-daemon updateWebsite
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,11 @@ jobs:
       with:
         jvm: 21
     - run: |
-        ./mill -i -j1 __.js[_].compile
-        ./mill -i __.compile
+        ./mill --no-daemon -j1 __.js[_].compile
+        ./mill --no-daemon __.compile
     - name: No test modules with no test classes
-      run: ./mill -i ci.noEmptyDiscoveredTestClasses --tasks __.discoveredTestClasses
-    - run: ./mill -i __.publishLocal
+      run: ./mill --no-daemon ci.noEmptyDiscoveredTestClasses --tasks __.discoveredTestClasses
+    - run: ./mill --no-daemon __.publishLocal
 
   test:
     runs-on: ${{ matrix.OS }}
@@ -75,14 +75,25 @@ jobs:
       if: runner.os == 'Linux'
     # - run: .github/scripts/scala-native-setup.sh
     #   if: runner.os != 'Windows'
-    - run: ./mill -i dockerTests
+    - run: ./mill --no-daemon dockerTests
       env:
         SCALA_VERSION: ${{ matrix.SCALA_VERSION }}
         COURSIER_JNI: force
-    - run: ./mill -i jvmTests
+    - run: ./mill --no-daemon jvmTests
       env:
         SCALA_VERSION: ${{ matrix.SCALA_VERSION }}
         COURSIER_JNI: force
+    - name: Upload JVM diagnostics (heap dumps + JFR recordings)
+      if: always()
+      uses: actions/upload-artifact@v5
+      with:
+        name: jvm-diagnostics-test-${{ matrix.OS }}-scala${{ matrix.SCALA_VERSION }}
+        path: |
+          hotspot-pid-*.jfr
+          out/mill-heap.hprof
+          out/**/*.hprof
+          out/**/*.jfr
+        if-no-files-found: ignore
 
   js-test:
     runs-on: ubuntu-latest
@@ -111,11 +122,22 @@ jobs:
         jvm: 21
     - run: |
         npm install --ignore-scripts
-        ./mill -i -j1 '__.js['"$SCALA_VERSION"'].compile'
-        ./mill -i jsTests --scalaVersion "$SCALA_VERSION"
+        ./mill --no-daemon -j1 '__.js['"$SCALA_VERSION"'].compile'
+        ./mill --no-daemon jsTests --scalaVersion "$SCALA_VERSION"
       shell: bash
       env:
         SCALA_VERSION: ${{ matrix.SCALA_VERSION }}
+    - name: Upload JVM diagnostics (heap dumps + JFR recordings)
+      if: always()
+      uses: actions/upload-artifact@v5
+      with:
+        name: jvm-diagnostics-js-test-scala${{ matrix.SCALA_VERSION }}
+        path: |
+          hotspot-pid-*.jfr
+          out/mill-heap.hprof
+          out/**/*.hprof
+          out/**/*.jfr
+        if-no-files-found: ignore
 
   bin-compat:
     runs-on: ubuntu-latest
@@ -129,7 +151,7 @@ jobs:
     - uses: coursier/setup-action@v2.0
       with:
         jvm: 21
-    - run: ./mill -i -k __.mimaReportBinaryIssues
+    - run: ./mill --no-daemon -k __.mimaReportBinaryIssues
 
   website-check:
     runs-on: ubuntu-latest
@@ -151,14 +173,14 @@ jobs:
     - uses: coursier/setup-action@v2.0
       with:
         jvm: 21
-    - run: ./mill -i docs.mdoc
+    - run: ./mill --no-daemon docs.mdoc
       env:
         COURSIER_JNI: force
     - run: .github/scripts/setup-mkdocs.sh
-    - run: ./mill -i docs.mkdocsBuild
+    - run: ./mill --no-daemon docs.mkdocsBuild
       env:
         COURSIER_JNI: force
-    - run: ./mill -i doc.generate --npm-install --yarn-run-build
+    - run: ./mill --no-daemon doc.generate --npm-install --yarn-run-build
       env:
         COURSIER_JNI: force
 
@@ -191,7 +213,7 @@ jobs:
           jvm: 21
       - name: Publish
         run: |
-          ./mill -i mill.scalalib.SonatypeCentralPublishModule/
+          ./mill --no-daemon mill.scalalib.SonatypeCentralPublishModule/
         env:
           MILL_PGP_SECRET_BASE64: ${{ secrets.PUBLISH_SECRET_KEY }}
           MILL_PGP_PASSPHRASE: ${{ secrets.PUBLISH_SECRET_KEY_PASSWORD }}
@@ -405,9 +427,9 @@ jobs:
       with:
         jvm: 21
     - name: Wait for sync to Central
-      run: ./mill -i waitForSync
+      run: ./mill --no-daemon waitForSync
     - name: Copy artifacts
-      run: ./mill -i copyJarLaunchers
+      run: ./mill --no-daemon copyJarLaunchers
     - uses: actions/attest-build-provenance@v4
       if: startsWith(github.ref, 'refs/tags/v')
       with:
@@ -485,7 +507,7 @@ jobs:
       with:
         name: launchers-jar
         path: artifacts/
-    - run: ./mill -i uploadLaunchers --directory artifacts/
+    - run: ./mill --no-daemon uploadLaunchers --directory artifacts/
       env:
         UPLOAD_GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
@@ -555,7 +577,7 @@ jobs:
       with:
         name: launchers-jar
         path: artifacts/
-    - run: ./mill -i uploadLaunchersSpecialRepo --directory artifacts/
+    - run: ./mill --no-daemon uploadLaunchersSpecialRepo --directory artifacts/
       env:
         UPLOAD_GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
@@ -594,7 +616,7 @@ jobs:
         with:
           jvm: 21
       - run: .github/scripts/setup-mkdocs.sh
-      - run: npm install --ignore-scripts && ./mill -i updateWebsite
+      - run: npm install --ignore-scripts && ./mill --no-daemon updateWebsite
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
@@ -616,6 +638,6 @@ jobs:
         with:
           jvm: 21
       - run: .github/scripts/setup-mkdocs.sh
-      - run: npm install --ignore-scripts && ./mill -i updateWebsite
+      - run: npm install --ignore-scripts && ./mill --no-daemon updateWebsite
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.mill-jvm-opts
+++ b/.mill-jvm-opts
@@ -1,0 +1,8 @@
+# Print JVM ergonomics flags (heap size, GC choice, etc.) at startup
+-XX:+PrintCommandLineFlags
+# Write a heap dump alongside the mill output directory when the JVM runs out of heap
+-XX:+HeapDumpOnOutOfMemoryError
+-XX:HeapDumpPath=out/mill-heap.hprof
+# Continuous JFR recording: flush to disk as chunks (disk=true), dump the final
+# chunk on normal exit or OOME so the recording survives a crashed JVM.
+# -XX:StartFlightRecording=name=continuous,disk=true,dumponexit=true,maxage=1h,maxsize=256m,settings=profile

--- a/.mill-jvm-opts
+++ b/.mill-jvm-opts
@@ -1,8 +1,10 @@
 # Print JVM ergonomics flags (heap size, GC choice, etc.) at startup
 -XX:+PrintCommandLineFlags
+-Xlog:gc*:file=gc_pid%p.log:time,uptime,level,tags:filecount=1,filesize=50m
 # Write a heap dump alongside the mill output directory when the JVM runs out of heap
 -XX:+HeapDumpOnOutOfMemoryError
 -XX:HeapDumpPath=out/mill-heap.hprof
+-XX:ErrorFile=out/hs_err_pid%p.log
 # Continuous JFR recording: flush to disk as chunks (disk=true), dump the final
 # chunk on normal exit or OOME so the recording survives a crashed JVM.
 # -XX:StartFlightRecording=name=continuous,disk=true,dumponexit=true,maxage=1h,maxsize=256m,settings=profile

--- a/mill-build/jfr-diag.jfc
+++ b/mill-build/jfr-diag.jfc
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration version="2.0" label="diag" description="profile with reduced rates for smaller files" provider="coursier-build">
+  <!-- CPU profiling: 100 ms instead of profile default 10 ms -->
+  <event name="jdk.ExecutionSample">
+    <setting name="enabled">true</setting>
+    <setting name="period">100 ms</setting>
+  </event>
+  <event name="jdk.NativeMethodSample">
+    <setting name="enabled">true</setting>
+    <setting name="period">100 ms</setting>
+  </event>
+  <!-- Allocation: throttled sampled event (JDK 16+) instead of per-TLAB events -->
+  <event name="jdk.ObjectAllocationSample">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="throttle">10/s</setting>
+  </event>
+  <event name="jdk.ObjectAllocationInNewTLAB">
+    <setting name="enabled">false</setting>
+  </event>
+  <event name="jdk.ObjectAllocationOutsideTLAB">
+    <setting name="enabled">false</setting>
+  </event>
+</configuration>

--- a/mill-build/src/coursierbuild/modules/CsTests.scala
+++ b/mill-build/src/coursierbuild/modules/CsTests.scala
@@ -13,30 +13,17 @@ trait CsTests extends TestModule with JavaModule {
   def defaultTask() = super[TestModule].defaultTask()
 
   def forkArgs = Task {
-    // Write a JFC overlay into this task's own dest so the file is guaranteed to exist
-    // whenever this task's cached result is used. A separate task's dest can be cleaned
-    // independently, causing the path in a cached forkArgs result to dangle.
-    val jfc = Task.dest / "allocation.jfc"
-    os.write(jfc,
-      """<?xml version="1.0" encoding="UTF-8"?>
-        |<configuration version="2.0" label="allocation" description="profile + TLAB allocation events" provider="coursier-build">
-        |  <event name="jdk.ObjectAllocationInNewTLAB">
-        |    <setting name="enabled">true</setting>
-        |    <setting name="stackTrace">true</setting>
-        |  </event>
-        |  <event name="jdk.ObjectAllocationOutsideTLAB">
-        |    <setting name="enabled">true</setting>
-        |    <setting name="stackTrace">true</setting>
-        |  </event>
-        |</configuration>
-        |""".stripMargin
-    )
+    val workspaceRoot = Iterator.iterate(Task.dest)(_ / os.up)
+      .find(p => os.exists(p / "build.mill"))
+      .getOrElse(sys.error("could not find workspace root (no build.mill found)"))
+    val jfc = workspaceRoot / "mill-build" / "jfr-diag.jfc"
     super.forkArgs() ++ Seq(
-      "-Xmx2G",
+      "-Xmx512M",
       "-Xlog:gc*:stdout:time,uptime,level,tags",
+      "-Xlog:gc*:file=gc_pid%p.log:time,uptime,level,tags:filecount=1,filesize=50m",
       "-XX:+PrintCommandLineFlags",
       "-XX:+HeapDumpOnOutOfMemoryError",
-      // settings= accepts a comma-separated list of JFC files layered left-to-right.
+      "-XX:ErrorFile=hs_err_pid%p.log",
       s"-XX:StartFlightRecording=name=continuous,disk=true,dumponexit=true,maxage=1h,maxsize=256m,settings=profile,$jfc"
     )
   }

--- a/mill-build/src/coursierbuild/modules/CsTests.scala
+++ b/mill-build/src/coursierbuild/modules/CsTests.scala
@@ -11,4 +11,33 @@ trait CsTests extends TestModule with JavaModule {
   def testFramework = "utest.runner.Framework"
 
   def defaultTask() = super[TestModule].defaultTask()
+
+  def forkArgs = Task {
+    // Write a JFC overlay into this task's own dest so the file is guaranteed to exist
+    // whenever this task's cached result is used. A separate task's dest can be cleaned
+    // independently, causing the path in a cached forkArgs result to dangle.
+    val jfc = Task.dest / "allocation.jfc"
+    os.write(jfc,
+      """<?xml version="1.0" encoding="UTF-8"?>
+        |<configuration version="2.0" label="allocation" description="profile + TLAB allocation events" provider="coursier-build">
+        |  <event name="jdk.ObjectAllocationInNewTLAB">
+        |    <setting name="enabled">true</setting>
+        |    <setting name="stackTrace">true</setting>
+        |  </event>
+        |  <event name="jdk.ObjectAllocationOutsideTLAB">
+        |    <setting name="enabled">true</setting>
+        |    <setting name="stackTrace">true</setting>
+        |  </event>
+        |</configuration>
+        |""".stripMargin
+    )
+    super.forkArgs() ++ Seq(
+      "-Xmx2G",
+      "-Xlog:gc*:stdout:time,uptime,level,tags",
+      "-XX:+PrintCommandLineFlags",
+      "-XX:+HeapDumpOnOutOfMemoryError",
+      // settings= accepts a comma-separated list of JFC files layered left-to-right.
+      s"-XX:StartFlightRecording=name=continuous,disk=true,dumponexit=true,maxage=1h,maxsize=256m,settings=profile,$jfc"
+    )
+  }
 }


### PR DESCRIPTION
Drop max heap for forked tests down to 2G and enable JFR and hprof capture


Actual recent OOME in CI: https://github.com/coursier/coursier/actions/runs/25218291464/job/73943871080?pr=3635#logs

I think the JVM default max heap for that run was likely 4GB (1/4 RAM size of the runner). AFAICT it wasn't explicity configured in the mill build
