### PR TITLE
Fix optional dependency propagation from dependencyManagement

### DIFF
--- a/modules/core/shared/src/main/scala/coursier/core/Resolution.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Resolution.scala
@@ -542,9 +542,6 @@ object Resolution {
 
           if (mgmtValues.config.nonEmpty && variant.isEmpty)
             variant = Variant.Configuration(mgmtValues.config)
-
-          if (mgmtValues.optional && !dep.optional)
-            dep = dep.withOptional(mgmtValues.optional)
         }
 
         for (dictForOverrides <- dictForOverridesOpt if dictForOverrides.nonEmpty) {

--- a/modules/core/shared/src/main/scala/coursier/core/Resolution.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Resolution.scala
@@ -538,11 +538,10 @@ object Resolution {
           }
         }
 
-        for (mgmtValues <- dependencyManagement.get(dep0.depManagementKey)) {
+        for (mgmtValues <- dependencyManagement.get(dep0.depManagementKey))
 
           if (mgmtValues.config.nonEmpty && variant.isEmpty)
             variant = Variant.Configuration(mgmtValues.config)
-        }
 
         for (dictForOverrides <- dictForOverridesOpt if dictForOverrides.nonEmpty) {
           val newOverrides = Overrides.add(dictForOverrides, dep.overridesMap)

--- a/modules/tests/shared/src/test/resources/resolutions/org.apache.maven/apache-maven/3.3.9
+++ b/modules/tests/shared/src/test/resources/resolutions/org.apache.maven/apache-maven/3.3.9
@@ -8,6 +8,7 @@ org.apache.maven.wagon:wagon-http:2.10:default
 org.apache.maven.wagon:wagon-file:2.10:default
 org.eclipse.aether:aether-connector-basic:1.0.2.v20150114:default
 org.eclipse.aether:aether-transport-wagon:1.0.2.v20150114:default
+org.slf4j:slf4j-simple:1.7.5:default
 org.apache.maven:maven-settings:3.3.9:default
 org.apache.maven:maven-plugin-api:3.3.9:default
 org.apache.maven:maven-model-builder:3.3.9:default


### PR DESCRIPTION
To close https://github.com/coursier/coursier/issues/3731

### Rationale
In Maven, the `<optional>` tag in `<dependencyManagement>` is used only as a metadata template and **does not propagate** to child module dependencies. 
If a child POM declares a dependency without `<optional>true</optional>`, it remains a required dependency even if the parent manages it with `<optional>true</optional>`.

Coursier was incorrectly propagating this flag, causing required dependencies (such as `io.kiota:kiota-http-vertx` in `io.apicurio:apicurio-registry-java-sdk-common:3.1.7`) to be marked as optional and skipped during resolution.

### Fixes / Changes
- Stopped propagating the `optional` flag from `mgmtValues` to dependencies in `Resolution.scala`.
- Updated `resolutions/org.apache.maven/apache-maven/3.3.9` test check-in list to include `slf4j-simple`.

**Note:** This depends on
- https://github.com/coursier/test-metadata/pull/11. 
