### PR TITLE
Support version ranges in parent POM coordinates

### DIFF
--- a/modules/core/jvm/src/test/scala/coursier/maven/PomParserTests.scala
+++ b/modules/core/jvm/src/test/scala/coursier/maven/PomParserTests.scala
@@ -1,7 +1,9 @@
 package coursier.maven
 
 import utest._
-import coursier.core.Info
+
+import coursier.core.{Info, Module, ModuleName, Organization}
+import coursier.version.VersionConstraint
 
 object PomParserTests extends TestSuite {
 

--- a/modules/core/jvm/src/test/scala/coursier/maven/PomParserTests.scala
+++ b/modules/core/jvm/src/test/scala/coursier/maven/PomParserTests.scala
@@ -293,5 +293,57 @@ object PomParserTests extends TestSuite {
       val message = failure.left.toOption.get
       assert(message.contains("1.0/SNAPSHOT"))
     }
+
+    test("parent version interval") {
+      val pom =
+        """
+          |<project xmlns="http://maven.apache.org/POM/4.0.0">
+          |    <modelVersion>4.0.0</modelVersion>
+          |    <parent>
+          |        <groupId>com.example</groupId>
+          |        <artifactId>parent</artifactId>
+          |        <version>[1.0,2.0)</version>
+          |    </parent>
+          |    <artifactId>child</artifactId>
+          |    <version>1.0</version>
+          |</project>""".stripMargin
+
+      val expectedParent = Some((
+        Module(Organization("com.example"), ModuleName("parent"), Map.empty),
+        VersionConstraint("[1.0,2.0)")
+      ))
+
+      val sax = MavenRepository.parseRawPomSax(pom)
+      val dom = MavenRepository.parseRawPomDom(pom)
+
+      assert(sax.map(_.parent0) == Right(expectedParent))
+      assert(dom.map(_.parent0) == Right(expectedParent))
+    }
+
+    test("version inherited from a parent with a version interval") {
+      // The child's own version cannot be known until the parent is resolved. Parsing must
+      // stay non-fatal here - Project.actualVersion0, set from the version the metadata was
+      // fetched at, is what's authoritative downstream. Both parsers must agree.
+      val pom =
+        """
+          |<project xmlns="http://maven.apache.org/POM/4.0.0">
+          |    <modelVersion>4.0.0</modelVersion>
+          |    <parent>
+          |        <groupId>com.example</groupId>
+          |        <artifactId>parent</artifactId>
+          |        <version>[1.0,2.0)</version>
+          |    </parent>
+          |    <artifactId>child</artifactId>
+          |</project>""".stripMargin
+
+      val sax = MavenRepository.parseRawPomSax(pom)
+      val dom = MavenRepository.parseRawPomDom(pom)
+
+      assert(sax.isRight)
+      assert(dom.isRight)
+      assert(sax.map(_.version0.asString) == Right("[1.0,2.0)"))
+      assert(dom.map(_.version0.asString) == Right("[1.0,2.0)"))
+      assert(sax.map(_.parent0) == dom.map(_.parent0))
+    }
   }
 }

--- a/modules/core/shared/src/main/scala/coursier/core/Definitions.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Definitions.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.{ConcurrentHashMap, ConcurrentMap}
 import coursier.core.Validation._
 import coursier.error.VariantError
 import coursier.util.Artifact
-import coursier.version.{Version => Version0}
+import coursier.version.{Version => Version0, VersionConstraint => VersionConstraint0}
 import dataclass.data
 import scala.util.hashing.MurmurHash3
 
