### PR TITLE
Don't add os-lib in test Scala.js modules

### DIFF
--- a/mill-build/src/coursierbuild/modules/CsTests.scala
+++ b/mill-build/src/coursierbuild/modules/CsTests.scala
@@ -1,11 +1,16 @@
 package coursierbuild.modules
 
 import coursierbuild.Deps.Deps
-import mill._, mill.scalalib._
+import mill._, mill.scalalib._, mill.scalajslib._
 
 trait CsTests extends TestModule with JavaModule {
-  def mvnDeps = super.mvnDeps() ++ Seq(
-    Deps.osLib,
+  // os-lib isn't published for Scala.js, only pull it in on the JVM (and Scala Native)
+  private def maybeOsLib: Seq[Dep] =
+    this match {
+      case _: ScalaJSModule => Nil
+      case _                => Seq(Deps.osLib)
+    }
+  def mvnDeps = super.mvnDeps() ++ maybeOsLib ++ Seq(
     Deps.pprint,
     Deps.utest
   )


### PR DESCRIPTION
os-lib isn't available on Scala.js and wasn't used in those tests anyway