### PR TITLE
Allow User Agent to be customized

### DIFF
--- a/mill-build/src/coursierbuild/CoursierProperties.scala
+++ b/mill-build/src/coursierbuild/CoursierProperties.scala
@@ -26,6 +26,7 @@ object CoursierProperties {
     "coursier.exception-retry-backoff-initial-delay",
     "coursier.exception-retry-backoff-max-delay",
     "coursier.exception-retry-backoff-multiplier",
+    "coursier.http.agent",
     "coursier.http.maxRedirects",
     "coursier.ivy.home",
     "coursier.jni",

--- a/modules/cache/jvm/src/main/scala/coursier/cache/CacheUrl.scala
+++ b/modules/cache/jvm/src/main/scala/coursier/cache/CacheUrl.scala
@@ -18,6 +18,8 @@ import scala.util.control.NonFatal
 
 object CacheUrl {
 
+  private val userAgent: String = sys.props.get("coursier.http.agent").getOrElse("Coursier/2.0")
+
   private val handlerClsCache = new ConcurrentHashMap[String, Option[URLStreamHandler]]
 
   private def handlerFor(url: String, classLoaders: Seq[ClassLoader]): Option[URLStreamHandler] = {
@@ -172,7 +174,7 @@ object CacheUrl {
 
         // Early in the development of coursier, I ran into some repositories (Sonatype ones?) not
         // returning the same content for user agent "Java/…".
-        conn0.setRequestProperty("User-Agent", "Coursier/2.0")
+        conn0.setRequestProperty("User-Agent", userAgent)
         // Some remote repositories (AWS CodeArtifact) return a "false" 404 if maven-metadata.xml is requested
         // with default Accept header Java sets for HttpUrlConnection
         conn0.setRequestProperty("Accept", "*/*")


### PR DESCRIPTION
## Problem/Solution
We want to debug the Maven Central usage by overriding the User-Agent.