### PR TITLE
Release memory sooner during iterations of resolution

### DIFF
--- a/modules/core/shared/src/main/scala/coursier/core/Resolution.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Resolution.scala
@@ -1761,7 +1761,8 @@ object Resolution {
       .toSet
   }
 
-  private lazy val nextNoMissingUnsafe: Resolution = {
+  // Lazy val here was a performance issue
+  private def nextNoMissingUnsafe: Resolution = {
     val (newConflicts, _, _) = nextDependenciesAndConflicts
 
     copyWithCache(


### PR DESCRIPTION
Heap dump analysis of builds that hit `OutOfMemoryErrors` pointed to long chains of Resolution instances that were linked by the lazy val `nextNoMissingUnsafe`.

There is only one caller of this private method, so changing to a def does not lead to extra computation, and allows the intermediate instances to be reclaimed by the GC.

References #3557