### PR TITLE
Use cachedHashCode rather than lazy val

### DIFF
--- a/modules/core/shared/src/main/scala/coursier/core/Definitions.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Definitions.scala
@@ -35,7 +35,7 @@ object ModuleName {
   *
   * Using the same terminology as Ivy.
   */
-@data(apply = false, settersCallApply = true) class Module(
+@data(apply = false, settersCallApply = true, cachedHashCode = true) class Module(
   organization: Organization,
   name: ModuleName,
   attributes: Map[String, String]
@@ -72,8 +72,6 @@ object ModuleName {
       case (k, v) =>
         k.contains("$") || v.contains("$")
     }
-
-  final override lazy val hashCode = tuple.hashCode()
 
   private[core] def copy(
     organization: Organization = this.organization,
@@ -962,7 +960,7 @@ object SnapshotVersioning {
     )
 }
 
-@data(apply = false, settersCallApply = true) class Publication(
+@data(apply = false, settersCallApply = true, cachedHashCode = true) class Publication(
   name: String,
   `type`: Type,
   ext: Extension,
@@ -975,8 +973,6 @@ object SnapshotVersioning {
   lazy val attributesHaveProperties =
     `type`.value.contains("$") ||
     classifier.value.contains("$")
-
-  final override lazy val hashCode = tuple.hashCode
 }
 
 object Publication {

--- a/modules/core/shared/src/main/scala/coursier/core/Dependency.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Dependency.scala
@@ -11,7 +11,7 @@ import java.util.concurrent.ConcurrentMap
   * The remaining fields are left untouched, some being transitively propagated (exclusions,
   * optional, in particular).
   */
-@data(apply = false, settersCallApply = true) class Dependency(
+@data(apply = false, settersCallApply = true, cachedHashCode = true) class Dependency(
   module: Module,
   versionConstraint: VersionConstraint0,
   variantSelector: VariantSelector,
@@ -482,9 +482,6 @@ import java.util.concurrent.ConcurrentMap
       fields = fields :+ endorseStrictVersions.toString
     s"Dependency(${fields.mkString(", ")})"
   }
-
-  override lazy val hashCode: Int =
-    tuple.hashCode()
 }
 
 object Dependency {

--- a/modules/util/shared/src/main/scala/coursier/util/Artifact.scala
+++ b/modules/util/shared/src/main/scala/coursier/util/Artifact.scala
@@ -3,16 +3,14 @@ package coursier.util
 import coursier.core.Authentication
 import dataclass.data
 
-@data class Artifact(
+@data(cachedHashCode = true) class Artifact(
   url: String,
   checksumUrls: Map[String, String] = Map.empty,
   extra: Map[String, Artifact] = Map.empty,
   changing: Boolean = false,
   optional: Boolean = false,
   authentication: Option[Authentication] = None
-) {
-  final override lazy val hashCode = tuple.hashCode()
-}
+)
 
 object Artifact {
 


### PR DESCRIPTION
This has been available in data-class since 0.2.5

The synthetic hashcode is more efficient than `tuple.hashCode`.

## Benchmark

https://6e5117db.coursier-benchmark-results.pages.dev/?sec=%C2%B7gc.alloc.rate.norm