### PR TITLE
Improve performance of property substitution

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -282,7 +282,10 @@ trait UtilJs extends CsScalaJsModule with Util {
 
 trait CoreJvm extends Core with CoreJvmBase with Shading {
   def sources = Task {
-    super.sources() ++ core.shared.sources()
+    val versionSources =
+      if (scalaVersion().startsWith("2.13")) core.shared.sourcesScala213()
+      else core.shared.sourcesScala212()
+    super.sources() ++ core.shared.sources() ++ versionSources
   }
   def moduleDeps = super.moduleDeps ++ Seq(
     util.jvm()
@@ -303,7 +306,10 @@ trait CoreJvm extends Core with CoreJvmBase with Shading {
 }
 trait CoreJs extends Core with CsScalaJsModule {
   def sources = Task {
-    super.sources() ++ core.shared.sources()
+    val versionSources =
+      if (scalaVersion().startsWith("2.13")) core.shared.sourcesScala213()
+      else core.shared.sourcesScala212()
+    super.sources() ++ core.shared.sources() ++ versionSources
   }
   def moduleDeps = super.moduleDeps ++ Seq(
     util.js()

--- a/mill-build/src/coursierbuild/modules/SharedScalaSources.scala
+++ b/mill-build/src/coursierbuild/modules/SharedScalaSources.scala
@@ -11,4 +11,7 @@ trait SharedScalaSources extends Module {
     os.sub / "src/test/scala",
     os.sub / "src/test/java"
   )
+
+  def sourcesScala213 = Task.Sources(os.sub / "src/main/scala-2.13")
+  def sourcesScala212 = Task.Sources(os.sub / "src/main/scala-2.12")
 }

--- a/modules/core/shared/src/main/scala-2.12/coursier/core/AbstractMap.scala
+++ b/modules/core/shared/src/main/scala-2.12/coursier/core/AbstractMap.scala
@@ -1,0 +1,12 @@
+package coursier.core
+
+// In 2.12, immutable.Map requires `+` and `-` as abstract instead of 2.13's `updated`/`removed`.
+// Bridge them so subclasses implement the 2.13-style API in both versions.
+private[coursier] abstract class AbstractMap[K, +V]
+    extends scala.collection.immutable.AbstractMap[K, V] {
+  def removed(key: K): scala.collection.immutable.Map[K, V]
+  def updated[V1 >: V](key: K, value: V1): scala.collection.immutable.Map[K, V1]
+
+  final def -(key: K): scala.collection.immutable.Map[K, V]                = removed(key)
+  final def +[V1 >: V](kv: (K, V1)): scala.collection.immutable.Map[K, V1] = updated(kv._1, kv._2)
+}

--- a/modules/core/shared/src/main/scala-2.12/coursier/core/AbstractSeq.scala
+++ b/modules/core/shared/src/main/scala-2.12/coursier/core/AbstractSeq.scala
@@ -1,0 +1,4 @@
+package coursier.core
+
+// scala.collection.immutable.AbstractSeq does not exist in 2.12
+private[coursier] abstract class AbstractSeq[+A] extends scala.collection.immutable.Seq[A]

--- a/modules/core/shared/src/main/scala-2.13/coursier/core/AbstractMap.scala
+++ b/modules/core/shared/src/main/scala-2.13/coursier/core/AbstractMap.scala
@@ -1,0 +1,4 @@
+package coursier.core
+
+private[coursier] abstract class AbstractMap[K, +V]
+    extends scala.collection.immutable.AbstractMap[K, V]

--- a/modules/core/shared/src/main/scala-2.13/coursier/core/AbstractSeq.scala
+++ b/modules/core/shared/src/main/scala-2.13/coursier/core/AbstractSeq.scala
@@ -1,0 +1,3 @@
+package coursier.core
+
+private[coursier] abstract class AbstractSeq[+A] extends scala.collection.immutable.AbstractSeq[A]

--- a/modules/core/shared/src/main/scala/coursier/core/Definitions.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Definitions.scala
@@ -6,10 +6,15 @@ import coursier.error.VariantError
 import coursier.util.Artifact
 import coursier.version.{Version => Version0}
 import dataclass.data
+import scala.util.hashing.MurmurHash3
 
 final case class Organization(value: String) extends AnyVal {
-  def map(f: String => String): Organization =
-    Organization(f(value))
+  private[coursier] def parsedValue = PropertyExpr.parse(value)
+  def map(f: String => String): Organization = {
+    val o = PropertyExpr.applySubstitution(value, f)
+    if (o eq value) this
+    else Organization(o)
+  }
 }
 
 object Organization {
@@ -18,8 +23,12 @@ object Organization {
 }
 
 final case class ModuleName(value: String) extends AnyVal {
-  def map(f: String => String): ModuleName =
-    ModuleName(f(value))
+  private[coursier] def parsedValue = PropertyExpr.parse(value)
+  def map(f: String => String): ModuleName = {
+    val newName = PropertyExpr.applySubstitution(value, f)
+    if (newName eq value) this
+    else ModuleName(newName)
+  }
 }
 
 object ModuleName {
@@ -93,8 +102,12 @@ final case class Type(value: String) extends AnyVal {
     value.isEmpty
   def nonEmpty: Boolean =
     value.nonEmpty
-  def map(f: String => String): Type =
-    Type(f(value))
+  private[coursier] def parsedValue = PropertyExpr.parse(value)
+  def map(f: String => String): Type = {
+    val newValue = PropertyExpr.applySubstitution(value, f)
+    if (newValue eq value) this
+    else Type(newValue)
+  }
 
   def asExtension: Extension =
     Extension(value)
@@ -143,8 +156,13 @@ final case class Classifier(value: String) extends AnyVal {
     value.isEmpty
   def nonEmpty: Boolean =
     value.nonEmpty
-  def map(f: String => String): Classifier =
-    Classifier(f(value))
+
+  private[coursier] def parsedValue = PropertyExpr.parse(value)
+  def map(f: String => String): Classifier = {
+    val newValue = PropertyExpr.applySubstitution(value, f)
+    if (newValue eq value) this
+    else Classifier(newValue)
+  }
 }
 
 object Classifier {
@@ -185,8 +203,13 @@ final case class Configuration(value: String) extends AnyVal {
     value.nonEmpty
   def -->(target: Configuration): Configuration =
     Configuration(s"$value->${target.value}")
-  def map(f: String => String): Configuration =
-    Configuration(f(value))
+
+  private[coursier] def parsedValue = PropertyExpr.parse(value)
+  def map(f: String => String): Configuration = {
+    val newValue = PropertyExpr.applySubstitution(value, f)
+    if (newValue eq value) this
+    else Configuration(newValue)
+  }
 }
 
 object Configuration {

--- a/modules/core/shared/src/main/scala/coursier/core/Dependency.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Dependency.scala
@@ -36,6 +36,10 @@ import java.util.concurrent.ConcurrentMap
   endorseStrictVersions: Boolean = false
 ) {
   assertValid(versionConstraint.asString, "version")
+
+  private[coursier] lazy val parsedVersionConstraint =
+    PropertyExpr.parse(versionConstraint.asString)
+
   def moduleVersionConstraint: (Module, VersionConstraint0) = (module, versionConstraint)
 
   @deprecated("Prefer moduleVersionConstraint instead", "2.1.25")
@@ -503,22 +507,21 @@ object Dependency {
     overridesMap: Overrides,
     endorseStrictVersions: Boolean
   ): Dependency =
-    coursier.util.Cache.cacheMethod(instanceCache)(
-      new Dependency(
-        module,
-        versionConstraint,
-        variantSelector,
-        minimizedExclusions,
-        publication,
-        optional,
-        transitive,
-        overrides,
-        boms,
-        bomDependencies,
-        overridesMap,
-        endorseStrictVersions
-      )
-    )
+    // TODO benchmark with/without this
+    coursier.util.Cache.cacheMethod(instanceCache)(new Dependency(
+      module,
+      versionConstraint,
+      variantSelector,
+      minimizedExclusions,
+      publication,
+      optional,
+      transitive,
+      overrides,
+      boms,
+      bomDependencies,
+      overridesMap,
+      endorseStrictVersions
+    ))
 
   @deprecated("Use the override accepting a VersionConstraint", "2.1.25")
   def apply(

--- a/modules/core/shared/src/main/scala/coursier/core/DependencyManagement.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/DependencyManagement.scala
@@ -18,6 +18,9 @@ object DependencyManagement {
     `type`: Type,
     classifier: Classifier
   ) {
+    private[coursier] lazy val hasProperties =
+      organization.parsedValue.hasProperties || name.parsedValue.hasProperties || `type`.parsedValue.hasProperties || classifier.parsedValue.hasProperties
+
     def map(f: String => String): Key = {
       val newOrg        = organization.map(f)
       val newName       = name.map(f)
@@ -109,8 +112,9 @@ object DependencyManagement {
       else
         this
     }
+    private def parsedConfig = PropertyExpr.parse(config.value)
     def mapButVersion(f: String => String): Values = {
-      val newConfig = config.map(f)
+      val newConfig = Configuration(parsedConfig.applySubstitution(config.value, f))
       val newExcl   = minimizedExclusions.map(f)
       if (config != newConfig || minimizedExclusions != newExcl)
         Values(
@@ -123,12 +127,16 @@ object DependencyManagement {
       else
         this
     }
+    private lazy val parsedVersionConstraint = PropertyExpr.parse(versionConstraint.asString)
     def mapVersion(f: String => String): Values = {
-      val newVersion = f(versionConstraint.asString)
+      val origVersionStr = versionConstraint.asString
+      val newVersion     = parsedVersionConstraint.applySubstitution(origVersionStr, f)
       if (versionConstraint.asString == newVersion) this
       else withVersionConstraint(VersionConstraint0(newVersion))
     }
-
+    val hasProperties = config.value.contains("$") ||
+      versionConstraint.asString.contains("$") ||
+      minimizedExclusions.hasProperties
     override def toString(): String = {
       var fields = Seq(
         config.toString,

--- a/modules/core/shared/src/main/scala/coursier/core/DependencyManagement.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/DependencyManagement.scala
@@ -112,7 +112,7 @@ object DependencyManagement {
       else
         this
     }
-    private def parsedConfig = PropertyExpr.parse(config.value)
+    private lazy val parsedConfig = PropertyExpr.parse(config.value)
     def mapButVersion(f: String => String): Values = {
       val newConfig = Configuration(parsedConfig.applySubstitution(config.value, f))
       val newExcl   = minimizedExclusions.map(f)

--- a/modules/core/shared/src/main/scala/coursier/core/LazyProperties.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/LazyProperties.scala
@@ -1,0 +1,423 @@
+package coursier.core
+
+import scala.collection.mutable
+import scala.collection.immutable
+import scala.collection.compat._
+
+/** A sequence of properties, with a mechanism to resolve interpolated references in values.
+  *
+  * Resolution is lazy.
+  *
+  * ```
+  * <properties>
+  *   <key1>value1</key1>
+  *   <key2>value2</key2>
+  *   <key3>${key1},${key2}</key2>
+  * </properties>
+  * ```
+  *
+  * For backwards compatibility, this implements `Seq[(String, String)`, so it can be used in
+  * `coursier.core.Project#properties` without making breaking changes to that API. This sequence
+  * contains the raw values.
+  *
+  * `toMap` returns an implementation of `scala.collection.immutable.Map`. Values returned from this
+  * map _are_ interpolated, although this is performed lazily.
+  *
+  * The `LazyProperties.merge` combinators can be used to concatenate multiple properties sequences,
+  * typically to merge properties from child/parent layers and to merge intrinsic properties (like
+  * `project.version`).
+  *
+  * These concatenations are themselves lazy, can be chained, and share internal state to enhance
+  * performance and reduce memory usage. This state includes an index (`Map[String, Entry`). Each
+  * `Entry` caches the parsed representation of the value as a seqeunce of literals and property
+  * references. (`ParsedSubstituteProps`)
+  *
+  * Utility methods for interpolating values into strings use `ParsedSubstituteProps` to avoid
+  * re-parsing the same value multiple times.
+  *
+  * Many `String`-typed values in the core model can themselves contain property references. Where
+  * possible, a class carrying such a field (`value`) should also carry a `lazy val` (`parsedValue`)
+  * to cache the parsed representation of that field, and then use
+  * `LazyProperties.fastApply(value, parsedValue, f)` in place of `f(value)` in `map` methods.
+  * `fastApply` will detect if `f` is of type `LazyProperties.Substitution` and use that to avoid
+  * re-parsing the value.
+  *
+  * If a breaking API change is ever planned, we can cleanup code by: a) wrap all such values in a
+  * class that encapsulates the parsed representation, and use this instead of `String`, b) change
+  * the type of `Project.properties` to something no longer be a `Seq`, and c) change all the
+  * `map(f: String => String)` methods to accept a `map(f: Substitutor)`
+  */
+private[coursier] sealed abstract class LazyProperties
+    extends AbstractSeq[(String, String)] {
+
+  protected def resolvedMap: immutable.Map[String, String]
+
+  override def toMap[K, V](
+    implicit ev: ((String, String)) <:< (K, V)
+  ): immutable.Map[K, V] =
+    resolvedMap.asInstanceOf[immutable.Map[K, V]]
+}
+
+private[coursier] object LazyProperties {
+
+  private case object Empty extends LazyProperties {
+    override def iterator: Iterator[(String, String)] = Iterator.empty
+    override def length: Int                          = 0
+    override def isEmpty: Boolean                     = true
+
+    override def apply(idx: Int): (String, String) =
+      throw new IndexOutOfBoundsException(idx.toString)
+
+    override protected val resolvedMap: immutable.Map[String, String] =
+      immutable.Map.empty
+  }
+
+  def merge(
+    properties: collection.Seq[(String, String)],
+    extraProperties: collection.Seq[(String, String)]
+  ): immutable.Seq[(String, String)] =
+    merge(Seq(properties, extraProperties))
+
+  def mergeLayerMaps(
+    layers: collection.Seq[collection.Map[String, _]]
+  ): immutable.Seq[(String, String)] =
+    merge(layers.iterator.map(mapLayerToSeq).toVector)
+
+  def merge(
+    layers: collection.Seq[collection.Seq[(String, String)]]
+  ): immutable.Seq[(String, String)] = {
+    var totalCount = 0
+    layers.foreach(l => totalCount += layerCount(l))
+    if (totalCount == 0) Empty
+    else {
+      val arr    = new Array[PropertyLayer](totalCount)
+      var offset = 0
+      layers.foreach(l => offset = fillLayers(l, arr, offset))
+      new ConcatProperties(arr)
+    }
+  }
+
+  def merge(
+    layer1: collection.Seq[(String, String)],
+    layer2: PropertyLayer
+  ): immutable.Seq[(String, String)] = {
+    val count  = layerCount(layer1) + 1
+    val arr    = new Array[PropertyLayer](count)
+    val offset = fillLayers(layer1, arr, 0)
+    arr(offset) = layer2
+    new ConcatProperties(arr)
+  }
+
+  def filterKeysNotIn(
+    properties: collection.Seq[(String, String)],
+    excludedKeys: Set[String]
+  ): immutable.Seq[(String, String)] = {
+    val count = layerCount(properties)
+    if (count == 0) Empty
+    else if (excludedKeys.isEmpty) {
+      val arr = new Array[PropertyLayer](count)
+      fillLayers(properties, arr, 0)
+      new ConcatProperties(arr)
+    }
+    else {
+      val arr = new Array[PropertyLayer](count)
+      fillLayers(properties, arr, 0)
+      new FilteredProperties(arr, excludedKeys)
+    }
+  }
+
+  def substitute(
+    s: String,
+    lookup: PropertyValueLookup,
+    trim: Boolean = false
+  ): String = {
+    val props = PropertyExpr.parse(s)
+    props.substitute(s, lookup, trim)
+  }
+
+  final class PropertyEntry(val value: String) {
+    lazy val parsed: PropertyExpr =
+      PropertyExpr.parse(value)
+  }
+
+  abstract class PropertyLayer {
+    def length: Int
+    def key(i: Int): String
+    def value(i: Int): String
+    def tuple(i: Int): (String, String)
+    def getOrNull(k: String): PropertyEntry
+
+    def iterator: IterableOnce[(String, String)] =
+      Iterator.tabulate(length) { i =>
+        tuple(i)
+      }
+  }
+  final class SeqPropertyLayer(val values: immutable.Seq[(String, String)]) extends PropertyLayer {
+    assert(!values.isInstanceOf[ConcatProperties])
+
+    override def iterator: IterableOnce[(String, String)] = values.iterator
+
+    private lazy val index: java.util.Map[String, PropertyEntry] = {
+      val m = new java.util.HashMap[String, PropertyEntry](math.max(16, values.length))
+      var i = 0
+      while (i < values.length) {
+        val key = values(i)._1
+        m.put(key, new PropertyEntry(values(i)._2))
+        i += 1
+      }
+      m
+    }
+
+    override def length: Int = values.length
+
+    override def key(i: Int): String = values(i)._1
+
+    override def value(i: Int): String = values(i)._2
+
+    override def tuple(i: Int): (String, String) = values(i)
+
+    override def getOrNull(k: String): PropertyEntry = index.get(k)
+
+  }
+
+  private def layerFromSeq(layer: collection.Seq[(String, String)]): PropertyLayer =
+    new SeqPropertyLayer(layer.toVector)
+
+  private def layerCount(properties: collection.Seq[(String, String)]): Int =
+    properties match {
+      case concat: ConcatProperties     => concat.layers.length
+      case filtered: FilteredProperties => filtered.layers.length
+      case Empty                        => 0
+      case other if other.isEmpty       => 0
+      case _                            => 1
+    }
+
+  private def fillLayers(
+    properties: collection.Seq[(String, String)],
+    dest: Array[PropertyLayer],
+    offset: Int
+  ): Int =
+    properties match {
+      case concat: ConcatProperties =>
+        System.arraycopy(concat.layers, 0, dest, offset, concat.layers.length)
+        offset + concat.layers.length
+      case filtered: FilteredProperties =>
+        System.arraycopy(filtered.layers, 0, dest, offset, filtered.layers.length)
+        offset + filtered.layers.length
+      case other if other.isEmpty =>
+        offset
+      case other =>
+        dest(offset) = layerFromSeq(other)
+        offset + 1
+    }
+
+  private def mapLayerToSeq(layer: collection.Map[String, _]): immutable.Seq[(String, String)] = {
+    val b = Vector.newBuilder[(String, String)]
+
+    layer.iterator.foreach {
+      case (k, s: String) =>
+        b += ((k, s))
+      case (k, values: collection.Seq[_]) =>
+        values.foreach {
+          case s: String => b += ((k, s))
+          case other =>
+            throw new IllegalArgumentException(
+              s"Property value sequences must contain only strings, got ${other.getClass.getName}"
+            )
+        }
+      case (k, values: Iterable[_]) =>
+        values.foreach {
+          case s: String => b += ((k, s))
+          case other =>
+            throw new IllegalArgumentException(
+              s"Property value collections must contain only strings, got ${other.getClass.getName}"
+            )
+        }
+      case (_, other) =>
+        throw new IllegalArgumentException(
+          s"Property map values must be a String or a Seq[String], got ${other.getClass.getName}"
+        )
+    }
+
+    b.result()
+  }
+
+  private abstract class LayeredLazyProperties(
+    val layers: Array[PropertyLayer]
+  ) extends LazyProperties {
+
+    override def length: Int = {
+      var total = 0
+      var i     = 0
+      while (i < layers.length) {
+        total += layers(i).length
+        i += 1
+      }
+      total
+    }
+
+    final def pairAtGlobalIndex(idx: Int): (String, String) = {
+      if (idx < 0)
+        throw new IndexOutOfBoundsException(idx.toString)
+
+      var remaining = idx
+      var layerIdx  = 0
+      while (layerIdx < layers.length) {
+        val layerSize = layers(layerIdx).length
+        if (remaining < layerSize)
+          return layers(layerIdx).tuple(remaining)
+        remaining -= layerSize
+        layerIdx += 1
+      }
+
+      throw new IndexOutOfBoundsException(idx.toString)
+    }
+
+    final def winnerEntryForKeyOrNull(key: String): PropertyEntry = {
+      var layerIdx = layers.length - 1
+      while (layerIdx >= 0) {
+        val entry = layers(layerIdx).getOrNull(key)
+        if (entry != null)
+          return entry
+        layerIdx -= 1
+      }
+      null
+    }
+  }
+
+  private final class LazyMapWithSubstitutedValues(
+    owner: LayeredLazyProperties,
+    includeKey: String => Boolean
+  ) extends AbstractMap[String, String] with PropertyValueLookup {
+    override def lookupOrNull(key: String): PropertyExpr =
+      owner.winnerEntryForKeyOrNull(key) match {
+        case null => null
+        case entry =>
+          entry.parsed
+      }
+
+    private[this] lazy val entries0 = {
+      val b        = Vector.newBuilder[(String, String)]
+      val seen     = mutable.HashSet.empty[String]
+      var layerIdx = owner.layers.length - 1
+
+      while (layerIdx >= 0) {
+        val layer = owner.layers(layerIdx)
+        var idx   = layer.length - 1
+
+        while (idx >= 0) {
+          val k = layer.key(idx)
+          if (includeKey(k) && !seen(k)) {
+            seen += k
+            val v = layer.value(idx)
+            b += ((k, v))
+          }
+          idx -= 1
+        }
+
+        layerIdx -= 1
+      }
+
+      b.result().reverse
+    }
+
+    override def getOrElse[V1 >: String](key: String, default: => V1): V1 =
+      if (!includeKey(key)) default
+      else
+        owner.winnerEntryForKeyOrNull(key) match {
+          case null => default
+          case entry =>
+            entry.parsed.substitute(entry.value, this, false)
+        }
+
+    override def get(key: String): Option[String] =
+      if (!includeKey(key)) None
+      else
+        owner.winnerEntryForKeyOrNull(key) match {
+          case null => None
+          case entry =>
+            Some(entry.parsed.substitute(entry.value, this, false))
+        }
+
+    override def iterator: Iterator[(String, String)] =
+      entries0.iterator
+
+    override def removed(key: String): immutable.Map[String, String] =
+      immutable.Map.from(entries0) - key
+
+    override def updated[V1 >: String](
+      key: String,
+      value: V1
+    ): immutable.Map[String, V1] =
+      immutable.Map.from(entries0.map { case (k, v) => (k, v: V1) }).updated(key, value)
+  }
+
+  private final class ConcatProperties(
+    layers: Array[PropertyLayer]
+  ) extends LayeredLazyProperties(layers) {
+
+    override def iterator: Iterator[(String, String)] =
+      layers.iterator.flatMap(_.iterator)
+
+    override def apply(idx: Int): (String, String) =
+      pairAtGlobalIndex(idx)
+
+    override protected lazy val resolvedMap: immutable.Map[String, String] =
+      new LazyMapWithSubstitutedValues(this, _ => true)
+  }
+
+  private final class FilteredProperties(
+    layers: Array[PropertyLayer],
+    excludedKeys: Set[String]
+  ) extends LayeredLazyProperties(layers) {
+
+    private[this] lazy val filteredLength = {
+      var count    = 0
+      var layerIdx = 0
+      while (layerIdx < layers.length) {
+        val layer = layers(layerIdx)
+        var idx   = 0
+        while (idx < layer.length) {
+          if (!excludedKeys.contains(layer.key(idx)))
+            count += 1
+          idx += 1
+        }
+        layerIdx += 1
+      }
+      count
+    }
+
+    override def iterator: Iterator[(String, String)] =
+      layers.iterator.flatMap(_.iterator).filter { case (k, _) => !excludedKeys.contains(k) }
+
+    override def length: Int =
+      filteredLength
+
+    override def apply(idx: Int): (String, String) = {
+      if (idx < 0)
+        throw new IndexOutOfBoundsException(idx.toString)
+
+      var remaining = idx
+      var layerIdx  = 0
+      while (layerIdx < layers.length) {
+        val layer = layers(layerIdx)
+        var i     = 0
+        while (i < layer.length) {
+          val k = layer.key(i)
+          if (!excludedKeys.contains(k)) {
+            if (remaining == 0)
+              return (k, layer.value(i))
+            remaining -= 1
+          }
+          i += 1
+        }
+        layerIdx += 1
+      }
+
+      throw new IndexOutOfBoundsException(idx.toString)
+    }
+
+    override protected lazy val resolvedMap: immutable.Map[String, String] =
+      new LazyMapWithSubstitutedValues(this, k => !excludedKeys.contains(k))
+  }
+}

--- a/modules/core/shared/src/main/scala/coursier/core/Overrides.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Overrides.scala
@@ -152,15 +152,7 @@ object Overrides {
       try {
         import scala.collection.compat._
         map.foreachEntry { (k, v) =>
-          if (
-            k.organization.value.contains("$") ||
-            k.name.value.contains("$") ||
-            k.classifier.value.contains("$") ||
-            k.`type`.value.contains("$") ||
-            v.config.value.contains("$") ||
-            v.versionConstraint.asString.contains("$") ||
-            v.minimizedExclusions.hasProperties
-          ) throw Found
+          if (k.hasProperties || v.hasProperties) throw Found
         }
         false
       }

--- a/modules/core/shared/src/main/scala/coursier/core/PropertyExpr.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/PropertyExpr.scala
@@ -1,0 +1,219 @@
+package coursier.core
+
+import coursier.core.PropertyExpr.Substitution
+
+import java.util.concurrent.atomic.AtomicLong
+import scala.collection.mutable
+
+private[coursier] sealed abstract class PropertyExpr {
+  def hasProperties: Boolean = this match {
+    case PropertyLiteral(_)   => false
+    case PropertyReference(_) => true
+    case Composite(_)         => true
+  }
+  final def substitute(s: String, lookup: PropertyValueLookup, trim: Boolean): String =
+    try
+      this match {
+        case PropertyLiteral(value) =>
+          value
+        case PropertyReference(name) =>
+          val resolvedExpr = lookup.lookupOrNull(name)
+          if (resolvedExpr == null) s
+          else {
+            val result = resolvedExpr match {
+              case PropertyLiteral(v) => v
+              case spe: SimplePropertyExpr =>
+                PropertyExpr.resolvePartToString(spe, lookup, trim, Nil, 1)
+              case Composite(ps) => PropertyExpr.renderSubstitutions(
+                  s,
+                  ps,
+                  lookup,
+                  trim,
+                  Nil,
+                  forceSubstitute = true,
+                  1
+                )
+            }
+            if (trim) result.trim else result
+          }
+        case Composite(parts) =>
+          PropertyExpr.renderSubstitutions(s, parts, lookup, trim)
+      }
+    catch {
+      case _: PropertyExpr.CyclicPropertyException =>
+        s
+    }
+  final def applySubstitution(value: String, f: (String => String)): String = f match {
+    case s: Substitution =>
+      s.applyWithPropertyExpr(value, this)
+    case _ => f(value)
+  }
+}
+
+private sealed abstract class SimplePropertyExpr extends PropertyExpr
+
+private final case class PropertyLiteral(value: String) extends SimplePropertyExpr
+
+private final case class PropertyReference(name: String) extends SimplePropertyExpr
+
+private final case class Composite(parts: Array[SimplePropertyExpr]) extends PropertyExpr
+
+private[coursier] object PropertyExpr {
+  private val InterpolationStartToken = "${"
+  private val InterpolationEndToken   = "}"
+
+  def applySubstitution(value: String, f: (String => String)): String = f match {
+    case s: Substitution =>
+      s.apply(value)
+    case _ => f(value)
+  }
+
+  def parse(s: String): PropertyExpr =
+    if (s.indexOf(InterpolationStartToken) < 0)
+      PropertyLiteral(s)
+    else parseSubstituteProps(s)
+
+  final class Substitution(lookup: PropertyValueLookup, trim: Boolean) extends (String => String) {
+    override def apply(v1: String): String =
+      PropertyExpr.parse(v1).substitute(v1, lookup, trim)
+    def applyWithPropertyExpr(v1: String, propertyExpr: PropertyExpr): String =
+      propertyExpr.substitute(v1, lookup, trim)
+  }
+
+  private val CycleTrackingDepthStart = 8
+  private def resolvePartToString(
+    part: SimplePropertyExpr,
+    lookup: PropertyValueLookup,
+    trim: Boolean,
+    seen: List[String],
+    depth: Int
+  ): String = part match {
+    case PropertyLiteral(value)  => value
+    case PropertyReference(name) =>
+      // Skip cycle tracking below depth CycleTrackingDepthStart: no allocation, no list scan
+      val isCycle = depth >= CycleTrackingDepthStart && seen.contains(name)
+      val resolvedExpr =
+        if (isCycle) throw new CyclicPropertyException else lookup.lookupOrNull(name)
+      if (resolvedExpr == null)
+        s"$${$name}"
+      else {
+        val nextSeen = if (depth < CycleTrackingDepthStart) Nil else name :: seen
+        val result = resolvedExpr match {
+          case PropertyLiteral(v) => v
+          case spe: SimplePropertyExpr =>
+            resolvePartToString(spe, lookup, trim, nextSeen, depth + 1)
+          case Composite(ps) =>
+            renderSubstitutions("", ps, lookup, trim, nextSeen, forceSubstitute = true, depth + 1)
+        }
+        if (trim) result.trim else result
+      }
+  }
+  private class CyclicPropertyException
+      extends RuntimeException("Cyclic property reference detected")
+
+  private def renderSubstitutions(
+    raw: String,
+    parts: Array[SimplePropertyExpr],
+    lookup: PropertyValueLookup,
+    trim: Boolean,
+    seen: List[String] = Nil,
+    forceSubstitute: Boolean = false,
+    depth: Int = 0
+  ): String = {
+    val n = parts.length
+
+    // Probe: before allocating anything, verify at least one ref resolves.
+    // Only runs at top level (!forceSubstitute), where seen=Nil, so no cycle check needed.
+    if (!forceSubstitute) {
+      var hasSubst = false
+      var j        = 0
+      while (j < n && !hasSubst) {
+        parts(j) match {
+          case PropertyReference(name) =>
+            if (lookup.lookupOrNull(name) != null) hasSubst = true
+          case _ =>
+        }
+        j += 1
+      }
+      if (!hasSubst) return raw
+    }
+
+    // Single-part fast path: no StringBuilder needed
+    if (n == 1)
+      return resolvePartToString(parts(0), lookup, trim, seen, depth)
+
+    // Single forward pass: capacity heuristic avoids resizing in the common case
+    val sb = new java.lang.StringBuilder(if (raw.nonEmpty) raw.length else 16)
+    var i  = 0
+    while (i < n) {
+      sb.append(resolvePartToString(parts(i), lookup, trim, seen, depth))
+      i += 1
+    }
+    sb.toString
+  }
+
+  private def parseSubstituteProps(s: String): PropertyExpr = {
+    // Fast path: Check if any interpolation exists at all
+    val firstTokenIdx = s.indexOf(InterpolationStartToken)
+
+    if (firstTokenIdx == -1)
+      // Return early without any allocations if no tokens are found
+      PropertyLiteral(s)
+    else {
+      // Slow path: Interpolation exists, proceed with parsing
+      val builder = Array.newBuilder[SimplePropertyExpr]
+
+      var idx = 0
+
+      val startLen = InterpolationStartToken.length
+      val endLen   = InterpolationEndToken.length
+
+      while (idx < s.length) {
+        val startIdx = if (idx == 0) firstTokenIdx else s.indexOf(InterpolationStartToken, idx)
+
+        if (startIdx == -1) {
+          appendLiteralToArray(builder, s.substring(idx))
+          idx = s.length
+        }
+        else {
+          if (startIdx > idx)
+            appendLiteralToArray(builder, s.substring(idx, startIdx))
+
+          val endIdx = s.indexOf(InterpolationEndToken, startIdx + startLen)
+
+          if (endIdx != -1) {
+            builder += PropertyReference(s.substring(startIdx + startLen, endIdx))
+            idx = endIdx + endLen
+          }
+          else {
+            // Unclosed token: append first char and move on
+            appendLiteralToArray(builder, InterpolationStartToken.substring(0, 1))
+            idx = startIdx + 1
+          }
+        }
+      }
+
+      val resultParts = builder.result()
+
+      // Final check: If parsing resulted in only one part, don't wrap it in Composite
+      resultParts.length match {
+        case 0 => PropertyLiteral(s)
+        case 1 => resultParts(0)
+        case _ => Composite(resultParts)
+      }
+    }
+  }
+
+  private def appendLiteralToArray(
+    builder: mutable.ArrayBuilder[SimplePropertyExpr],
+    value: String
+  ): Unit = {
+    if (value.nonEmpty)
+      builder += PropertyLiteral(value)
+  }
+}
+
+private[coursier] trait PropertyValueLookup {
+  def lookup(key: String): Option[PropertyExpr] = Option(lookupOrNull(key))
+  def lookupOrNull(key: String): PropertyExpr
+}

--- a/modules/core/shared/src/main/scala/coursier/core/Resolution.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Resolution.scala
@@ -1,5 +1,6 @@
 package coursier.core
 
+import coursier.core.LazyProperties.{PropertyEntry, PropertyLayer}
 import coursier.error.{DependencyError, VariantError}
 import coursier.util.Artifact
 import coursier.version.{
@@ -10,12 +11,12 @@ import coursier.version.{
 import dataclass.data
 
 import java.util.concurrent.ConcurrentHashMap
-
 import scala.annotation.tailrec
 import scala.collection.compat._
 import scala.collection.compat.immutable.LazyList
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
+import java.util.concurrent.atomic.AtomicReferenceArray
 
 object Resolution {
 
@@ -115,97 +116,18 @@ object Resolution {
 
     acc
   }
-
-  def hasProps(s: String): Boolean = {
-
-    var ok  = false
-    var idx = 0
-
-    while (idx < s.length && !ok) {
-      var dolIdx = idx
-      while (dolIdx < s.length && s.charAt(dolIdx) != '$')
-        dolIdx += 1
-      idx = dolIdx
-
-      if (dolIdx < s.length - 2 && s.charAt(dolIdx + 1) == '{') {
-        var endIdx = dolIdx + 2
-        while (endIdx < s.length && s.charAt(endIdx) != '}')
-          endIdx += 1
-        if (endIdx < s.length) {
-          assert(s.charAt(endIdx) == '}')
-          ok = true
-        }
-      }
-
-      if (!ok && idx < s.length) {
-        assert(s.charAt(idx) == '$')
-        idx += 1
-      }
-    }
-
-    ok
-  }
+  @deprecated
+  def hasProps(s: String): Boolean = PropertyExpr.parse(s).hasProperties
 
   def substituteProps(s: String, properties: Map[String, String]): String =
     substituteProps(s, properties, trim = false)
 
-  def substituteProps(s: String, properties: Map[String, String], trim: Boolean): String = {
-
-    // this method is called _very_ often, hence the micro-optimization
-
-    var b: java.lang.StringBuilder = null
-    var idx                        = 0
-
-    while (idx < s.length) {
-      var dolIdx = idx
-      while (dolIdx < s.length && s.charAt(dolIdx) != '$')
-        dolIdx += 1
-      if (idx != 0 || dolIdx < s.length) {
-        if (b == null)
-          b = new java.lang.StringBuilder(s.length + 32)
-        b.append(s, idx, dolIdx)
-      }
-      idx = dolIdx
-
-      var name: String = null
-      if (dolIdx < s.length - 2 && s.charAt(dolIdx + 1) == '{') {
-        var endIdx = dolIdx + 2
-        while (endIdx < s.length && s.charAt(endIdx) != '}')
-          endIdx += 1
-        if (endIdx < s.length) {
-          assert(s.charAt(endIdx) == '}')
-          name = s.substring(dolIdx + 2, endIdx)
-        }
-      }
-
-      if (name == null) {
-        if (idx < s.length) {
-          assert(s.charAt(idx) == '$')
-          b.append('$')
-          idx += 1
-        }
-      }
-      else {
-        idx = idx + 2 + name.length + 1 // == endIdx + 1
-        properties.get(name) match {
-          case None =>
-            b.append(s, dolIdx, idx)
-          case Some(v) =>
-            val v0 = if (trim) v.trim else v
-            b.append(v0)
-        }
-      }
-    }
-
-    if (b == null)
-      s
-    else
-      b.toString
-  }
+  def substituteProps(s: String, properties: Map[String, String], trim: Boolean): String =
+    LazyProperties.substitute(s, new PropertiesWrapper(properties).lookup, trim)
 
   def withProperties0(
     dependencies: Seq[(Variant, Dependency)],
-    properties: Map[String, String]
+    properties: PropertiesWrapper
   ): Seq[(Variant, Dependency)] =
     dependencies.map(withProperties(_, properties))
 
@@ -219,7 +141,7 @@ object Resolution {
         case (config, dep) =>
           (Variant.Configuration(config), dep)
       },
-      properties
+      new PropertiesWrapper(properties)
     ).map {
       case (c: Variant.Configuration, dep) =>
         (c.configuration, dep)
@@ -227,25 +149,84 @@ object Resolution {
         sys.error("Deprecated method doesn't support Gradle Module variants")
     }
 
-  private def withProperties(
-    map: DependencyManagement.GenericMap,
-    properties: Map[String, String]
-  ): Option[DependencyManagement.Map] = {
-    val b       = new mutable.HashMap[DependencyManagement.Key, DependencyManagement.Values]
-    var changed = false
-    for (kv <- map) {
-      val (k0, v0) = withProperties(kv, properties)
-      if (!changed && (k0 != kv._1 || v0 != kv._2))
-        changed = true
-      b(k0) = b.get(k0).fold(v0)(_.orElse(v0))
+  private final class PropertiesWrapper(val properties: Map[String, String]) {
+    val lookup = properties match {
+      case pvl: PropertyValueLookup => pvl
+      case _ => new PropertyValueLookup {
+          override def lookup(key: String): Option[PropertyExpr] = Option(lookupOrNull(key))
+
+          override def lookupOrNull(key: String): PropertyExpr =
+            properties.getOrElse(key, null) match {
+              case null => null
+              case x    => PropertyExpr.parse(x)
+            }
+        }
     }
-    if (changed) Some(b.toMap)
-    else None
+    val substitutionTrimmed = new PropertyExpr.Substitution(lookup, true)
+    val substitution        = new PropertyExpr.Substitution(lookup, false)
   }
 
   private def withProperties(
+    map: DependencyManagement.GenericMap,
+    properties: PropertiesWrapper
+  ): Option[DependencyManagement.Map] =
+    map match {
+      case im: scala.collection.immutable.Map[DependencyManagement.Key, DependencyManagement.Values]
+          if !map.keysIterator.exists(_.hasProperties) =>
+        var changed = false
+        val b = im.transform { (k, v) =>
+          val v0 = withProperties(v, properties)
+          if (!changed && (v0 != v))
+            changed = true
+          v0
+        }
+        if (changed) Some(b)
+        else None
+
+      case _ =>
+        val b       = new java.util.HashMap[DependencyManagement.Key, DependencyManagement.Values]()
+        var changed = false
+
+        val it = map.iterator
+        while (it.hasNext) {
+          val kv = it.next()
+          if (kv._1.hasProperties) {
+            val (k0, v0) = withProperties(kv, properties)
+
+            if (!changed && (k0 != kv._1 || v0 != kv._2))
+              changed = true
+
+            val existing = b.get(k0)
+            if (existing == null)
+              b.put(k0, v0)
+            else
+              b.put(k0, existing.orElse(v0))
+          }
+          else {
+            val v0 = withProperties(kv._2, properties)
+
+            if (!changed && (v0 != kv._2))
+              changed = true
+
+            val existing = b.get(kv._1)
+            if (existing == null)
+              b.put(kv._1, v0)
+            else
+              b.put(kv._1, existing.orElse(v0))
+          }
+
+        }
+
+        if (changed)
+          // convert java.util.HashMap -> scala immutable.Map
+          Some(b.asScala.toMap)
+        else
+          None
+    }
+
+  private def withProperties(
     overrides: Overrides,
-    properties: Map[String, String]
+    properties: PropertiesWrapper
   ): Overrides =
     if (overrides.hasProperties)
       overrides.mapMap(withProperties(_, properties))
@@ -254,66 +235,66 @@ object Resolution {
 
   private def withProperties(
     entry: (DependencyManagement.Key, DependencyManagement.Values),
-    properties: Map[String, String]
+    properties: PropertiesWrapper
   ): (DependencyManagement.Key, DependencyManagement.Values) = {
 
-    def substituteTrimmedProps(s: String) =
-      substituteProps(s, properties, trim = true)
-    def substituteProps0(s: String) =
-      substituteProps(s, properties, trim = false)
-
     val (key, values) = entry
-
-    (
-      key.map(substituteProps0),
-      values.mapButVersion(substituteProps0).mapVersion(substituteTrimmedProps)
-    )
+    val newKey        = key.map(properties.substitution)
+    val newValues =
+      values.mapButVersion(properties.substitution).mapVersion(properties.substitutionTrimmed)
+    if ((newKey eq key) && (newValues eq values))
+      entry
+    else (newKey, newValues)
   }
+  private def withProperties(
+    values: DependencyManagement.Values,
+    properties: PropertiesWrapper
+  ): DependencyManagement.Values =
+    values.mapButVersion(properties.substitution).mapVersion(properties.substitutionTrimmed)
 
   /** Substitutes `properties` in `dependencies`.
     */
   private def withProperties(
     variantDep: (Variant, Dependency),
-    properties: Map[String, String]
+    properties: PropertiesWrapper
   ): (Variant, Dependency) = {
 
     val (variant, dep) = variantDep
 
-    if (variant.asConfiguration.exists(_.value.contains("$")) || dep.hasProperties) {
-
-      def substituteTrimmedProps(s: String) =
-        substituteProps(s, properties, trim = true)
-      def substituteProps0(s: String) =
-        substituteProps(s, properties, trim = false)
+    if (variant.asConfiguration.exists(_.parsedValue.hasProperties) || dep.hasProperties) {
 
       val dep0 = dep
         .withVersionConstraintConserve(
-          if (dep.versionConstraint.asString.contains("$"))
-            VersionConstraint0(substituteTrimmedProps(dep.versionConstraint.asString))
+          if (dep.parsedVersionConstraint.hasProperties)
+            VersionConstraint0(dep.parsedVersionConstraint.applySubstitution(
+              dep.versionConstraint.asString,
+              properties.substitutionTrimmed
+            ))
           else
             dep.versionConstraint
         )
         .copy0(
           module = dep.module.copy(
-            organization = dep.module.organization.map(substituteProps0),
-            name = dep.module.name.map(substituteProps0)
+            organization = dep.module.organization.map(properties.substitution),
+            name = dep.module.name.map(properties.substitution)
           ),
           attributes = dep.attributes
-            .withType(dep.attributes.`type`.map(substituteProps0))
-            .withClassifier(dep.attributes.classifier.map(substituteProps0)),
+            .withType(dep.attributes.`type`.map(properties.substitution))
+            .withClassifier(dep.attributes.classifier.map(properties.substitution)),
           variantSelector = dep.variantSelector
             .asConfiguration
-            .map(_.map(substituteProps0))
+            .map(_.map(properties.substitution))
             .map(VariantSelector.ConfigurationBased(_))
             .getOrElse(dep.variantSelector),
-          minimizedExclusions = dep.minimizedExclusions.map(substituteProps0)
+          minimizedExclusions = dep.minimizedExclusions.map(properties.substitution)
         )
-
-      val finalVariant = variant
-        .asConfiguration
-        .map(_.map(substituteProps0))
-        .map(Variant.Configuration(_))
-        .getOrElse(variant)
+      val finalVariant = variant.asConfiguration match {
+        case s @ Some(x) =>
+          val newConfig = x.map(properties.substitution)
+          Variant.Configuration(newConfig)
+        case None =>
+          variant
+      }
 
       // FIXME The content of the optional tag may also be a property in
       // the original POM. Maybe not parse it that earlier?
@@ -495,9 +476,10 @@ object Resolution {
     keepVariant: Variant => Boolean
   ): Seq[(Variant, Dependency)] = {
 
-    val dependencies         = withProperties0(rawDependencies, properties)
-    val overridesOpt         = rawOverridesOpt.map(withProperties(_, properties))
-    val dependencyManagement = withProperties(rawDependencyManagement, properties)
+    val propertiesWrapper    = new PropertiesWrapper(properties)
+    val dependencies         = withProperties0(rawDependencies, propertiesWrapper)
+    val overridesOpt         = rawOverridesOpt.map(withProperties(_, propertiesWrapper))
+    val dependencyManagement = withProperties(rawDependencyManagement, propertiesWrapper)
 
     // See http://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Management
 
@@ -772,65 +754,82 @@ object Resolution {
     val config0 = actualConfiguration(config, configurations)
     (config0, parentConfigurations(config0, configurations))
   }
-
-  private def staticProjectProperties(project: Project): Seq[(String, String)] =
-    // FIXME The extra properties should only be added for Maven projects, not Ivy ones
-    Seq(
+  private val ProjectProperties: Seq[(String, (Project => String))] =
+    Vector(
       // some artifacts seem to require these (e.g. org.jmock:jmock-legacy:2.5.1)
       // although I can find no mention of them in any manual / spec
-      "pom.groupId"    -> project.module.organization.value,
-      "pom.artifactId" -> project.module.name.value,
-      "pom.version"    -> project.actualVersion0.repr,
+      "pom.groupId"    -> ((project: Project) => project.module.organization.value),
+      "pom.artifactId" -> ((project: Project) => project.module.name.value),
+      "pom.version"    -> ((project: Project) => project.actualVersion0.repr),
       // Required by some dependencies too (org.apache.directory.shared:shared-ldap:0.9.19 in particular)
-      "groupId"            -> project.module.organization.value,
-      "artifactId"         -> project.module.name.value,
-      "version"            -> project.actualVersion0.asString,
-      "project.groupId"    -> project.module.organization.value,
-      "project.artifactId" -> project.module.name.value,
-      "project.version"    -> project.actualVersion0.asString,
-      "project.packaging"  -> project.packagingOpt.getOrElse(Type.jar).value
-    ) ++ project.parent0.toSeq.flatMap {
-      case (parModule, parVersion) =>
-        Seq(
-          "project.parent.groupId"    -> parModule.organization.value,
-          "project.parent.artifactId" -> parModule.name.value,
-          "project.parent.version"    -> parVersion.asString,
-          "parent.groupId"            -> parModule.organization.value,
-          "parent.artifactId"         -> parModule.name.value,
-          "parent.version"            -> parVersion.asString
-        )
+      "groupId"            -> ((project: Project) => project.module.organization.value),
+      "artifactId"         -> ((project: Project) => project.module.name.value),
+      "version"            -> ((project: Project) => project.actualVersion0.asString),
+      "project.groupId"    -> ((project: Project) => project.module.organization.value),
+      "project.artifactId" -> ((project: Project) => project.module.name.value),
+      "project.version"    -> ((project: Project) => project.actualVersion0.asString),
+      "project.packaging"  -> ((project: Project) => project.packagingOpt.getOrElse(Type.jar).value)
+    )
+  private val ProjectPropertiesMap = ProjectProperties.zipWithIndex.map { case ((k, f), i) =>
+    (k, (f, i))
+  }.toMap
+  private val ProjectWithParentProperties: Seq[(String, (Project => String))] =
+    ProjectProperties ++ Vector(
+      "project.parent.groupId" -> ((project: Project) => project.parent0.get._1.organization.value),
+      "project.parent.artifactId" -> ((project: Project) => project.parent0.get._1.name.value),
+      "project.parent.version"    -> ((project: Project) => project.parent0.get._2.asString),
+      "parent.groupId"    -> ((project: Project) => project.parent0.get._1.organization.value),
+      "parent.artifactId" -> ((project: Project) => project.parent0.get._1.name.value),
+      "parent.version"    -> ((project: Project) => project.parent0.get._2.asString)
+    )
+  private val ProjectWithParentPropertiesMap =
+    ProjectWithParentProperties.zipWithIndex.map { case ((k, f), i) => (k, (f, i)) }.toMap
+
+  class StaticProjectPropertiesPropertyLayer(project: Project) extends PropertyLayer {
+    private val hasParent = project.parent0.isDefined
+    private val templateSeq =
+      if (project.parent0.isDefined) ProjectWithParentProperties else ProjectProperties
+
+    private val templateMap =
+      if (hasParent) ProjectWithParentPropertiesMap else ProjectPropertiesMap
+    private lazy val entries = new AtomicReferenceArray[PropertyEntry](templateSeq.length)
+
+    override def length: Int = templateSeq.length
+
+    override def key(i: Int): String = templateSeq(i)._1
+
+    override def value(i: Int): String = templateSeq(i)._2(project)
+
+    override def tuple(i: Int): (String, String) = (key(i), value(i))
+
+    override def getOrNull(k: String): LazyProperties.PropertyEntry =
+      templateMap.getOrElse(k, null) match {
+        case null   => null
+        case (f, i) => getOrCreateEntry(i)
+      }
+
+    private def getOrCreateEntry(i: Int) = {
+      val entries = this.entries
+      entries.get(i) match {
+        case null =>
+          val entry = new PropertyEntry(templateSeq(i)._2(project))
+          if (!entries.compareAndSet(i, null, entry))
+            entries.get(i)
+          else
+            entry
+        case x =>
+          x
+      }
     }
+  }
+
+  private def staticProjectProperties(project: Project): Seq[(String, String)] =
+    LazyProperties.merge(Nil, staticProjectPropertiesLayer(project))
+  private def staticProjectPropertiesLayer(project: Project): PropertyLayer =
+    new StaticProjectPropertiesPropertyLayer(project)
 
   def projectProperties(project: Project): Seq[(String, String)] =
-    // loose attempt at substituting properties in each others in properties0
-    // doesn't try to go recursive for now, but that could be made so if necessary
-    substitute(project.properties ++ staticProjectProperties(project))
-
-  private def substitute(properties0: Seq[(String, String)]): Seq[(String, String)] = {
-
-    val done = properties0
-      .iterator
-      .collect {
-        case kv @ (_, value) if !hasProps(value) =>
-          kv
-      }
-      .toMap
-
-    var didSubstitutions = false
-
-    val res = properties0.map {
-      case (k, v) =>
-        val res = substituteProps(v, done)
-        if (!didSubstitutions)
-          didSubstitutions = res != v
-        k -> res
-    }
-
-    if (didSubstitutions)
-      substitute(res)
-    else
-      res
-  }
+    LazyProperties.merge(project.properties, staticProjectPropertiesLayer(project))
 
   private def parents(
     project: Project,
@@ -865,12 +864,14 @@ object Resolution {
 
     // section numbers in the comments refer to withDependencyManagement
 
-    val parentProperties0 = parents(project, projectCache)
-      .toVector
-      .flatMap(_.properties)
+    val parentProperties0 = LazyProperties.merge(
+      parents(project, projectCache)
+        .toVector
+        .map(_.properties)
+    )
 
     val projectWithProperties = withFinalProperties(
-      project.withProperties(parentProperties0 ++ project.properties)
+      project.withProperties(LazyProperties.merge(parentProperties0, project.properties))
     )
 
     val actualConfigOrError = finalSelector(
@@ -1335,9 +1336,13 @@ object Resolution {
             val p0 =
               withDependencyManagement(
                 p.withProperties(
-                  extraProperties ++
-                    p.properties.filter(kv => !forceProperties.contains(kv._1)) ++
-                    forceProperties
+                  LazyProperties.merge(
+                    Seq(
+                      extraProperties,
+                      LazyProperties.filterKeysNotIn(p.properties, forceProperties.keySet),
+                      forceProperties.toVector
+                    )
+                  )
                 )
               )
             (modVer, (s, p0))
@@ -1560,7 +1565,7 @@ object Resolution {
           (k, v) =>
             v.config.isEmpty || keepConfigs.contains(v.config)
         }
-        withProperties(retainedEntries, projectProperties(bomProject).toMap)
+        withProperties(retainedEntries, new PropertiesWrapper(projectProperties(bomProject).toMap))
       }): _*
     }
   lazy val bomDepMgmtOverrides = bomEntries(globalBomModuleVersions)
@@ -1815,16 +1820,18 @@ object Resolution {
         .toSet
     else {
 
-      val parentProperties0 = parents(project, k => projectCache0.get(k).map(_._2))
-        .toVector
-        .flatMap(_.properties)
+      val parentProperties0 = LazyProperties.merge(
+        parents(project, k => projectCache0.get(k).map(_._2))
+          .toVector
+          .map(_.properties)
+      )
 
       // 1.1 (see above)
-      val approxProperties = parentProperties0.toMap ++ projectProperties(project)
+      val approxProperties = LazyProperties.merge(parentProperties0, projectProperties(project))
 
       val profiles = profiles0(
         project,
-        approxProperties,
+        approxProperties.toMap,
         osInfo,
         jdkVersion0,
         userActivations
@@ -1832,20 +1839,26 @@ object Resolution {
 
       val profileDependencies = profiles.flatMap(p => p.dependencies ++ p.dependencyManagement)
 
+      val profileProperties = LazyProperties.mergeLayerMaps(
+        profiles.map(_.properties)
+      )
+
       val project0 =
         project.withProperties(
-          project.properties ++ profiles.flatMap(_.properties)
+          LazyProperties.merge(project.properties, profileProperties)
         ) // belongs to 1.5 & 1.6
 
-      val propertiesMap0 = withFinalProperties(
-        project0.withProperties(parentProperties0 ++ project0.properties)
-      ).properties.toMap
+      val propertiesMap0 = LazyProperties.merge(
+        LazyProperties.merge(parentProperties0, project0.properties),
+        staticProjectPropertiesLayer(project)
+      )
+      val propertiesWrapper0 = new PropertiesWrapper(propertiesMap0.toMap)
 
       val modules = withProperties0(
         project0.dependencies0 ++
           project0.dependencyManagement0 ++
           profileDependencies.map { case (c, d) => (Variant.Configuration(c), d) },
-        propertiesMap0
+        propertiesWrapper0
       ).collect {
         case (v, dep) if isImport(v, dep) =>
           dep.moduleVersionConstraint
@@ -1965,16 +1978,18 @@ object Resolution {
 
     // A bit fragile, but seems to work
 
-    val parentProperties0 = parents(project, k => projectCache0.get(k).map(_._2))
-      .toVector
-      .flatMap(_.properties)
+    val parentProperties0 = LazyProperties.merge(
+      parents(project, k => projectCache0.get(k).map(_._2))
+        .toVector
+        .map(_.properties)
+    )
 
     // 1.1 (see above)
-    val approxProperties = parentProperties0.toMap ++ projectProperties(project)
+    val approxProperties = LazyProperties.merge(parentProperties0, projectProperties(project))
 
     val profiles = profiles0(
       project,
-      approxProperties,
+      approxProperties.toMap,
       osInfo,
       jdkVersion0,
       userActivations
@@ -1983,14 +1998,20 @@ object Resolution {
     // 1.2 made from Pom.scala (TODO look at the very details?)
 
     // 1.3 & 1.4 (if only vaguely so)
+    val profileProperties = LazyProperties.mergeLayerMaps(
+      profiles.map(_.properties)
+    )
+
     val project0 =
       project.withProperties(
-        project.properties ++ profiles.flatMap(_.properties)
+        LazyProperties.merge(project.properties, profileProperties)
       ) // belongs to 1.5 & 1.6
 
-    val propertiesMap0 = withFinalProperties(
-      project0.withProperties(parentProperties0 ++ project0.properties)
-    ).properties.toMap
+    val propertiesMap0 = LazyProperties.merge(
+      LazyProperties.merge(parentProperties0, project0.properties),
+      staticProjectPropertiesLayer(project)
+    )
+    val propertiesWrapper0 = new PropertiesWrapper(propertiesMap0.toMap)
 
     val (importDeps, standardDeps) = {
 
@@ -1998,10 +2019,9 @@ object Resolution {
         project0.dependencies0 +:
           profiles.map(_.dependencies.map { case (c, d) => (Variant.Configuration(c), d) })
       )
-
       val (importDeps0, standardDeps0) = dependencies0
         .map { dep =>
-          val (v0, dep0) = withProperties(dep, propertiesMap0)
+          val (v0, dep0) = withProperties(dep, propertiesWrapper0)
           if (isImport(v0, dep0))
             (dep0 :: Nil, Nil)
           else
@@ -2025,7 +2045,7 @@ object Resolution {
       )
 
       dependenciesMgmt0.flatMap { dep =>
-        val (conf0, dep0) = withProperties(dep, propertiesMap0)
+        val (conf0, dep0) = withProperties(dep, propertiesWrapper0)
         if (isImport(conf0, dep0))
           dep0 :: Nil
         else
@@ -2097,18 +2117,19 @@ object Resolution {
       depMgmtInputs ++
         retainedImportProjects.map {
           case (p, endorseStrictVersions) =>
-            val overrides = withProperties(p.overrides, projectProperties(p).toMap)
+            val overrides =
+              withProperties(p.overrides, new PropertiesWrapper(projectProperties(p).toMap))
             if (endorseStrictVersions) overrides.enforceGlobalStrictVersions
             else overrides
         } ++
         retainedParentProjects.map { p =>
-          withProperties(p.overrides, staticProjectProperties(p).toMap)
+          withProperties(p.overrides, new PropertiesWrapper(staticProjectProperties(p).toMap))
         }: _*
     )
 
     project0
-      .withPackagingOpt(project0.packagingOpt.map(_.map(substituteProps(_, propertiesMap0))))
-      .withVersion0(Version0(substituteProps(project0.version0.asString, propertiesMap0)))
+      .withPackagingOpt(project0.packagingOpt.map(_.map(propertiesWrapper0.substitution)))
+      .withVersion0(Version0(propertiesWrapper0.substitution.apply(project0.version0.asString)))
       .withDependencies0(
         standardDeps ++
           project0.parent0 // belongs to 1.5 & 1.6
@@ -2123,7 +2144,9 @@ object Resolution {
       .withDependencyManagement0(Nil)
       .withOverrides(depMgmt)
       .withProperties(
-        retainedParentProjects.flatMap(_.properties) ++ project0.properties
+        LazyProperties.merge(
+          retainedParentProjects.map(_.properties) :+ project0.properties
+        )
       )
   }
 

--- a/modules/core/shared/src/main/scala/coursier/core/Variant.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Variant.scala
@@ -10,7 +10,7 @@ sealed abstract class Variant extends Product with Serializable {
 
 object Variant {
   @data class Configuration(configuration: Configuration0) extends Variant {
-    def asConfiguration: Option[Configuration0] =
+    lazy val asConfiguration: Option[Configuration0] =
       Some(configuration)
     def isEmpty: Boolean =
       configuration.isEmpty

--- a/modules/core/shared/src/main/scala/coursier/maven/Pom.scala
+++ b/modules/core/shared/src/main/scala/coursier/maven/Pom.scala
@@ -8,6 +8,7 @@ import coursier.core.{
   Dependency,
   Extension,
   Info,
+  LazyProperties,
   Module,
   ModuleName,
   Organization,
@@ -335,7 +336,7 @@ object Pom {
           case (conf, dep) =>
             (Variant.Configuration(conf), dep)
         },
-        properties,
+        LazyProperties.merge(Seq(properties)),
         profiles,
         None,
         None,

--- a/modules/core/shared/src/main/scala/coursier/maven/PomParser.scala
+++ b/modules/core/shared/src/main/scala/coursier/maven/PomParser.scala
@@ -2,6 +2,7 @@ package coursier.maven
 
 import coursier.core._
 import coursier.core.Validation._
+import coursier.core.LazyProperties
 import coursier.util.SaxHandler
 import coursier.version.{VersionConstraint, VersionParse}
 
@@ -163,7 +164,7 @@ object PomParser {
       val versionOpt = Some(version).filter(_.nonEmpty)
         .orElse(Some(parentVersion).filter(_.nonEmpty))
 
-      val properties0 = properties.toList
+      val properties0 = LazyProperties.merge(Seq(properties.toList))
 
       val parentModuleOpt =
         for {

--- a/modules/tests/shared/src/test/scala/coursier/tests/ResolutionTests.scala
+++ b/modules/tests/shared/src/test/scala/coursier/tests/ResolutionTests.scala
@@ -869,16 +869,55 @@ object ResolutionTests extends TestSuite {
     }
 
     test("parts") {
-      test("propertySubstitution") {
-        val res =
-          Resolution.withProperties0(
-            Seq(Variant.emptyConfiguration -> dep"a-company:a-name:$${a.property}"),
-            Map("a.property"               -> "a-version")
-          )
-        val expected =
-          Seq(Variant.emptyConfiguration -> dep"a-company:a-name:a-version")
+      test("missingPropertyIsPreserved") {
+        val res = Resolution.substituteProps(
+          "prefix-$${missing}-suffix",
+          Map.empty
+        )
 
-        assert(res == expected)
+        assert(res == "prefix-$${missing}-suffix")
+      }
+
+      test("malformedPropertyReferenceIsPreserved") {
+        val res = Resolution.substituteProps(
+          "prefix-$${missing",
+          Map("missing" -> "value")
+        )
+
+        assert(res == "prefix-$${missing")
+      }
+
+      test("duplicateProjectPropertiesPreferenceLastOne") {
+        val props = Resolution.projectProperties(
+          Project(
+            mod"acme:dupe-props",
+            "1.0",
+            properties = Seq(
+              "a" -> "1",
+              "a" -> "2",
+              "b" -> "${a}"
+            )
+          )
+        )
+
+        assert(props.take(3) == List("a" -> "1", "a" -> "2", "b" -> "${a}"))
+        assert(props.toMap.apply("a") == "2")
+      }
+
+      test("duplicateProjectPropertiesCycleReachFixpoint") {
+        val props = Resolution.projectProperties(
+          Project(
+            mod"acme:dupe-props",
+            "1.0",
+            properties = Seq(
+              "a" -> "1",
+              "a" -> "${a}2"
+            )
+          )
+        )
+
+        assert(props.take(2) == Seq("a" -> "1", "a" -> "${a}2"))
+        assert(props.toMap.apply("a") == "${a}2")
       }
     }
 

--- a/modules/tests/shared/src/test/scala/coursier/tests/TestUtil.scala
+++ b/modules/tests/shared/src/test/scala/coursier/tests/TestUtil.scala
@@ -4,6 +4,7 @@ import coursier.core.{
   Configuration,
   Dependency,
   Info,
+  LazyProperties,
   Module,
   Overrides,
   Profile,
@@ -69,7 +70,14 @@ object TestUtil {
           .view
           .mapValues {
             case (s, p) =>
-              (s, p.withProperties(p.properties.filter { case (k, _) => !projectProperties(k) }))
+              (
+                s,
+                p.withProperties(
+                  LazyProperties.merge(Seq(p.properties.filter { case (k, _) =>
+                    !projectProperties(k)
+                  }))
+                )
+              )
           }
           .iterator
           .toMap
@@ -128,7 +136,7 @@ object TestUtil {
             (mod, Version(ver))
         },
         dependencyManagement,
-        properties,
+        LazyProperties.merge(Seq(properties)),
         profiles,
         versions,
         snapshotVersioning,


### PR DESCRIPTION
Lazily substitute properties -- most are never queried.

Cache the parsed form of property values themselves and of
other strings that support property substitution.

Minimize API changes by making the new `LazyProperties` structure
implement `Seq[(String, String)]`

Future work:
  - Change classes like `Organization` to wrap `PropertyExpr` rather
    than raw strings, further reusing parsing of values. This incrementally
    improves performance but is a binary incompatible change
    
## Benchmark:

https://7d8db12a.coursier-benchmark-results.pages.dev/?sec=%C2%B7gc.alloc.rate.norm

## Context

This is part 4/N of the changes described in https://github.com/coursier/coursier/issues/3329#issuecomment-4296809636 . This is the most important change for performance.