### PR TITLE
Performance micro-optimisations in resolution hot paths

### DIFF
--- a/modules/core/shared/src/main/scala/coursier/core/Definitions.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Definitions.scala
@@ -1017,9 +1017,12 @@ object ArtifactSource {
 
 private[coursier] object Validation {
   def validateCoordinate(value: String, name: String): Either[String, String] =
-    Seq('/', '\\').foldLeft[Either[String, String]](Right(value)) { (acc, char) =>
-      acc.filterOrElse(value => !value.contains(char), s"$name $value contains invalid '$char'")
-    }
+    if (value.contains('/'))
+      Left(s"$name $value contains invalid '/' character")
+    else if (value.contains('\\'))
+      Left(s"$name $value contains invalid '\\' character")
+    else
+      Right(value)
 
   def assertValid(value: String, name: String): Unit =
     validateCoordinate(value, name).fold(msg => throw new AssertionError(msg), identity)

--- a/modules/core/shared/src/main/scala/coursier/core/Dependency.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Dependency.scala
@@ -259,7 +259,10 @@ import java.util.concurrent.ConcurrentMap
   )
   def withExclusions(newExclusions: Set[(Organization, ModuleName)]): Dependency =
     withMinimizedExclusions(MinimizedExclusions(newExclusions))
-
+  private[core] def withVersionConstraintConserve(versionConstraint: VersionConstraint0)
+    : Dependency =
+    if (versionConstraint == this.versionConstraint) this
+    else withVersionConstraint(versionConstraint)
   @deprecated(
     "This method will be dropped in favor of minimizedExclusions() in a future version",
     "2.1.0-M6"

--- a/modules/core/shared/src/main/scala/coursier/core/MinimizedExclusions.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/MinimizedExclusions.scala
@@ -67,7 +67,8 @@ object MinimizedExclusions {
 
     override def size(): Int                              = Int.MaxValue
     override def subsetOf(other: ExclusionData): Boolean  = other == ExcludeAll
-    override def toSet(): Set[(Organization, ModuleName)] = Set((allOrganizations, allNames))
+    private val _toSet: Set[(Organization, ModuleName)]   = Set((allOrganizations, allNames))
+    override def toSet(): Set[(Organization, ModuleName)] = _toSet
 
     def hasProperties: Boolean = false
 
@@ -160,8 +161,15 @@ object MinimizedExclusions {
           }
       }
 
-    override def toSet(): Set[(Organization, ModuleName)] =
-      byOrg.map(_ -> allNames) ++ byModule.map(allOrganizations -> _) ++ specific
+    private lazy val _toSet = {
+      val b = Set.newBuilder[(Organization, ModuleName)]
+      byOrg.foreach(org => b.+=((org, allNames)))
+      byModule.foreach(name => b.+=((allOrganizations, name)))
+      b ++= specific
+      b.result()
+    }
+
+    override def toSet(): Set[(Organization, ModuleName)] = _toSet
 
     lazy val hasProperties: Boolean =
       byOrg.exists(_.value.contains("$")) ||

--- a/modules/core/shared/src/main/scala/coursier/core/Resolution.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Resolution.scala
@@ -287,7 +287,7 @@ object Resolution {
         substituteProps(s, properties, trim = false)
 
       val dep0 = dep
-        .withVersionConstraint(
+        .withVersionConstraintConserve(
           if (dep.versionConstraint.asString.contains("$"))
             VersionConstraint0(substituteTrimmedProps(dep.versionConstraint.asString))
           else
@@ -376,7 +376,7 @@ object Resolution {
 
                 (
                   versionOpt match {
-                    case Some(version) => Right(deps.map(_.withVersionConstraint(version)))
+                    case Some(version) => Right(deps.map(_.withVersionConstraintConserve(version)))
                     case None          => Left(deps)
                   },
                   versionOpt
@@ -384,7 +384,7 @@ object Resolution {
               }
 
             case Some(forcedVersion) =>
-              (Right(deps.map(_.withVersionConstraint(forcedVersion))), Some(forcedVersion))
+              (Right(deps.map(_.withVersionConstraintConserve(forcedVersion))), Some(forcedVersion))
           }
         }
       }
@@ -557,7 +557,7 @@ object Resolution {
             overridesOpt.exists(_.contains(dep0.depManagementKey))
           )
           if (useManagedVersion)
-            dep = dep.withVersionConstraint(mgmtValues.versionConstraint)
+            dep = dep.withVersionConstraintConserve(mgmtValues.versionConstraint)
 
           if (mgmtValues.minimizedExclusions.nonEmpty) {
             val newExcl = dep.minimizedExclusions.join(mgmtValues.minimizedExclusions)
@@ -2392,7 +2392,7 @@ object Resolution {
   def dependenciesWithRetainedVersions: Set[Dependency] =
     dependencies.map { dep =>
       retainedVersions.get(dep.module).fold(dep) { v =>
-        dep.withVersionConstraint(VersionConstraint0.fromVersion(v))
+        dep.withVersionConstraintConserve(VersionConstraint0.fromVersion(v))
       }
     }
 

--- a/modules/core/shared/src/main/scala/coursier/core/Resolution.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Resolution.scala
@@ -1672,8 +1672,9 @@ object Resolution {
     val nextModules = nextDependenciesAndConflicts._2
       .map(_.moduleVersionConstraint)
 
-    (boms ++ modules ++ nextModules)
-      .filterNot(mod => projectCache0.contains(mod) || errorCache.contains(mod))
+    Seq(boms, modules, nextModules).iterator.flatMap(_.filterNot(mod =>
+      projectCache0.contains(mod) || errorCache.contains(mod)
+    )).toSet
   }
 
   /** Whether the resolution is done.


### PR DESCRIPTION
A collection of small allocation- and CPU-reduction improvements identified
in the resolution hot paths:
- **Cache `MinimizedExclusions.toSet`** — pre-compute the singleton set in  `ExcludeAll` and lazily memoize it in `SetBasedExclusions`, replacing the  repeated `++` chain.
- **Eliminate `Seq`/`fold` overhead in `validateCoordinate`** — replace the  generic `foldLeft` over a two-element `Seq` with direct `if/else if` checks,  avoiding boxing and lambda allocation on a hot path.
- **Avoid `Dependency` copy when version constraint is unchanged** — introduce  withVersionConstraintConserve` and use it at all call sites in `Resolution`,  returning `this` when the constraint is already equal.
- **Avoid intermediate collections in `missingFromCache`** — replace the  `boms ++ modules ++ nextModules` chain (two intermediate sets) with a lazy  `Iterator.flatMap` before the final `.toSet`.
  
##  Benchmarks
  
https://78cd20f7.coursier-benchmark-results.pages.dev/?sec=%C2%B7gc.alloc.rate.norm

These improvements are still minor relative to my planned change to property substitution, but [that change](https://github.com/retronym/coursier/pull/2) is not binary compatible so needs to wait until a [2.2.x branch is open for business](https://github.com/coursier/coursier/pull/3635#discussion_r3173659660).

This is PR 3/N from the work summarised in https://github.com/coursier/coursier/issues/3329#issuecomment-4296809636