### PR TITLE
Default Packaging Type to Jar if Unset in Maven Metadata

### DIFF
--- a/modules/core/shared/src/main/scala/coursier/maven/MavenRepositoryInternal.scala
+++ b/modules/core/shared/src/main/scala/coursier/maven/MavenRepositoryInternal.scala
@@ -472,6 +472,7 @@ private[coursier] class MavenRepositoryInternal(
 
       val packagingPublicationOpt = project
         .packagingOpt
+        .orElse(Some(Type.jar))
         .filter(_ => dependency.attributes.isEmpty)
         .map { packaging =>
           Publication(


### PR DESCRIPTION
The POM.xml standard says that the default packaging format is a Jar (<https://maven.apache.org/pom.html#packaging>), but right now that's not handled. If this code doesn't return a packaging type, every download other than the POM itself gets marked as Optional.

This can lead to situations where the POM doesn't specify a default format and the Jar downloads silently fail because of some issue with the Maven server (e.g. being blocked by a Sonatype Firewall policy).

This fixed the issue (https://github.com/bazel-contrib/rules_jvm_external/issues/1613) for us, but I've not worked in this codebase before so unfortunately I don't know if I've broken anything else.