@@ -271,7 +271,7 @@ object Attributes {
   configurations: Map[Configuration, Seq[Configuration]],
 
   // Maven-specific
-  parent0: Option[(Module, Version0)],
+  parent0: Option[(Module, VersionConstraint0)],
   dependencyManagement0: Seq[(Variant, Dependency)],
   properties: Seq[(String, String)],
   profiles: Seq[Profile],
@@ -353,7 +353,7 @@ object Attributes {
           (Variant.Configuration(config), dep)
       },
       configurations,
-      parent.map { case (mod, ver) => (mod, Version0(ver)) },
+      parent.map { case (mod, ver) => (mod, VersionConstraint0(ver)) },
       dependencyManagement.map {
         case (config, dep) =>
           (Variant.Configuration(config), dep)
@@ -401,7 +401,7 @@ object Attributes {
           (Variant.Configuration(config), dep)
       },
       configurations,
-      parent.map { case (mod, ver) => (mod, Version0(ver)) },
+      parent.map { case (mod, ver) => (mod, VersionConstraint0(ver)) },
       dependencyManagement.map {
         case (config, dep) =>
           (Variant.Configuration(config), dep)
@@ -446,7 +446,7 @@ object Attributes {
     withParent0(
       newParent.map {
         case (mod, ver) =>
-          (mod, Version0(ver))
+          (mod, VersionConstraint0(ver))
       }
     )
 
@@ -698,7 +698,7 @@ object Project {
           (Variant.Configuration(config), dep)
       },
       configurations,
-      parent.map { case (mod, ver) => (mod, Version0(ver)) },
+      parent.map { case (mod, ver) => (mod, VersionConstraint0(ver)) },
       dependencyManagement.map {
         case (config, dep) =>
           (Variant.Configuration(config), dep)
@@ -746,7 +746,7 @@ object Project {
           (Variant.Configuration(config), dep)
       },
       configurations,
-      parent.map { case (mod, ver) => (mod, Version0(ver)) },
+      parent.map { case (mod, ver) => (mod, VersionConstraint0(ver)) },
       dependencyManagement.map {
         case (config, dep) =>
           (Variant.Configuration(config), dep)

--- a/modules/core/shared/src/main/scala/coursier/core/Resolution.scala
+++ b/modules/core/shared/src/main/scala/coursier/core/Resolution.scala
@@ -829,10 +829,6 @@ object Resolution {
     projectCache: ((Module, VersionConstraint0)) => Option[Project]
   ): LazyList[Project] =
     project.parent0
-      .map {
-        case (m, v) =>
-          (m, VersionConstraint0.fromVersion(v))
-      }
       .flatMap(projectCache) match {
       case None         => LazyList.empty
       case Some(parent) => parent #:: parents(parent, projectCache)
@@ -1803,19 +1799,13 @@ object Resolution {
 
     val needsParent =
       project.parent0.exists {
-        case (parMod, parVer) =>
-          val par0        = (parMod, VersionConstraint0.fromVersion(parVer))
+        par0 =>
           val parentFound = projectCache0.contains(par0) || errorCache.contains(par0)
           !parentFound
       }
 
     if (needsParent)
-      project.parent0
-        .map {
-          case (parMod, parVer) =>
-            (parMod, VersionConstraint0.fromVersion(parVer))
-        }
-        .toSet
+      project.parent0.toSet
     else {
 
       val parentProperties0 = LazyProperties.merge(
@@ -2051,12 +2041,7 @@ object Resolution {
       }
     }
 
-    val parentDeps = project0.parent0
-      .map {
-        case (parMod, parVer) =>
-          (parMod, VersionConstraint0.fromVersion(parVer))
-      }
-      .toSeq // belongs to 1.5 & 1.6
+    val parentDeps = project0.parent0.toSeq // belongs to 1.5 & 1.6
 
     val allImportDeps = (importDeps ++ importDepsMgmt)
       .map(dep => (dep.module, dep.versionConstraint, dep.endorseStrictVersions))
@@ -2131,10 +2116,6 @@ object Resolution {
       .withDependencies0(
         standardDeps ++
           project0.parent0 // belongs to 1.5 & 1.6
-            .map {
-              case (parMod, parVer) =>
-                (parMod, VersionConstraint0.fromVersion(parVer))
-            }
             .filter(projectCache0.contains)
             .toSeq
             .flatMap(projectCache0(_)._2.dependencies0)

--- a/modules/core/shared/src/main/scala/coursier/maven/Pom.scala
+++ b/modules/core/shared/src/main/scala/coursier/maven/Pom.scala
@@ -195,7 +195,7 @@ object Pom {
       parentModuleOpt <- parentOpt
         .map(module(_).map(Some(_)))
         .getOrElse(Right(None))
-      parentVersionOpt = parentOpt.map(readVersion)
+      parentVersionOpt = parentOpt.map(readVersionConstraint)
 
       xmlDeps = pom.children
         .find(_.label == "dependencies")
@@ -214,7 +214,7 @@ object Pom {
         .orElse(parentModuleOpt.map(_.organization).filter(_.value.nonEmpty))
         .toRight("No organization found")
       version <- Some(readVersion(pom)).filter(_.asString.nonEmpty)
-        .orElse(parentVersionOpt.filter(_.asString.nonEmpty))
+        .orElse(parentVersionOpt.filter(_.asString.nonEmpty).map(c => Version(c.asString)))
         .toRight("No version found")
 
       _ <- parentVersionOpt
@@ -331,7 +331,7 @@ object Pom {
         },
         // this is customized later on in MavenRepositoryInternal
         Map.empty[Configuration, Seq[Configuration]],
-        parentModuleOpt.map((_, parentVersionOpt.getOrElse(Version.zero))),
+        parentModuleOpt.map((_, parentVersionOpt.getOrElse(VersionConstraint.empty))),
         depMgmts.map {
           case (conf, dep) =>
             (Variant.Configuration(conf), dep)

--- a/modules/core/shared/src/main/scala/coursier/maven/PomParser.scala
+++ b/modules/core/shared/src/main/scala/coursier/maven/PomParser.scala
@@ -207,7 +207,7 @@ object PomParser {
         val parentOpt = for {
           parentModule  <- parentModuleOpt
           parentVersion <- validateCoordinate(parentVersion, "parent version")
-        } yield (parentModule, coursier.version.Version(parentVersion))
+        } yield (parentModule, coursier.version.VersionConstraint(parentVersion))
 
         val projModule = Module(Organization(finalGroupId), ModuleName(artifactId), Map.empty)
 

--- a/modules/coursier/shared/src/test/scala/coursier/tests/ResolveTests.scala
+++ b/modules/coursier/shared/src/test/scala/coursier/tests/ResolveTests.scala
@@ -730,6 +730,12 @@ object ResolveTests extends TestSuite {
       }
     }
 
+    test("parent version interval") {
+      // Regression for https://github.com/coursier/coursier/issues/3765
+      // env-var declares parent dev.openfeature.contrib:parent:[1.0,2.0)
+      check(dep"dev.openfeature.contrib.providers:env-var:0.0.12")
+    }
+
     test("properties") {
       test("in packaging") {
         async {

--- a/modules/tests/js/src/test/scala/coursier/tests/JsTests.scala
+++ b/modules/tests/js/src/test/scala/coursier/tests/JsTests.scala
@@ -3,7 +3,7 @@ package coursier.tests
 import coursier.maven.MavenRepository
 import coursier.tests.compatibility._
 import coursier.util.StringInterpolators._
-import coursier.version.Version
+import coursier.version.{Version, VersionConstraint}
 
 import utest._
 
@@ -34,7 +34,7 @@ object JsTests extends TestSuite {
         .map {
           case (_, proj) =>
             val parent = proj.parent0
-            assert(parent == Some(mod"ch.qos.logback:logback-parent", Version("1.1.3")))
+            assert(parent == Some(mod"ch.qos.logback:logback-parent", VersionConstraint("1.1.3")))
         }
         .run
         .map { res =>

--- a/modules/tests/shared/src/test/resources/resolutions/dev.openfeature.contrib.providers/env-var/0.0.12
+++ b/modules/tests/shared/src/test/resources/resolutions/dev.openfeature.contrib.providers/env-var/0.0.12
@@ -1,0 +1,2 @@
+dev.openfeature.contrib.providers:env-var:0.0.12:default
+org.apache.commons:commons-lang3:3.18.0:default

--- a/modules/tests/shared/src/test/scala/coursier/tests/ResolutionTests.scala
+++ b/modules/tests/shared/src/test/scala/coursier/tests/ResolutionTests.scala
@@ -133,6 +133,27 @@ object ResolutionTests extends TestSuite {
       ),
       parent0 = Some(mod"org.gnome:parent", "7.0")
     ),
+    // Parent POM referenced through a version interval: only 1.5 is in [1.0,2.0),
+    // so resolving the child must pick up 1.5's dependencies and not 2.5's.
+    Project(
+      mod"com.example:ranged-parent",
+      "1.5",
+      Seq(
+        Variant.emptyConfiguration -> dep"acme:config:1.3.0"
+      )
+    ),
+    Project(
+      mod"com.example:ranged-parent",
+      "2.5",
+      Seq(
+        Variant.emptyConfiguration -> dep"acme:play-json:2.4.0"
+      )
+    ),
+    Project(
+      mod"com.example:ranged-child",
+      "1.0",
+      parent0 = Some((mod"com.example:ranged-parent", "[1.0,2.0)"))
+    ),
     Project(
       mod"gov.nsa:secure-pgp",
       "10.0",
@@ -597,6 +618,26 @@ object ResolutionTests extends TestSuite {
         val expected = Resolution()
           .withRootDependencies(Seq(dep))
           .withDependencies(Set(dep.withDefaultScope) ++ trDeps.map(_.withDefaultScope))
+
+        assert(res == expected)
+      }
+    }
+    test("parentVersionInterval") {
+      async {
+        // com.example:ranged-child declares its parent as com.example:ranged-parent:[1.0,2.0).
+        // Resolving it requires the parent to be looked up by interval and its dependencies
+        // inherited - acme:config:1.3.0 comes from ranged-parent:1.5, and acme:play-json
+        // (from the out-of-interval ranged-parent:2.5) must not show up.
+        val dep = dep"com.example:ranged-child:1.0"
+        val res = await(resolve0(
+          Seq(dep)
+        )).clearCaches
+
+        val expected = Resolution()
+          .withRootDependencies(Seq(dep))
+          .withDependencies(
+            Set(dep.withDefaultScope, dep"acme:config:1.3.0".withDefaultScope)
+          )
 
         assert(res == expected)
       }

--- a/modules/tests/shared/src/test/scala/coursier/tests/TestRepository.scala
+++ b/modules/tests/shared/src/test/scala/coursier/tests/TestRepository.scala
@@ -7,6 +7,19 @@ import coursier.version.{Version => Version0, VersionConstraint => VersionConstr
 final case class TestRepository(projects: Map[(Module, VersionConstraint0), Project])
     extends Repository with Repository.VersionApi {
 
+  private lazy val versionsByModule: Map[Module, List[Version0]] =
+    projects
+      .toList
+      .flatMap {
+        case ((module, constraint), _) =>
+          constraint.preferred.map((module, _))
+      }
+      .groupBy(_._1)
+      .map {
+        case (module, l) =>
+          (module, l.map(_._2).distinct.sorted)
+      }
+
   override def find0[F[_]](
     module: Module,
     version: Version0,
@@ -20,6 +33,27 @@ final case class TestRepository(projects: Map[(Module, VersionConstraint0), Proj
           .get((module, VersionConstraint0.fromVersion(version)))
           .map((this, _))
           .toRight("Not found")
+      )
+    )
+
+  /** Lists the versions this repository was built from, so that version-interval constraints (on
+    * dependencies or on parent POMs) can be resolved against it.
+    */
+  override protected def fetchVersions[F[_]](
+    module: Module,
+    fetch: Repository.Fetch[F]
+  )(implicit
+    F: Monad[F]
+  ): EitherT[F, String, (Versions, String)] =
+    EitherT(
+      F.point(
+        versionsByModule.get(module).filter(_.nonEmpty) match {
+          case None =>
+            Left(s"${module.repr} not found")
+          case Some(available) =>
+            val latest = available.last
+            Right((Versions(latest, latest, available, None), s"test:${module.repr}"))
+        }
       )
     )
 

--- a/modules/tests/shared/src/test/scala/coursier/tests/TestUtil.scala
+++ b/modules/tests/shared/src/test/scala/coursier/tests/TestUtil.scala
@@ -133,7 +133,7 @@ object TestUtil {
         configurations,
         parent0.map {
           case (mod, ver) =>
-            (mod, Version(ver))
+            (mod, VersionConstraint(ver))
         },
         dependencyManagement,
         LazyProperties.merge(Seq(properties)),


### PR DESCRIPTION
Store the parent version as a `VersionConstraint` parsed from the POM, so it is never narrowed through `fromVersion`. This removes five `fromVersion` call sites in `Resolution` and restores the pre-2.1.25 lookup path.

Closes #3765
