### PR TITLE
Default to URL-based channels for apps

### DIFF
--- a/doc/docs/cli-appdescriptors.md
+++ b/doc/docs/cli-appdescriptors.md
@@ -67,7 +67,7 @@ isn't detected automatically, or if the wrong main class is detected.
 You should then put the details passed to the `bootstrap` command in
 an [application descriptor](#application-descriptor-reference).
 Examples of such application descriptors live in
-[the default channel GitHub repository](https://github.com/coursier/apps/tree/master/apps/resources).
+[the default channel GitHub repository](https://github.com/coursier/apps/tree/main/apps/resources).
 
 At the minimum, your application descriptor should have
 `repositories` and `dependencies` sections, like
@@ -113,10 +113,11 @@ You can either:
 #### Use the contrib channel
 
 Send a pull requests adding your application channel
-under the [resources directory](https://github.com/coursier/apps/tree/master/apps-contrib/resources)
+under the [resources directory](https://github.com/coursier/apps/tree/main/apps-contrib/resources)
 of the contrib channel.
-Once the maintainers of this repository merge your pull request and cut a release,
-your users should be able to install and run your appplication like
+Once the maintainers of this repository merge your pull request, and its CI
+updates the JSON file of the contrib channel, your users should be able to
+install and run your application like
 ```bash
 $ cs install --contrib my-app
 $ my-app
@@ -167,40 +168,37 @@ Channels consist either of
 - [a collection of JSON files in a JAR](#jar-based-channels), published on a Maven repository, or
 - [a local directory, containing JSON files](#directory-based-channels).
 
-For example, the default channel, `io.get-coursier:apps` is JAR-based.
-It lives in [this GitHub repository](https://github.com/coursier/apps).
-It is published as `io.get-coursier:apps`
-[on Maven Central](https://repo1.maven.org/maven2/io/get-coursier/apps).
+For example, the default channel is URL-based. It lives in
+[this GitHub repository](https://github.com/coursier/apps), that holds one
+JSON file per application under its
+[`apps/resources`](https://github.com/coursier/apps/tree/main/apps/resources)
+directory. Those are aggregated in a single JSON file,
+[`apps.json`](https://github.com/coursier/apps/blob/main/apps.json), that
+coursier reads from
+`https://raw.githubusercontent.com/coursier/apps/main/listings/apps.json`.
 
-Its JAR contains a number of JSON files at its root:
+That file contains a JSON object, whose keys are application names, and
+whose values are application descriptors:
 ```
-$ unzip -l "$(cs fetch io.get-coursier:apps:0.0.8)" | grep json
-      188  02-09-2020 17:48   ammonite.json
-      175  02-09-2020 17:48   coursier.json
-      332  02-09-2020 17:48   cs.json
-      241  02-09-2020 17:48   dotty-repl.json
-      150  02-09-2020 17:48   echo-graalvm.json
-      108  02-09-2020 17:48   echo-java.json
-      172  02-09-2020 17:48   echo-native.json
-      335  02-09-2020 17:48   giter8.json
-      135  02-09-2020 17:48   mdoc.json
-      323  02-09-2020 17:48   mill-interactive.json
-      321  02-09-2020 17:48   mill.json
-      524  02-09-2020 17:48   sbt-launcher.json
-      222  02-09-2020 17:48   scala.json
-      209  02-09-2020 17:48   scalac.json
-      213  02-09-2020 17:48   scaladoc.json
-      180  02-09-2020 17:48   scalafix.json
-      184  02-09-2020 17:48   scalafmt.json
-      204  02-09-2020 17:48   scalap.json
+$ curl -sL https://raw.githubusercontent.com/coursier/apps/main/listings/apps.json | jq keys
+[
+  "almond",
+  "ammonite",
+  "bloop",
+  "bloop-jvm",
+  "coursier",
+  "cs",
+  …
+]
 ```
 
 ### JAR-based channels
 
 These channels can be created by publishing a JAR to a Maven or Ivy repository.
-The default channel, `io.get-coursier:apps`,
-living in [this GitHub repository](https://github.com/coursier/apps),
-is [published](https://repo1.maven.org/maven2/io/get-coursier/apps) this way.
+The `io.get-coursier:apps` module, published
+[on Maven Central](https://repo1.maven.org/maven2/io/get-coursier/apps) from
+[this GitHub repository](https://github.com/coursier/apps), is such a channel
+(it used to be the default channel of coursier).
 
 [The JAR it publishes](https://repo1.maven.org/maven2/io/get-coursier/apps/0.0.8/apps-0.0.8.jar)
 contains JSON files at its root (`scala.json`, `ammonite.json`, etc.)
@@ -215,7 +213,8 @@ JAR-based channels can be passed to the `--channel` option of `install` command,
 via their Maven coordinates, with no version, like `io.get-coursier:apps`.
 The latest version of the channel module is automatically pulled.
 
-The following command explicitly adds the default channel via its coordinates:
+The following command uses the `io.get-coursier:apps` channel, via its
+coordinates, rather than the default channel:
 ```bash
 $ cs install --default-channels=false \
     --channel io.get-coursier:apps \

--- a/doc/docs/cli-install.md
+++ b/doc/docs/cli-install.md
@@ -173,10 +173,13 @@ $ cs list --dir /myCustomDirectory
 
 Application descriptors are pulled via "channels": repositories listing available applications and how they must be installed.
 
-By default, coursier uses the Main channel `io.get-coursier:apps`.
+By default, coursier uses the Main channel, a single JSON file living in the
+[coursier/apps](https://github.com/coursier/apps) repository, at
+`https://raw.githubusercontent.com/coursier/apps/main/listings/apps.json`.
 It can be disabled with the `--default-channels=false` option.
 
-There also exists a Contrib channel `io.get-coursier:apps-contrib`, which is not used by default, and can be enabled with `--contrib`.
+There also exists a Contrib channel, `https://raw.githubusercontent.com/coursier/apps/main/listings/apps-contrib.json`,
+which is not used by default, and can be enabled with `--contrib`.
 For example:
 
 ```bash

--- a/modules/cli-tests/src/main/resources/setup-channel/README.md
+++ b/modules/cli-tests/src/main/resources/setup-channel/README.md
@@ -1,7 +1,7 @@
 # Setup channel snapshot
 
-These JSON files are a snapshot of the app descriptors from the
-`io.get-coursier:apps` channel (built from https://github.com/coursier/apps),
+These JSON files are a snapshot of the app descriptors from the default
+channel (https://github.com/coursier/apps, `apps/resources` directory),
 limited to the apps installed by `cs setup` (see
 `coursier.cli.setup.DefaultAppList`).
 
@@ -10,11 +10,10 @@ the test does not depend on the `coursier/apps` repository / channel being
 reachable. `SetupTests` runs the `setup` test both against this snapshot and
 against the live default channel.
 
-To refresh the snapshot, grab the latest `io.get-coursier:apps` jar and copy
-the relevant `*.json` entries here:
+To refresh the snapshot, copy the relevant `*.json` files from a clone of the
+coursier/apps repository here:
 
 ```
-cs fetch io.get-coursier:apps:latest.release
-unzip -o <path-to-apps.jar> -d /tmp/apps
-cp /tmp/apps/{cs,coursier,scala,scalac,scala-cli,sbt,sbtn,scalafmt}.json .
+git clone https://github.com/coursier/apps.git /tmp/apps
+cp /tmp/apps/apps/resources/{cs,coursier,scala,scalac,scala-cli,sbt,sbtn,scalafmt}.json .
 ```

--- a/modules/cli-tests/src/main/scala/coursier/clitests/SetupTests.scala
+++ b/modules/cli-tests/src/main/scala/coursier/clitests/SetupTests.scala
@@ -36,7 +36,7 @@ abstract class SetupTests extends TestSuite {
   def tests = Tests {
 
     // Run the same setup test twice: once against a local snapshot of the
-    // io.get-coursier:apps channel (so that it doesn't depend on the
+    // default coursier/apps channel (so that it doesn't depend on the
     // coursier/apps repository being reachable), and once against the live
     // default channel.
     test("setup-local-channel") {
@@ -61,7 +61,7 @@ abstract class SetupTests extends TestSuite {
   private def setupApps =
     List("cs", "coursier", "scala", "scalac", "scala-cli", "sbt", "sbtn", "scalafmt")
 
-  // Directory containing a snapshot of the io.get-coursier:apps channel
+  // Directory containing a snapshot of the default coursier/apps channel
   // (bundled as test resources under setup-channel/). Lets the setup test use a
   // local channel instead of depending on the coursier/apps repository.
   private def localChannelDir: os.Path = {

--- a/modules/cli/src/main/scala/coursier/cli/channel/ChannelOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/channel/ChannelOptions.scala
@@ -9,13 +9,13 @@ import coursier.cli.options.{OptionGroup, OutputOptions}
   "Those channels are stored in coursier configuration files.\n" +
   "\n" +
   "Examples:\n" +
-  "$ cs channel --add io.get-coursier:apps-contrib\n" +
+  "$ cs channel --add https://raw.githubusercontent.com/coursier/apps/main/listings/apps-contrib.json\n" +
   "$ cs channel --list\n"
 )
 final case class ChannelOptions(
   @Group(OptionGroup.channel)
   @ExtraName("a")
-  @HelpMessage("adds given URL based channels")
+  @HelpMessage("adds given channels (URL, org:name, or local directory)")
     add: List[String] = Nil,
   @Group(OptionGroup.channel)
   @ExtraName("l")

--- a/modules/cli/src/main/scala/coursier/cli/install/InstallOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/install/InstallOptions.scala
@@ -17,7 +17,7 @@ import coursier.cli.options.{
   "\n" +
   "Examples:\n" +
   "$ cs install scalafmt\n" +
-  "$ cs install --channel io.get-coursier:apps-contrib proguard\n" +
+  "$ cs install --channel https://raw.githubusercontent.com/coursier/apps/main/listings/apps-contrib.json proguard\n" +
   "$ cs install --contrib proguard\n"
 )
 final case class InstallOptions(

--- a/modules/cli/src/main/scala/coursier/cli/install/SharedChannelOptions.scala
+++ b/modules/cli/src/main/scala/coursier/cli/install/SharedChannelOptions.scala
@@ -7,8 +7,8 @@ import coursier.cli.options.OptionGroup
 final case class SharedChannelOptions(
 
   @Group(OptionGroup.channel)
-  @HelpMessage("Channel for apps")
-  @ValueDescription("org:name")
+  @HelpMessage("Channel for apps (URL of a JSON file, org:name of a JAR, or local directory)")
+  @ValueDescription("url|org:name|directory")
     channel: List[String] = Nil,
 
   @Group(OptionGroup.channel)

--- a/modules/install/src/main/scala/coursier/install/Channels.scala
+++ b/modules/install/src/main/scala/coursier/install/Channels.scala
@@ -5,7 +5,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
 import java.util.zip.ZipFile
 
-import argonaut.{DecodeJson, Parse}
+import argonaut.{DecodeJson, JsonObject, Parse}
 import coursier.Fetch
 import coursier.cache.Cache
 import coursier.cache.internal.FileUtil
@@ -14,7 +14,6 @@ import coursier.install.Codecs.{decodeObj, encodeObj}
 import coursier.ivy.IvyRepository
 import coursier.maven.MavenRepositoryLike
 import coursier.util.{Artifact, Task}
-import coursier.util.StringInterpolators._
 import dataclass._
 
 import scala.jdk.CollectionConverters._
@@ -105,6 +104,56 @@ import scala.jdk.CollectionConverters._
         zf.close()
   }
 
+  /** Fetches the JSON file of a URL-based channel, and decodes it.
+    *
+    * @return
+    *   the local file the channel was downloaded to, and the decoded channel content (app name ->
+    *   app descriptor)
+    */
+  private def urlChannelContent(channel: Channel.FromUrl): Task[(File, Map[String, JsonObject])] = {
+
+    val loggerOpt = cache.loggerOpt
+
+    val a = Artifact(
+      channel.url,
+      Map.empty,
+      Map.empty,
+      changing = true,
+      optional = false,
+      authentication = None
+    )
+
+    val fetch = cache.file(a).run
+
+    val task = loggerOpt match {
+      case None => fetch
+      case Some(logger) =>
+        Task.delay(logger.init(sizeHint = Some(1))).flatMap { _ =>
+          fetch.attempt.flatMap { a =>
+            Task.delay(logger.stop()).flatMap { _ =>
+              Task.fromEither(a)
+            }
+          }
+        }
+    }
+
+    for {
+      e <- task
+      f <- Task.fromEither(e.left.map(err => new Channels.ErrorFetchingChannel(channel, err)))
+      content <- Task.delay {
+        val b = Files.readAllBytes(f.toPath)
+        new String(b, StandardCharsets.UTF_8)
+      }
+      m <- Task.fromEither {
+        Parse.decodeEither(content)(DecodeJson.MapDecodeJson(
+          DecodeJson.StringDecodeJson,
+          decodeObj
+        ))
+          .left.map(err => new Channels.ErrorDecodingChannel(channel, f, err))
+      }
+    } yield (f, m)
+  }
+
   def find(id: String): Task[Option[ChannelData]] = {
 
     def fromModule(channel: Channel.FromModule): Task[Option[ChannelData]] =
@@ -151,55 +200,17 @@ import scala.jdk.CollectionConverters._
           }
       } yield dataOpt
 
-    def fromUrl(channel: Channel.FromUrl): Task[Option[ChannelData]] = {
-
-      val loggerOpt = cache.loggerOpt
-
-      val a = Artifact(
-        channel.url,
-        Map.empty,
-        Map.empty,
-        changing = true,
-        optional = false,
-        authentication = None
-      )
-
-      val fetch = cache.file(a).run
-
-      val task = loggerOpt match {
-        case None => fetch
-        case Some(logger) =>
-          Task.delay(logger.init(sizeHint = Some(1))).flatMap { _ =>
-            fetch.attempt.flatMap { a =>
-              Task.delay(logger.stop()).flatMap { _ =>
-                Task.fromEither(a)
-              }
-            }
+    def fromUrl(channel: Channel.FromUrl): Task[Option[ChannelData]] =
+      urlChannelContent(channel).map {
+        case (f, m) =>
+          m.get(id).map { obj =>
+            ChannelData(
+              channel,
+              s"$f#$id",
+              encodeObj(obj).nospaces.getBytes(StandardCharsets.UTF_8)
+            )
           }
       }
-
-      for {
-        e <- task
-        f <- Task.fromEither(e.left.map(err => new Exception(s"Error getting ${channel.url}", err)))
-        content <- Task.delay {
-          val b = Files.readAllBytes(f.toPath)
-          new String(b, StandardCharsets.UTF_8)
-        }
-        m <- Task.fromEither {
-          Parse.decodeEither(content)(DecodeJson.MapDecodeJson(
-            DecodeJson.StringDecodeJson,
-            decodeObj
-          ))
-            .left.map(err => new Exception(s"Error decoding $f (${channel.url}): $err"))
-        }
-      } yield m.get(id).map { obj =>
-        ChannelData(
-          channel,
-          s"$f#$id",
-          encodeObj(obj).nospaces.getBytes(StandardCharsets.UTF_8)
-        )
-      }
-    }
 
     def fromDirectory(channel: Channel.FromDirectory): Task[Option[ChannelData]] = {
 
@@ -300,50 +311,11 @@ import scala.jdk.CollectionConverters._
           }
       } yield dataOpt
 
-    def fromUrl(channel: Channel.FromUrl): Task[List[String]] = {
-
-      val loggerOpt = cache.loggerOpt
-
-      val a = Artifact(
-        channel.url,
-        Map.empty,
-        Map.empty,
-        changing = true,
-        optional = false,
-        authentication = None
-      )
-
-      val fetch = cache.file(a).run
-
-      val task = loggerOpt match {
-        case None => fetch
-        case Some(logger) =>
-          Task.delay(logger.init(sizeHint = Some(1))).flatMap { _ =>
-            fetch.attempt.flatMap { a =>
-              Task.delay(logger.stop()).flatMap { _ =>
-                Task.fromEither(a)
-              }
-            }
-          }
+    def fromUrl(channel: Channel.FromUrl): Task[List[String]] =
+      urlChannelContent(channel).map {
+        case (_, m) =>
+          m.keys.filter(matchQuery).toList
       }
-
-      for {
-        e <- task
-        f <- Task.fromEither(e.left.map(err => new Exception(s"Error getting ${channel.url}", err)))
-        content <- Task.delay {
-          val b = Files.readAllBytes(f.toPath)
-          new String(b, StandardCharsets.UTF_8)
-        }
-        m <- Task.fromEither {
-          Parse.decodeEither(content)(DecodeJson.MapDecodeJson(
-            DecodeJson.StringDecodeJson,
-            decodeObj
-          ))
-            .left.map(err => new Exception(s"Error decoding $f (${channel.url}): $err"))
-        }
-      } yield m.keys.filter(matchQuery).toList
-
-    }
 
     def fromDirectory(channel: Channel.FromDirectory): Task[List[String]] = Task.delay {
       if (Files.isDirectory(channel.path)) {
@@ -394,16 +366,23 @@ import scala.jdk.CollectionConverters._
 
 object Channels {
 
+  // Single JSON files generated from the app descriptors of the
+  // https://github.com/coursier/apps repository (see its README)
+  private def defaultChannelUrl =
+    "https://raw.githubusercontent.com/coursier/apps/main/listings/apps.json"
+  private def contribChannelUrl =
+    "https://raw.githubusercontent.com/coursier/apps/main/listings/apps-contrib.json"
+
   private lazy val defaultChannels0 =
     // TODO Allow to customize that via env vars / Java properties
     Seq(
-      Channel.module(mod"io.get-coursier:apps")
+      Channel.url(defaultChannelUrl)
     )
 
   private lazy val contribChannels0 =
     // TODO Allow to customize that via env vars / Java properties
     Seq(
-      Channel.module(mod"io.get-coursier:apps-contrib")
+      Channel.url(contribChannelUrl)
     )
 
   def defaultChannels: Seq[Channel] =
@@ -430,6 +409,17 @@ object Channels {
   final class AppNotFound(val id: String, val channels: Seq[Channel])
       extends ChannelsException(
         s"Cannot find app $id in channels ${channels.map(_.repr).mkString(", ")}"
+      )
+
+  final class ErrorFetchingChannel(val channel: Channel, val cause: Throwable)
+      extends ChannelsException(
+        s"Error getting channel ${channel.repr}: ${cause.getMessage}",
+        cause
+      )
+
+  final class ErrorDecodingChannel(val channel: Channel, val file: File, val reason: String)
+      extends ChannelsException(
+        s"Error decoding channel ${channel.repr} ($file): $reason"
       )
 
   final class ErrorParsingAppDescriptor(val id: String, val channel: Channel, val reason: String)

--- a/modules/install/src/test/scala/coursier/install/ChannelsTests.scala
+++ b/modules/install/src/test/scala/coursier/install/ChannelsTests.scala
@@ -1,0 +1,198 @@
+package coursier.install
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+
+import coursier.cache.FileCache
+import coursier.parse.DependencyParser
+import coursier.util.Task
+import utest._
+
+import scala.jdk.CollectionConverters._
+
+object ChannelsTests extends TestSuite {
+
+  private def delete(d: Path): Unit = {
+    if (Files.isDirectory(d)) {
+      var s: java.util.stream.Stream[Path] = null
+      try {
+        s = Files.list(d)
+        s.iterator().asScala.toVector.foreach(delete)
+      }
+      finally if (s != null)
+          s.close()
+    }
+    Files.deleteIfExists(d)
+  }
+
+  private def withTempDir[T](f: Path => T): T = {
+    val tmpDir = Files.createTempDirectory("coursier-channels-test")
+    try f(tmpDir)
+    finally delete(tmpDir)
+  }
+
+  private val fooDescriptor =
+    """{
+      |  "repositories": ["central"],
+      |  "dependencies": ["org.foo:foo:1.2.3"],
+      |  "mainClass": "foo.Main"
+      |}""".stripMargin
+  private val barDescriptor =
+    """{
+      |  "repositories": ["central"],
+      |  "dependencies": ["org.bar::bar:latest.release"]
+      |}""".stripMargin
+
+  private def channelFileContent =
+    s"""{
+       |  "foo": $fooDescriptor,
+       |  "bar": $barDescriptor
+       |}
+       |""".stripMargin
+
+  private def write(path: Path, content: String): Unit = {
+    Files.createDirectories(path.getParent)
+    Files.write(path, content.getBytes(StandardCharsets.UTF_8))
+  }
+
+  private def fooDependency =
+    DependencyParser.javaOrScalaDependencyParams("org.foo:foo:1.2.3") match {
+      case Left(err)       => sys.error(err)
+      case Right((dep, _)) => dep
+    }
+
+  val tests = Tests {
+
+    test("url channel") {
+      withTempDir { tmpDir =>
+        val channelFile = tmpDir.resolve("channel.json")
+        write(channelFile, channelFileContent)
+
+        val cache   = FileCache[Task]().withLocation(tmpDir.resolve("cache").toFile)
+        val channel = Channel.url(channelFile.toUri.toASCIIString)
+        assert(channel.url.startsWith("file:"))
+        val channels = Channels().withChannels(Seq(channel)).withCache(cache)
+
+        implicit val ec = cache.ec
+
+        // find
+        val fooDataOpt = channels.find("foo").unsafeRun(wrapExceptions = true)
+        assert(fooDataOpt.exists(_.channel == channel))
+        val parsed = RawAppDescriptor.parse(fooDataOpt.get.strData)
+        assert(parsed.exists(_.mainClass.contains("foo.Main")))
+        assert(parsed.exists(_.dependencies == List("org.foo:foo:1.2.3")))
+
+        // not found
+        val bazDataOpt = channels.find("baz").unsafeRun(wrapExceptions = true)
+        assert(bazDataOpt.isEmpty)
+
+        // app descriptor
+        val appInfo = channels.appDescriptor("foo").unsafeRun(wrapExceptions = true)
+        assert(appInfo.appDescriptor.dependencies == Seq(fooDependency))
+        assert(appInfo.source.channel == channel)
+        val notFound =
+          channels.appDescriptor("baz").attempt.unsafeRun(wrapExceptions = true)
+        assert(notFound.left.exists(_.isInstanceOf[Channels.AppNotFound]))
+
+        // search
+        val all = channels.searchAppName(Nil).unsafeRun(wrapExceptions = true)
+        assert(all == List("bar", "foo"))
+        val some = channels.searchAppName(Seq("fo")).unsafeRun(wrapExceptions = true)
+        assert(some == List("foo"))
+      }
+    }
+
+    test("url and directory channels") {
+      withTempDir { tmpDir =>
+        val channelFile = tmpDir.resolve("channel.json")
+        write(channelFile, channelFileContent)
+        val dir = tmpDir.resolve("dir-channel")
+        write(dir.resolve("baz.json"), barDescriptor)
+        // shadowed by the URL channel, that comes first
+        write(dir.resolve("foo.json"), barDescriptor)
+
+        val cache      = FileCache[Task]().withLocation(tmpDir.resolve("cache").toFile)
+        val urlChannel = Channel.url(channelFile.toUri.toASCIIString)
+        val dirChannel = Channel.FromDirectory(dir)
+        val channels   = Channels().withChannels(Seq(urlChannel, dirChannel)).withCache(cache)
+
+        implicit val ec = cache.ec
+
+        val foo = channels.find("foo").unsafeRun(wrapExceptions = true)
+        assert(foo.exists(_.channel == urlChannel))
+        val baz = channels.find("baz").unsafeRun(wrapExceptions = true)
+        assert(baz.exists(_.channel == dirChannel))
+        val all = channels.searchAppName(Nil).unsafeRun(wrapExceptions = true)
+        assert(all == List("bar", "baz", "foo", "foo"))
+      }
+    }
+
+    test("unreachable url channel") {
+      withTempDir { tmpDir =>
+        val cache    = FileCache[Task]().withLocation(tmpDir.resolve("cache").toFile)
+        val channel  = Channel.url(tmpDir.resolve("missing.json").toUri.toASCIIString)
+        val channels = Channels().withChannels(Seq(channel)).withCache(cache)
+
+        implicit val ec = cache.ec
+
+        val res = channels.find("foo").attempt.unsafeRun(wrapExceptions = true)
+        assert(res.left.exists(_.isInstanceOf[Channels.ErrorFetchingChannel]))
+        val res0 = channels.appDescriptor("foo").attempt.unsafeRun(wrapExceptions = true)
+        assert(res0.left.exists(_.isInstanceOf[Channels.ChannelsException]))
+        val res1 = channels.searchAppName(Nil).attempt.unsafeRun(wrapExceptions = true)
+        assert(res1.left.exists(_.isInstanceOf[Channels.ErrorFetchingChannel]))
+      }
+    }
+
+    test("malformed url channel") {
+      withTempDir { tmpDir =>
+        val channelFile = tmpDir.resolve("channel.json")
+        write(channelFile, """{ "foo": [] }""")
+        val cache    = FileCache[Task]().withLocation(tmpDir.resolve("cache").toFile)
+        val channel  = Channel.url(channelFile.toUri.toASCIIString)
+        val channels = Channels().withChannels(Seq(channel)).withCache(cache)
+
+        implicit val ec = cache.ec
+
+        val res = channels.find("foo").attempt.unsafeRun(wrapExceptions = true)
+        assert(res.left.exists(_.isInstanceOf[Channels.ErrorDecodingChannel]))
+      }
+    }
+
+    test("default channels are URL-based") {
+      val default = Channels.defaultChannels
+      val contrib = Channels.contribChannels
+      assert(default.nonEmpty)
+      assert(contrib.nonEmpty)
+      assert(default.forall(_.isInstanceOf[Channel.FromUrl]))
+      assert(contrib.forall(_.isInstanceOf[Channel.FromUrl]))
+      assert(default.forall(_.repr.startsWith("https://raw.githubusercontent.com/coursier/apps/")))
+      assert(contrib.forall(_.repr.startsWith("https://raw.githubusercontent.com/coursier/apps/")))
+      assert(default != contrib)
+    }
+
+    test("parse") {
+      test("url") {
+        val url = "https://raw.githubusercontent.com/coursier/apps/main/apps.json"
+        val res = Channel.parse(url)
+        assert(res == Right(Channel.FromUrl(url)))
+      }
+      test("github url") {
+        val res = Channel.parse("https://github.com/coursier/apps/blob/main/apps.json")
+        val expected =
+          Channel.FromUrl("https://raw.githubusercontent.com/coursier/apps/main/apps.json")
+        assert(res == Right(expected))
+      }
+      test("gh shorthand") {
+        val res = Channel.parse("gh:coursier/apps/main")
+        val expected =
+          Channel.FromUrl("https://raw.githubusercontent.com/coursier/apps/main/apps.json")
+        assert(res == Right(expected))
+      }
+      test("module") {
+        val res = Channel.parse("io.get-coursier:apps")
+        assert(res.exists(_.isInstanceOf[Channel.FromModule]))
+      }
+    }
+  }
+}


### PR DESCRIPTION
Rather than the Maven-based `io.get-coursier:apps`, that's being deprecated in favor of URL-based `https://raw.githubusercontent.com/coursier/apps/refs/heads/main/listings/{apps,apps-contrib}.json`, see https://github.com/coursier/apps/pull/334